### PR TITLE
🐛 Consulting Template - background video is not visible

### DIFF
--- a/components/blocks/booking.tsx
+++ b/components/blocks/booking.tsx
@@ -25,7 +25,7 @@ export const Booking: FC<{
       </Container>
 
       <video
-        className="absolute -z-100 h-full min-w-full object-cover transition-opacity duration-1000"
+        className="absolute -z-1 h-full min-w-full object-cover transition-opacity duration-1000"
         playsInline
         autoPlay
         muted

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -56,7 +56,7 @@ export const Layout = ({ children, className = "" }) => {
               </Suspense>
             </div>
           </header>
-          <main className="grow bg-white">{children}</main>
+          <main className="grow bg-white -z-100">{children}</main>
           <Footer />
         </div>
       </Theme>


### PR DESCRIPTION
Closes #302 

![image](https://user-images.githubusercontent.com/16027480/221803149-a6d93ced-b916-4484-ab89-c9aac0277ecd.png)
**Figure: The background video will be on top of the main block**