### PR TITLE
liveStream - remove prose classes

### DIFF
--- a/components/liveStream/liveStream.tsx
+++ b/components/liveStream/liveStream.tsx
@@ -299,7 +299,6 @@ export const LiveStream: FC<LiveStreamProps> = ({ isLive, event }) => {
 								id={eventDescriptionCollapseId}
 								ref={collapsableEventDescriptionRefCallback}
 								className={classNames(
-									"prose",
 									{ "max-h-70": collapseMap[eventDescriptionCollapseId] },
 									{ "max-h-screen": !collapseMap[eventDescriptionCollapseId] },
 									{
@@ -385,7 +384,6 @@ export const LiveStream: FC<LiveStreamProps> = ({ isLive, event }) => {
 									<div className="col-span-5">
 										<p className="mb-3 font-bold">{speakerInfo.Title}</p>
 										<p
-											className="prose-sm"
 											dangerouslySetInnerHTML={{
 												__html: speakerInfo.PresenterShortDescription,
 											}}


### PR DESCRIPTION
Classes were causing text to render incorrectly (or not at all)
closes #524

URL `https://app-sswwebsite-9eb3-pr-523.azurewebsites.net/?liveBanner=1&liveStream=1`

<img width="1466" alt="CleanShot 2023-04-19 at 15 08 12@2x" src="https://user-images.githubusercontent.com/600044/232972355-993e8652-6d6f-4cfa-ab49-0e7b4f5d0b20.png">
