### PR TITLE
✨ Add click to edit on newsletters template

### DIFF
--- a/pages/[filename].tsx
+++ b/pages/[filename].tsx
@@ -1,5 +1,5 @@
 import { InferGetStaticPropsType } from "next";
-import { useTina } from "tinacms/dist/react";
+import { tinaField, useTina } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 import { client } from "../.tina/__generated__/client";
 import { pageBlocks } from "../components/blocks";
@@ -49,7 +49,10 @@ export default function HomePage(
         <Blocks prefix="PageBeforeBody" blocks={data.page.beforeBody} />
         <Container className={"flex-1 pt-4"}>
           <div className="gap-4 md:grid md:grid-cols-5">
-            <div className={contentClass}>
+            <div 
+              data-tina-field={tinaField(data.page, "_body")} 
+              className={contentClass}
+            >
               <TinaMarkdown
                 components={componentRenderer}
                 content={data.page._body}

--- a/pages/[filename].tsx
+++ b/pages/[filename].tsx
@@ -49,8 +49,8 @@ export default function HomePage(
         <Blocks prefix="PageBeforeBody" blocks={data.page.beforeBody} />
         <Container className={"flex-1 pt-4"}>
           <div className="gap-4 md:grid md:grid-cols-5">
-            <div 
-              data-tina-field={tinaField(data.page, "_body")} 
+            <div
+              data-tina-field={tinaField(data.page, "_body")}
               className={contentClass}
             >
               <TinaMarkdown


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
Added Tinas click to edit feature to the template used by the home and newsletter page so that users can click on the element they want to edit.

Fixes #836 

Affected routes:
- /
- /newsletters

![image](https://github.com/SSWConsulting/SSW.Website/assets/10693364/df081fd7-9a71-4883-b41f-f0364d44bcac)
**Figure: The body section on the newsletters page can now be clicked to edit**

![image](https://github.com/SSWConsulting/SSW.Website/assets/10693364/07c96f04-dcf3-4e1b-9db9-f042fa1a3c67)
**Figure: The body section on the home page can now be clicked to edit**

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
