### PR TITLE
🔍 Make names consistent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,10 @@
 Fixes #{{ ISSUE NUMBER }}
 
 Affected routes:
+
 - <!-- E.g. `/offices/brisbane`  -->
 
 Add done video, screenshots
 
-<!-- As per rule {{ TODO: ADD RULE URL }} -->
-<!-- Call someone to review your changes to get them merged ASAP -->
+<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
+<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

--- a/content/global/index.json
+++ b/content/global/index.json
@@ -1,10 +1,10 @@
 {
   "header": {
     "name": "SSW Consulting - Sydney, Brisbane, Melbourne, Newcastle",
-    "title": "SSW Consulting - .NET, Web, Mobile, CRM, SharePoint, Azure, Power BI, Angular, React, Office 365 and Dynamics",
+    "title": "SSW - Enterprise Software Development",
     "description": "30+ years of Microsoft software and web development experience in Australia, France and China. We build with Angular, React, .NET, Azure, Dynamics 365 CRM.",
     "url": "https://www.ssw.com.au/",
-    "site_name": "SSW Consulting",
+    "site_name": "SSW - Enterprise Software Development",
     "alternate_site_name": "SSW"
   },
   "aboutUs": {

--- a/next-seo.config.ts
+++ b/next-seo.config.ts
@@ -27,4 +27,5 @@ export const NEXT_SEO_DEFAULT: NextSeoProps = {
 		site: layoutData.header.url,
 		cardType: "summary_large_image",
 	},
+	additionalMetaTags: [{ property: "keywords", content: ".NET, Web, Mobile, CRM, SharePoint, Azure, Power BI, Angular, React, Blazor, Office 365, Dynamics" }],
 };


### PR DESCRIPTION
Making the titles consistent, this change was approved by @camillars

Attempting to fix https://github.com/SSWConsulting/SSW.Website/issues/1205

Making the title shorter improved a few things
- Google doesn’t rely on the title tag as much
- The tech stacks are in the titles of the consulting pages


Affected routes:
- `/`

<img width="834" alt="image" src="https://github.com/SSWConsulting/SSW.Website-v3/assets/38869720/980de995-fcf7-4424-906c-dea558276f0e">

**Figure: Consistent names**

<!-- As per rule {{ TODO: ADD RULE URL }} -->
<!-- Call someone to review your changes to get them merged ASAP -->
