### PR TITLE
📄 Consulting Page - Support Plans

### DIFF
--- a/content/consulting/support-plans.mdx
+++ b/content/consulting/support-plans.mdx
@@ -1,0 +1,69 @@
+---
+type: consulting
+description: null
+booking:
+  title: >-
+    Want to be covered by a <span class="text-sswRed">support plan</span>?
+  subTitle: >-
+    Peace of mind in case of an emergency
+  videoBackground: /images/MVC_background.mp4
+benefits:
+  benefitList:
+    - image: /images/benefits/smart-hands-and-feet.png
+      title: PEACE OF MIND
+      description: >
+        Know that you have insurance in place for your software so you aren't 
+        vulnerable to any nasty surprises.
+    - image: /images/benefits/development-process.png
+      title: JUMP THE QUEUE
+      description: >
+        In case of emergency, you can pay a premium to make sure your issue is 
+        dealt with first and guarantee a response time.
+    - image: /images/benefits/crm-integration.png
+      title: FLEXIBLE OPTIONS
+      description: >
+        Decide on an issue by issue basis what the level of urgency is and only 
+        pay for what you use.
+    - image: /images/benefits/content-pack-and-dashboard-built-in.png
+      title: DEVOPS DASHBOARDS
+      description: >
+        SSW will keep track of your uptime, error rates, and usage in real time 
+        with accessible dashboards.
+technologies:
+  header: Enabling Technologies
+  technologyCards:
+    - technologyCard: content/technologies/zendesk.mdx
+    - technologyCard: content/technologies/azure-devops.mdx
+    - technologyCard: content/technologies/ms-azure.mdx
+    - technologyCard: content/technologies/github.mdx
+solution:
+  project: supporting your software
+callToAction: "Talk to us about {{TITLE}}"
+seo:
+  title: Want to be covered by a Support Plan?
+---
+
+# The benefits of an **SSW Support Plan**
+
+SSW has built and supported thousands of applications over 3 decades, and we
+know the best way to support your key systems.
+
+<VideoEmbed url="https://www.youtube.com/watch?v=35vWStpYIY0" />
+
+SSW Support Plans were created to help our customers who have mission critical
+systems remain up, secure and fast. Unlike Support Plans offered elsewhere, SSW
+Support Plans help our customers lower cost by asking the client to assess the
+priority of each issue and pay a small premium on the developers hourly rate.
+In return, SSW will make sure the issue is addressed ASAP ï¿½ even if key developers
+are booked elsewhere. The customer chooses how quickly each issue is dealt with.
+
+The SSW Support Plan charges a small monthly fee and in return SSW creates all
+of the tooling, dashboards and infrastructure so that clients can rest easy
+knowing all of SSW's technical staff have access to all of the client's
+necessary information. SSW have always been a reliable support partner and
+this plan we believe is a better alternative to high reoccurring monthly fees
+that offer little value to well-built software.
+
+We stand behind the software we build and offer Support Plans to all of our
+clients. We also offer Support Plans on software built by others, so that
+everyone can have access to SSW's depth of experience.

--- a/content/consulting/support-plans.mdx
+++ b/content/consulting/support-plans.mdx
@@ -54,7 +54,7 @@ SSW Support Plans were created to help our customers who have mission critical
 systems remain up, secure and fast. Unlike Support Plans offered elsewhere, SSW
 Support Plans help our customers lower cost by asking the client to assess the
 priority of each issue and pay a small premium on the developers hourly rate.
-In return, SSW will make sure the issue is addressed ASAP ï¿½ even if key developers
+In return, SSW will make sure the issue is addressed ASAP even if key developers
 are booked elsewhere. The customer chooses how quickly each issue is dealt with.
 
 The SSW Support Plan charges a small monthly fee and in return SSW creates all


### PR DESCRIPTION
Closes #377 

URL: /consulting/support-plans

Changes:
- Changed position of text on page to enforce standard consulting page - text was below benefits, moved above instead:
![image](https://user-images.githubusercontent.com/20507092/225157142-2fea08c5-7785-4d3e-b641-f27900c8dfaf.png)
to
![image](https://user-images.githubusercontent.com/20507092/225157114-505ff8c3-e214-4e4d-bbdb-054799afa7ef.png)