### PR TITLE
💄Consulting Pages - Added responsive padding

### DIFF
--- a/components/blocks/booking.tsx
+++ b/components/blocks/booking.tsx
@@ -11,7 +11,7 @@ export const Booking: FC<{
   return (
     <>
       <Container padding="px-4" className="w-full">
-        <h1 dangerouslySetInnerHTML={{ __html: title }}></h1>
+        <h1 className="md:px-32 lg:px-48" dangerouslySetInnerHTML={{ __html: title }}></h1>
         <h2>{subTitle}</h2>
         {children}
         <div className="flex animate-more-bounce flex-col items-center pt-20">


### PR DESCRIPTION
Closes #271 

On the v1 site, the line breaks were controlled by using `<br>` tags:
![image](https://user-images.githubusercontent.com/20507092/221442388-c491aa32-ae1b-4327-ba73-d806f89e4c16.png)
**Figure: v1  /consulting/bots.aspx**
![image](https://user-images.githubusercontent.com/20507092/221455084-fba4398d-b34a-4c3d-bb8b-4d863d680f6c.png)
**Figure: HTML controlling line breaks in above screenshot**

I added responsive padding to create greater consistency on consulting page headers, which means there does not have to be a manual entry of a break tag when implementing consistent headers across pages.
