### PR TITLE
🐛Homepage - Incorrect Display of Carousel on Mobile Devices

### DIFF
--- a/components/blocks/aboutUs.tsx
+++ b/components/blocks/aboutUs.tsx
@@ -15,7 +15,7 @@ import { VideoModal } from "../videoModal";
 
 dayjs.extend(timezone);
 dayjs.extend(utc);
-
+ 
 const DAY_KEYS = {
   Sunday: 0,
   Monday: 1,

--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -21,7 +21,7 @@ beforeBody:
         openIn: sameWindow
         imgSrc: /images/carousel/need-help.jpeg
     backgroundColor: lightgray
-    showOnMobileDevices: true
+    showOnMobileDevices: false
     _template: Carousel
   - bigCardsLabel: Consulting
     bigCards:


### PR DESCRIPTION
We recently added a new schema value to determine whether a carousel element should be displayed on mobile, but show on mobile should be set to false on the homepage. 

Fixes #813 

Affected routes:

- `/`