### PR TITLE
PR check - Adding condition to check this issue

### DIFF
--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -26,7 +26,7 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = git diff --name-only ${{github.event.pull_request.head.ref}} main
+          $diff = (git diff --name-only ${{github.event.pull_request.head.ref}} main)
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -25,13 +25,12 @@ jobs:
             content:
               - 'content/**'
               - 'public/**'
-              - '.github/**'
 
       - name: For Testing
         run: echo ${{steps.changes.outputs.content}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'pr-link-issue' && github.event.pull_request.head.ref != '.github/' }}
+        if: ${{ steps.changes.outputs.content == 'true'}}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -29,7 +29,6 @@ jobs:
             other_changes:
               - '!content/**'
               - '!public/**'
-              - '!.github/**'
 
       - name: For Testing
         run: echo ${{steps.changes.outputs.content_changes}} - ${{steps.changes.outputs.other_changes}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Check linked issues
     steps:
+      - name: For Testing
+        run: echo ${{github.event.pull_request.head.ref}}
+
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'public/' && github.event.pull_request.head.ref != '.github/' }}
         id: check-linked-issues

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -31,7 +31,7 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = git diff --name-only HEAD^ HEAD
+          $diff = git diff --name-only HEAD main
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -22,6 +22,9 @@ jobs:
       #         fetch-depth: 2
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          # Checkout as many commits as needed for the diff
+          fetch-depth: 2
 
       - shell: pwsh
         # Give an id to the step, so we can reference it later
@@ -29,12 +32,15 @@ jobs:
         run: |
           # Diff HEAD with the previous commit
           $diff = git diff --name-only HEAD^ HEAD
+
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }
           $HasDiff = $SourceDiff.Length -gt 0
+
           # Set the output named "docs_changed"
           Write-Host "::set-output name=docs_changed::$HasDiff"
           Write-Host "::set-output name=docs::$diff"
+          Write-Host "::set-output name=docs_s::$SourceDiff"
 
       - name: For Testing
         run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -28,16 +28,13 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = (git diff --name-only HEAD^ HEAD)
-
+          $diff = git diff --name-only HEAD^ HEAD
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' or $_ -notmatch '^.github/' }
           $HasDiff = $SourceDiff.Length -gt 0
-
           # Set the output named "docs_changed"
-          echo "docs_changed=$HasDiff" >> $env:GITHUB_OUTPUT
-          echo "docs=$diff" >> $env:GITHUB_OUTPUT
-          echo "docs_s=$SourceDiff" >> $env:GITHUB_OUTPUT
+          Write-Host "::set-output name=docs_changed::$HasDiff"
+          Write-Host "::set-output name=docs::$diff"
 
       - name: For Testing
         run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -33,9 +33,9 @@ jobs:
           $HasDiff = $SourceDiff.Length -gt 0
 
           # Set the output named "docs_changed"
-          Write-Host "::set-output name=docs_changed::$HasDiff"
-          Write-Host "::set-output name=docs::$diff"
-          Write-Host "::set-output name=docs_s::$SourceDiff"
+          Write-Host "docs_changed=$HasDiff" >> GITHUB_OUTPUT
+          Write-Host "docs=$diff" >> GITHUB_OUTPUT
+          Write-Host "docs_s=$SourceDiff" >> GITHUB_OUTPUT
 
       - name: For Testing
         run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -31,7 +31,7 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = git diff --name-only HEAD main
+          $diff = git diff --name-only main...HEAD
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -17,21 +17,27 @@ jobs:
     runs-on: ubuntu-latest
     name: Check linked issues
     steps:
-      - name: Check paths
-        id: changes
-        uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v2
         with:
-          filters: |
-            content_changes:
-              - 'content/**'
-              - 'public/**'
-            other_changes:
-              - '!content/**'
-            other_changes2:
-              - '!public/**'
+          # Checkout as many commits as needed for the diff
+          fetch-depth: 2
+      - shell: pwsh
+        # Give an id to the step, so we can reference it later
+        id: check_file_changed
+        run: |
+          # Diff HEAD with the previous commit
+          $diff = git diff --name-only HEAD^ HEAD
+
+          # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' or $_ -notmatch '^.github/' }
+          $HasDiff = $SourceDiff.Length -gt 0
+
+          # Set the output named "docs_changed"
+          Write-Host "::set-output name=docs_changed::$HasDiff"
+          Write-Host "::set-output name=docs::$diff"
 
       - name: For Testing
-        run: echo ${{steps.changes.outputs.content_changes}} - ${{steps.changes.outputs.other_changes}} - ${{steps.changes.outputs.other_changes2}}
+        run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{steps.changes.outputs.other_changes == 'true'}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # Source Difference
           if ( ([string]::IsNullOrEmpty(" ${{ steps.check_file_changed.outputs.sourceDiff }} "))) {
-            echo "✅Content Changes - 🏃Skipping next step"
+            echo "🏃 content change only - skipping lint action"
           }
           else {
             echo "${{ steps.check_file_changed.outputs.sourceDiff }}"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check linked issues
     steps:
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'public/' && github.event.pull_request.head.ref != 'workflows/' }}
+        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'public/' && github.event.pull_request.head.ref != '.github/' }}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -25,9 +25,11 @@ jobs:
             content:
               - 'content/**'
               - 'public/**'
+              - '.github/**'
             other:
               - '!content/**'
               - '!public/**'
+              - '!.github/**'
 
       - name: For Testing
         run: echo ${{steps.changes.outputs.content}} - ${{steps.changes.outputs.other}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -29,7 +29,7 @@ jobs:
           $diff = git diff --name-only HEAD^ HEAD
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^./.github/' }
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }
           $HasDiff = $SourceDiff.Length -gt 0
 
           # Set the output named "docs_changed"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -28,7 +28,7 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = (git diff --name-only HEAD main)
+          $diff = (git diff --name-only HEAD^ HEAD)
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -28,7 +28,7 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = (git diff --name-only ${{github.event.pull_request.head.ref}} main)
+          $diff = (git diff --name-only HEAD main)
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -3,9 +3,6 @@ name: PR - Lint PR
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - "content/**"
-      - "public/**"
 
 concurrency:
   group: ci-${{ github.event.number }}
@@ -21,6 +18,7 @@ jobs:
     name: Check linked issues
     steps:
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
+        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'public/' }}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -18,9 +18,9 @@ jobs:
     name: Check linked issues
     steps:
       - uses: actions/checkout@v2
-        with:
-          # Checkout as many commits as needed for the diff
-          fetch-depth: 2
+      #        with:
+      # Checkout as many commits as needed for the diff
+      #         fetch-depth: 2
       - shell: pwsh
         # Give an id to the step, so we can reference it later
         id: check_file_changed

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           filters: |
             content:
-              - '!content/**'
-              - '!public/**'
-              - '!.github/**'
+              - 'content/**'
+              - 'public/**'
+              - '.github/**'
 
       - name: For Testing
         run: echo ${{steps.changes.outputs.content}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           # Source Difference
           if ( ([string]::IsNullOrEmpty(" ${{ steps.check_file_changed.outputs.sourceDiff }} "))) {
-            echo "❌Content Change only - 🏃Skipping next step"
+            echo "✅Content Changes - 🏃Skipping next step"
           }
           else {
             echo "${{ steps.check_file_changed.outputs.sourceDiff }}"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -17,8 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Check linked issues
     steps:
+      - name: Check paths
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            content:
+              - '!content/**'
+              - '!public/**'
+              - '!.github/**'
+
       - name: For Testing
-        run: echo ${{github.event.pull_request.head.ref}}
+        run: echo ${{steps.changes.outputs.content}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'pr-link-issue' && github.event.pull_request.head.ref != '.github/' }}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -37,8 +37,9 @@ jobs:
 
       - name: Non-content files - 📂
         run: |
+          # Source Difference
           if ( ([string]::IsNullOrEmpty(" ${{ steps.check_file_changed.outputs.sourceDiff }} "))) {
-            echo "🤷Content Change - 🏃Skipping next step"
+            echo "❌Content Change only - 🏃Skipping next step"
           }
           else {
             echo "${{ steps.check_file_changed.outputs.sourceDiff }}"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -28,6 +28,7 @@ jobs:
             other_changes:
               - '!content/**'
               - '!public/**'
+              - '!.github/**'
 
       - name: For Testing
         run: echo ${{steps.changes.outputs.content_changes}} - ${{steps.changes.outputs.other_changes}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -28,20 +28,13 @@ jobs:
           # Diff HEAD with the previous commit
           $diff = git diff --name-only HEAD^ HEAD
 
-          # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' }
           $HasDiff = $SourceDiff.Length -gt 0
 
-          # Set the output named "docs_changed"
-          echo "docs_changed=$HasDiff" >> $env:GITHUB_OUTPUT
-          echo "docs=$diff" >> $env:GITHUB_OUTPUT
-          echo "docs_s=$SourceDiff" >> $env:GITHUB_OUTPUT
-
-      - name: For Testing
-        run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}
+          echo "hasNonContentChanges=$HasDiff" >> $env:GITHUB_OUTPUT
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{steps.check_file_changed.outputs.docs_changed == 'True' }}
+        if: ${{steps.check_file_changed.outputs.hasNonContentChanges == 'True' }}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -26,10 +26,12 @@ jobs:
               - 'content/**'
               - 'public/**'
             other_changes:
-              - '!.github/**'
+              - '!content/**'
+            other_changes2:
+              - '!public/**'
 
       - name: For Testing
-        run: echo ${{steps.changes.outputs.content_changes}} - ${{steps.changes.outputs.other_changes}}
+        run: echo ${{steps.changes.outputs.content_changes}} - ${{steps.changes.outputs.other_changes}} - ${{steps.changes.outputs.other_changes2}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{steps.changes.outputs.other_changes == 'true'}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -25,9 +25,12 @@ jobs:
             content:
               - 'content/**'
               - 'public/**'
+            other:
+              - '!content/**'
+              - '!public/**'
 
       - name: For Testing
-        run: echo ${{steps.changes.outputs.content}}
+        run: echo ${{steps.changes.outputs.content}} - ${{steps.changes.outputs.other}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{ steps.changes.outputs.content == 'true'}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -37,11 +37,12 @@ jobs:
 
       - name: Non-content files - 📂
         run: |
-          if [[ -z "${{ steps.check_file_changed.outputs.sourceDiff }}" ]]; then
-            echo "🤷Content Change - Skipping next step"
-          else
+          if ( ([string]::IsNullOrEmpty(" ${{ steps.check_file_changed.outputs.sourceDiff }} "))) {
+            echo "🤷Content Change - 🏃Skipping next step"
+          }
+          else {
             echo "${{ steps.check_file_changed.outputs.sourceDiff }}"
-          fi
+          }
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{steps.check_file_changed.outputs.hasNonContentChanges == 'True' }}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -25,7 +25,6 @@ jobs:
             content_changes:
               - 'content/**'
               - 'public/**'
-              - '.github/**'
             other_changes:
               - '!content/**'
               - '!public/**'

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -36,7 +36,12 @@ jobs:
           echo "sourceDiff=$SourceDiff" >> $env:GITHUB_OUTPUT
 
       - name: Non-content files - 📂
-        run: echo ${{steps.check_file_changed.outputs.sourceDiff}}
+        run: |
+          if [[ -z "${{ steps.check_file_changed.outputs.sourceDiff }}" ]]; then
+            echo "🤷Content Change - Skipping next step"
+          else
+            echo "${{ steps.check_file_changed.outputs.sourceDiff }}"
+          fi
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{steps.check_file_changed.outputs.hasNonContentChanges == 'True' }}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -30,7 +30,7 @@ jobs:
           # Diff HEAD with the previous commit
           $diff = git diff --name-only HEAD^ HEAD
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' or $_ -notmatch '^.github/' }
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }
           $HasDiff = $SourceDiff.Length -gt 0
           # Set the output named "docs_changed"
           Write-Host "::set-output name=docs_changed::$HasDiff"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -26,7 +26,7 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = git diff --name-only HEAD^ HEAD
+          $diff = git diff --name-only ${{github.event.pull_request.head.ref}} main
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -29,6 +29,7 @@ jobs:
           # Diff HEAD with the previous commit
           $diff = git diff --name-only HEAD^ HEAD
 
+# TODO: Next time we need to modify which directories we ignore, break this out to a variable which is easy to configure
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' }
           $HasDiff = $SourceDiff.Length -gt 0
 

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -33,9 +33,9 @@ jobs:
           $HasDiff = $SourceDiff.Length -gt 0
 
           # Set the output named "docs_changed"
-          Write-Host "docs_changed=$HasDiff" >> GITHUB_OUTPUT
-          Write-Host "docs=$diff" >> GITHUB_OUTPUT
-          Write-Host "docs_s=$SourceDiff" >> GITHUB_OUTPUT
+          echo "docs_changed=$HasDiff" >> $env:GITHUB_OUTPUT
+          echo "docs=$diff" >> $env:GITHUB_OUTPUT
+          echo "docs_s=$SourceDiff" >> $env:GITHUB_OUTPUT
 
       - name: For Testing
         run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -35,9 +35,10 @@ jobs:
           # Set the output named "docs_changed"
           Write-Host "::set-output name=docs_changed::$HasDiff"
           Write-Host "::set-output name=docs::$diff"
+          Write-Host "::set-output name=docs_s::$SourceDiff"
 
       - name: For Testing
-        run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}}
+        run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - - ${{steps.check_file_changed.outputs.docs_s}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{steps.changes.outputs.other_changes == 'true'}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -24,14 +24,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           # Checkout as many commits as needed for the diff
-          fetch-depth: 4
+          fetch-depth: 2
 
       - shell: pwsh
         # Give an id to the step, so we can reference it later
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = git diff --name-only HEAD^^ HEAD
+          $diff = git diff --name-only HEAD^ HEAD
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -26,8 +26,6 @@ jobs:
               - 'content/**'
               - 'public/**'
             other_changes:
-              - '!content/**'
-              - '!public/**'
               - '!.github/**'
 
       - name: For Testing

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           fetch-depth: 2
 
-      - shell: pwsh
+      - name: 🔎Checking non-content changes
+        shell: pwsh
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
@@ -32,6 +33,10 @@ jobs:
           $HasDiff = $SourceDiff.Length -gt 0
 
           echo "hasNonContentChanges=$HasDiff" >> $env:GITHUB_OUTPUT
+          echo "sourceDiff=$SourceDiff" >> $env:GITHUB_OUTPUT
+
+      - name: Non-content files
+        run: echo ${{steps.check_file_changed.outputs.sourceDiff}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{steps.check_file_changed.outputs.hasNonContentChanges == 'True' }}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -32,7 +32,7 @@ jobs:
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' }
           $HasDiff = $SourceDiff.Length -gt 0
 
-          echo "hasNonContentChanges=$HasDiff" >> $env:GITHUB_OUTPUT
+          echo "hasCodeChanges=$HasDiff" >> $env:GITHUB_OUTPUT
           echo "sourceDiff=$SourceDiff" >> $env:GITHUB_OUTPUT
 
       - name: Non-content files - 📂
@@ -46,7 +46,7 @@ jobs:
           }
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{steps.check_file_changed.outputs.hasNonContentChanges == 'True' }}
+        if: ${{steps.check_file_changed.outputs.hasCodeChanges == 'True' }}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: 🔎Checking non-content changes
+      - name: Checking non-content changes - 🔎
         shell: pwsh
         id: check_file_changed
         run: |
@@ -35,7 +35,7 @@ jobs:
           echo "hasNonContentChanges=$HasDiff" >> $env:GITHUB_OUTPUT
           echo "sourceDiff=$SourceDiff" >> $env:GITHUB_OUTPUT
 
-      - name: Non-content files
+      - name: Non-content files - 📂
         run: echo ${{steps.check_file_changed.outputs.sourceDiff}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -29,7 +29,7 @@ jobs:
           $diff = git diff --name-only HEAD^ HEAD
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' or $_ -notmatch '^.github/' }
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' -or $_ -notmatch '^.github/' }
           $HasDiff = $SourceDiff.Length -gt 0
 
           # Set the output named "docs_changed"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check linked issues
     steps:
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'public/' }}
+        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'public/' && github.event.pull_request.head.ref != 'workflows/' }}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -17,17 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Check linked issues
     steps:
-      #        with:
-      # Checkout as many commits as needed for the diff
-      #         fetch-depth: 2
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          # Checkout as many commits as needed for the diff
           fetch-depth: 2
 
       - shell: pwsh
-        # Give an id to the step, so we can reference it later
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
@@ -38,9 +33,9 @@ jobs:
           $HasDiff = $SourceDiff.Length -gt 0
 
           # Set the output named "docs_changed"
-          Write-Host "::set-output name=docs_changed::$HasDiff"
-          Write-Host "::set-output name=docs::$diff"
-          Write-Host "::set-output name=docs_s::$SourceDiff"
+          echo "docs_changed=$HasDiff" >> $env:GITHUB_OUTPUT
+          echo "docs=$diff" >> $env:GITHUB_OUTPUT
+          echo "docs_s=$SourceDiff" >> $env:GITHUB_OUTPUT
 
       - name: For Testing
         run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -29,7 +29,7 @@ jobs:
           $diff = git diff --name-only HEAD^ HEAD
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' -or $_ -notmatch '^./.github/' }
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^./.github/' }
           $HasDiff = $SourceDiff.Length -gt 0
 
           # Set the output named "docs_changed"
@@ -38,7 +38,7 @@ jobs:
           Write-Host "::set-output name=docs_s::$SourceDiff"
 
       - name: For Testing
-        run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - - ${{steps.check_file_changed.outputs.docs_s}}
+        run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
         if: ${{steps.changes.outputs.other_changes == 'true'}}

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -22,20 +22,20 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           filters: |
-            content:
+            content_changes:
               - 'content/**'
               - 'public/**'
               - '.github/**'
-            other:
+            other_changes:
               - '!content/**'
               - '!public/**'
               - '!.github/**'
 
       - name: For Testing
-        run: echo ${{steps.changes.outputs.content}} - ${{steps.changes.outputs.other}}
+        run: echo ${{steps.changes.outputs.content_changes}} - ${{steps.changes.outputs.other_changes}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{ steps.changes.outputs.content == 'true'}}
+        if: ${{steps.changes.outputs.other_changes == 'true'}}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo ${{steps.check_file_changed.outputs.docs_changed}} - ${{steps.check_file_changed.outputs.docs}} - ${{steps.check_file_changed.outputs.docs_s}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{steps.changes.outputs.other_changes == 'true'}}
+        if: ${{steps.check_file_changed.outputs.docs_changed == 'True' }}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo ${{github.event.pull_request.head.ref}}
 
       - uses: nearform-actions/github-action-check-linked-issues@v1.4.16
-        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'public/' && github.event.pull_request.head.ref != '.github/' }}
+        if: ${{ github.event.pull_request.head.ref != 'content/' && github.event.pull_request.head.ref != 'pr-link-issue' && github.event.pull_request.head.ref != '.github/' }}
         id: check-linked-issues
         with:
           exclude-branches: "dependabot/**"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -29,7 +29,7 @@ jobs:
           $diff = git diff --name-only HEAD^ HEAD
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' -or $_ -notmatch '^.github/' }
+          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -or $_ -notmatch '^public/' -or $_ -notmatch '^./.github/' }
           $HasDiff = $SourceDiff.Length -gt 0
 
           # Set the output named "docs_changed"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Check linked issues
     steps:
-      - uses: actions/checkout@v2
       #        with:
       # Checkout as many commits as needed for the diff
       #         fetch-depth: 2

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -31,7 +31,7 @@ jobs:
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = git diff --name-only HEAD origin/main
+          $diff = git diff --name-only HEAD^^ HEAD
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -24,14 +24,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           # Checkout as many commits as needed for the diff
-          fetch-depth: 2
+          fetch-depth: 4
 
       - shell: pwsh
         # Give an id to the step, so we can reference it later
         id: check_file_changed
         run: |
           # Diff HEAD with the previous commit
-          $diff = git diff --name-only main...HEAD
+          $diff = git diff --name-only HEAD origin/main
 
           # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
           $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/' }

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -20,6 +20,9 @@ jobs:
       #        with:
       # Checkout as many commits as needed for the diff
       #         fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - shell: pwsh
         # Give an id to the step, so we can reference it later
         id: check_file_changed

--- a/content/consulting/access-database-upsizing.mdx
+++ b/content/consulting/access-database-upsizing.mdx
@@ -48,7 +48,7 @@ seo:
     - url: /images/consulting/open-graph/access.jpg
       width: 1200
       height: 629
-      alt: SSW Microsoft Access Consulting - Enterprises Software Development
+      alt: SSW Microsoft Access Consulting - Enterprise Software Development
 ---
 
 <VideoEmbed url="https://www.youtube.com/watch?v=ebRQ-FWSIv4" />

--- a/content/consulting/access-database-upsizing.mdx
+++ b/content/consulting/access-database-upsizing.mdx
@@ -48,7 +48,7 @@ seo:
     - url: /images/consulting/open-graph/access.jpg
       width: 1200
       height: 629
-      alt: SSW Microsoft Access Consulting - Enterprise Software Development
+      alt: SSW Microsoft Access Consulting - Enterprises Software Development
 ---
 
 <VideoEmbed url="https://www.youtube.com/watch?v=ebRQ-FWSIv4" />

--- a/infra/create-pr-environment.bicep
+++ b/infra/create-pr-environment.bicep
@@ -11,10 +11,6 @@ var dev = {
   'cost-category': 'dev/test'
 }
 
-var core = {
-  'cost-category': 'core'
-}
-
 var acrName = replace(acrLoginServer, '.azurecr.io', '')
 module keyVault 'keyVault.bicep' = {
   name:'keyVault-${now}'


### PR DESCRIPTION
Fixes #777 

**Description:**
GitHub workflow - PR Linked Issue - skipping if the PR has only content from `content/` or `public/`.  