### PR TITLE
Fix Possible typo on SSW Terms & Conditions page

### DIFF
--- a/content/pages/terms-and-conditions.mdx
+++ b/content/pages/terms-and-conditions.mdx
@@ -39,9 +39,9 @@ Thank you for choosing SSW for your software solutions. Please print, complete, 
 
 [Learn more about SSW roles](https://github.com/SSWConsulting/SSW.Roles)
 
-## I/we/the Client engages SSW on the following terms:
+## The Client engages SSW on the following terms:
 
-I/we/the Client authorizes SSW to provide the resources suitable for the project. SSW generally works in teams of 2-3 on most projects - often a Solution Architect works with a Senior Software Developer overseen by a Scrum Master. Work requested by me or any other person from the Client will be performed by SSW.
+The Client authorizes SSW to provide the resources suitable for the project. SSW generally works in teams of 2-3 on most projects - often a Solution Architect works with a Senior Software Developer overseen by a Scrum Master. Work requested by me or any other person from the Client will be performed by SSW.
 
 <FixedColumns
   firstColBody={<>
@@ -202,7 +202,7 @@ I/we/the Client authorizes SSW to provide the resources suitable for the project
 
 ## Agreement
 
-I/we/the Client authorizes the above and I have read and agree to SSW's Terms and Conditions. This agreement shall become effective upon acceptance and can be terminated within 1 month, in writing by either party. This contract is governed by the laws of NSW, Australia. The parties submit to the non-exclusive jurisdiction of the courts of New South Wales Australia. The operation of the postal acceptance rule is expressly excluded.
+The Client authorizes the above and I have read and agree to SSW's Terms and Conditions. This agreement shall become effective upon acceptance and can be terminated within 1 month, in writing by either party. This contract is governed by the laws of NSW, Australia. The parties submit to the non-exclusive jurisdiction of the courts of New South Wales Australia. The operation of the postal acceptance rule is expressly excluded.
 
 <AgreementForm
   backgroundColor="lightgray"


### PR DESCRIPTION
As per email thread - **Re: Possible typo on SSW Terms & Conditions page**

 
Requested from Cameron Shaw

1. Please make the following changes: 
Delete "I/We" 
(It occurs three times on the page)
It should only say "The Client"
 
 Closes #720 