### PR TITLE
GTM - Lazy loading for scripts

### DIFF
--- a/components/layout/analytics.tsx
+++ b/components/layout/analytics.tsx
@@ -4,7 +4,7 @@ const gtmId = process.env.NEXT_PUBLIC_GOOGLE_GTM_ID;
 
 export const Analytics = () => {
   return (
-    <Script id="google-tag-manager" strategy="afterInteractive">
+    <Script id="google-tag-manager" strategy="lazyOnload">
       {`
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

Related to #248 

**Description:**
By default, it was loading GTM scripts as afterInteractive strategy, which consumes time while loading the page, now we are loading the scripts as LazyLoading strategy as it will be injected into the HTML client-side during browser idle time.

Affected routes:

- `/`

