### PR TITLE
🐛Employment Page - Fixed broken image display

### DIFF
--- a/components/employment/opportunities.tsx
+++ b/components/employment/opportunities.tsx
@@ -53,7 +53,7 @@ export const Opportunities = ({ opportunities }: OpportunitiesProps) => {
         <h3 className="mb-4">
           <Image
             alt="Question Mark"
-            src="/images/employment/question.png"
+            src="/images/Employment/question.png"
             height={16}
             width={16}
             className="inline"
@@ -204,7 +204,7 @@ const FilterOption = ({
       >
         <Image
           alt="Arrow"
-          src="/images/employment/arrow.png"
+          src="/images/Employment/arrow.png"
           height={10}
           width={10}
           className="absolute m-2 ml-1"

--- a/content/employment/index.mdx
+++ b/content/employment/index.mdx
@@ -130,7 +130,7 @@ afterBody: >
   # **Recruitment** process at SSW
 
 
-  <CustomImage src="/images/employment/recruitment_doodle.png" altText="SSW
+  <CustomImage src="/images/Employment/recruitment_doodle.png" altText="SSW
   Recruitment Process" height={349} width={1093} />
 
 

--- a/content/marketing/dressing-down.mdx
+++ b/content/marketing/dressing-down.mdx
@@ -2,7 +2,7 @@
 title: <span class="text-sswRed">Dressing down</span> (aka casual Fridays)?
 backgroundImage: /images/sswMarketingBackground.jpg
 mediaComponent: >-
-  ![Dress code graphic](images/Employment/dresscode.png)
+  ![Dress code graphic](/images/Employment/dresscode.png)
 textSide: left
 ---
 


### PR DESCRIPTION
Fixes #348

Affected routes:

- `/employment`

Add done video, screenshots
