### PR TITLE
AppInsight - locking the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@headlessui/react": "1.7.14",
     "@headlessui/tailwindcss": "^0.1.3",
     "@microsoft/applicationinsights-react-js": "^3.4.2",
-    "@microsoft/applicationinsights-web": "^2.8.5",
+    "@microsoft/applicationinsights-web": "2.8.14",
     "@tailwindcss/typography": "^0.5.9",
     "animate-css-grid": "^1.5.1",
     "aos": "^2.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,7 +3056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/applicationinsights-web@npm:^2.8.5":
+"@microsoft/applicationinsights-web@npm:2.8.14":
   version: 2.8.14
   resolution: "@microsoft/applicationinsights-web@npm:2.8.14"
   dependencies:
@@ -4554,7 +4554,7 @@ __metadata:
     "@headlessui/react": 1.7.14
     "@headlessui/tailwindcss": ^0.1.3
     "@microsoft/applicationinsights-react-js": ^3.4.2
-    "@microsoft/applicationinsights-web": ^2.8.5
+    "@microsoft/applicationinsights-web": 2.8.14
     "@next/eslint-plugin-next": ^13.4.6
     "@svgr/webpack": ^8.0.1
     "@tailwindcss/typography": ^0.5.9


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

Fixes #829 for PR: https://github.com/SSWConsulting/SSW.Website/pull/826

#### Description:
Locking appInsight web package to a particular version 2.8.14 to avoid compatibility issues and being picked by Dependabot to update it.