### PR TITLE
🐛 Initial Meeting Form - Added Logging and Updated Secrets

### DIFF
--- a/components/bookingForm/bookingForm.tsx
+++ b/components/bookingForm/bookingForm.tsx
@@ -94,7 +94,10 @@ export const BookingForm = ({ recaptchaKey }) => {
           router.push("/thankyou/");
         }, 1000);
       })
-      .catch(() => alert("Failed to create lead in CRM"));
+      .catch((err) => {
+        console.error(err);
+        return alert("Failed to create lead in CRM")
+      });
   };
 
   const getCommonFieldProps = (fieldName: string) => ({


### PR DESCRIPTION
Closes #278 

The request now sends the required recaptcha data:
![image](https://user-images.githubusercontent.com/20507092/221469457-21a6bc8d-f9c4-417b-9a25-7ee33b4ede04.png)
**Figure: the test request body**

The environment variable for the recaptcha public key has been updated in the GitHub repo secrets, which should ensure that the recaptcha box is displayed correctly.