### PR TITLE
🐛Consulting Page - Broken Benefits List

### DIFF
--- a/components/util/consulting/benefits.tsx
+++ b/components/util/consulting/benefits.tsx
@@ -6,31 +6,31 @@ import classNames from "classnames";
 const BenefitCard = ({ className, data, aosType }) => {
 	const { image, title, description, linkURL, linkName } = data;
 	return (
-		<article
-			className={classNames("px-14 py-11", className)}
-			data-aos={aosType}
-		>
-			<figure className="relative mx-auto h-40 w-40 select-none md:float-left">
-				{image && (
-					<Image src={image} sizes="100vw" fill alt={title || "benefit icon"} />
-				)}
-			</figure>
+    <article
+      className={classNames("px-14 py-11", className)}
+      data-aos={aosType}
+    >
+      <figure className="relative mx-auto h-40 w-40 select-none md:float-left">
+        {image && (
+          <Image src={image} sizes="100vw" fill alt={title || "benefit icon"} />
+        )}
+      </figure>
 
-			<h4 className="mb-2 mt-4 text-center text-xl font-medium uppercase leading-snug md:text-left">
-				{title}
-			</h4>
-			<article>
-				<section className="mx-auto w-full max-w-full p-0 text-center text-sm font-light leading-normal prose-p:m-0 prose-p:first-of-type:pt-0 prose-strong:font-bold md:text-left md:text-md">
-					<TinaMarkdown content={description} />
-				</section>
-				{linkURL && (
-					<a className="text-white no-underline" href={linkURL}>
-						{linkName}
-					</a>
-				)}
-			</article>
-		</article>
-	);
+      <h4 className="mb-2 mt-4 text-center text-xl font-medium uppercase leading-snug md:text-left">
+        {title}
+      </h4>
+      <article>
+        <section className="mx-auto w-full max-w-full p-0 text-center text-sm font-light leading-normal prose-p:m-0 prose-p:first-of-type:pt-0 prose-strong:font-bold prose-li:m-0 md:text-left md:text-md">
+          <TinaMarkdown content={description} />
+        </section>
+        {linkURL && (
+          <a className="text-white no-underline" href={linkURL}>
+            {linkName}
+          </a>
+        )}
+      </article>
+    </article>
+  );
 };
 
 export const Benefits = ({ data }) => {


### PR DESCRIPTION
Minor change to make `margin: 0` for all `li` elements in a benefits block. No other benefits cards contain `li` elements, only the security page, so this change has a minor impact. 

Fixes #773 

Affected routes:

- `/consulting/security`

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/87d25058-a857-40d1-abd6-583dd904bf0f)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/bf5a4899-0154-4fdb-b293-525f9e2b109b)
**Figure: After**
