### PR TITLE
🐛Bug - Consulting Text Too Small

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -223,12 +223,13 @@ module.exports = {
           "Helvetica",
           "sans-serif",
         ],
-        helvetica: [
+        helvetica: ["Helvetica Neue", "Helvetica", "sans-serif"],
+        body: [
+          "var(--open-sans-font)",
           "Helvetica Neue",
           "Helvetica",
           "sans-serif",
         ],
-        body: ["var(--open-sans-font)", "Helvetica Neue", "Helvetica", "sans-serif"],
       },
       animation: {
         "more-bounce": "more-bounce 2s infinite",
@@ -282,17 +283,17 @@ module.exports = {
               marginBottom: "7px",
             },
             h4: {
-              color: theme("colors.sswBlack")
+              color: theme("colors.sswBlack"),
             },
             strong: {
-              color: theme("colors.sswBlack")
+              color: theme("colors.sswBlack"),
             },
             a: {
-              fontWeight: "300"
+              fontWeight: "300",
             },
             p: {
               marginBottom: "10px",
-              color: theme("colors.sswBlack")
+              color: theme("colors.sswBlack"),
             },
             hr: {
               margin: "30px 0",
@@ -313,8 +314,10 @@ module.exports = {
             },
             "p, ul": {
               fontWeight: theme("fontWeight.light"),
-              margin: "0 auto",
-              padding: "20px 0",
+              fontSize: "1.125rem",
+              lineHeight: "1.75rem",
+              margin: "1rem auto",
+              padding: "0",
             },
             "p > img": {
               margin: "0 auto",


### PR DESCRIPTION
As per the original issue conversation, @tiagov8 requested specific changes to CSS, which were implemented in this PR. 

As per https://tailwindcss.com/docs/font-size, I have substituted the equivalent `1.125rem` for `18px`. 

Fixes #749 

Affected routes:

- All consulting routes

**Images:**
**/consulting/react**
![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/feb1854e-2c7f-446e-896f-f6b08005f876)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/c5f1d724-ed34-4340-be5b-13c905a0c44d)
**Figure: After**

**/consulting/artificial-intelligence**
![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/33651f7d-2ed6-488d-b439-d00aa1bae934)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/7c97c27d-cf70-4638-a35e-587b743689f6)
**Figure: After**

**/consulting/angular**
![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/31c00e44-3e96-4728-b958-9d751a4e09f2)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/4f734749-548a-4fb9-bf42-be7ad719dc4f)
**Figure: After**

