### PR TITLE
📝🔀 Make PR lint check skip if only content is changed

### DIFF
--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -21,20 +21,20 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Check for non-content/public changes
+      - name: Check paths
         id: changes
         uses: dorny/paths-filter@v2
         with:
           filters: |
-            nonContentPublic:
-              - '!content/**'
-              - '!public/**'
-
+            content:
+              - 'content/**'
+            public:
+              - 'public/**'
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.14
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"
-        if: steps.changes.outputs.nonContentPublic == 'true'
+        if: steps.changes.outputs.content == 'false' || steps.changes.outputs.public == 'false'
 
       - name: Generate summary
         run: |

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -27,14 +27,13 @@ jobs:
         with:
           filters: |
             content:
-              - 'content/**'
-            public:
-              - 'public/**'
+              - '!content/**'
+              - '!public/**'
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.14
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"
-        if: steps.changes.outputs.content == 'false' || steps.changes.outputs.public == 'false'
+        if: steps.changes.outputs.content
 
       - name: Generate summary
         run: |

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -21,27 +21,21 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Check if the PR modifies files outside content/public
-        id: check-modified-files
-        run: |
-          modified_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
-          should_skip=true
-
-          for file in $modified_files; do
-            if [[ $file != content/* && $file != public/* ]]; then
-              should_skip=false
-              break
-            fi
-          done
-
-          echo "should_skip=$should_skip" >> $GITHUB_ENV
+      - name: Check for non-content/public changes
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            nonContentPublic:
+              - '!content/**'
+              - '!public/**'
 
       - uses: nearform/github-action-check-linked-issues@v1.4.14
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"
-        if: env.should_skip == 'false'
-      
+        if: steps.changes.outputs.nonContentPublic == 'true'
+
       - name: Generate summary
         run: |
           echo "Found ${{ steps.check-linked-issues.outputs.linked_issues_count }} issues linked to PR" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -3,9 +3,6 @@ name: PR - Lint PR
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'content/**'
-      - 'public/**'
 
 concurrency: 
   group: ci-${{ github.event.number }}
@@ -19,12 +16,31 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     name: Check linked issues
+
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Check if the PR modifies files outside content/public
+        id: check-modified-files
+        run: |
+          modified_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          should_skip=true
+
+          for file in $modified_files; do
+            if [[ $file != content/* && $file != public/* ]]; then
+              should_skip=false
+              break
+            fi
+          done
+
+          echo "should_skip=$should_skip" >> $GITHUB_ENV
 
       - uses: nearform/github-action-check-linked-issues@v1.4.14
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"
+        if: env.should_skip == 'false'
       
       - name: Generate summary
         run: |

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -30,7 +30,7 @@ jobs:
               - '!content/**'
               - '!public/**'
 
-      - uses: nearform/github-action-check-linked-issues@v1.4.14
+      - uses: nearform-actions/github-action-check-linked-issues@v1.4.14
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"


### PR DESCRIPTION
This is still a required check, so it needs to run on every PR.
Not sure if there is a better way to do this.

We could alternatively make this a not required check

Fixes the problem on #768
