### PR TITLE
Updated CodeAuditor scan command line

### DIFF
--- a/.github/workflows/weekly-codeauditor-scan.yml
+++ b/.github/workflows/weekly-codeauditor-scan.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - name: 'SSW CodeAuditor - Check broken links and performance'
         continue-on-error: true
-        run: 'docker run sswconsulting/codeauditor --token ${{ secrets.CODEAUDITOR_TOKEN }} --url https://www.ssw.com.au/ --maxthread 200 --debug'
+        run: 'docker container run --cap-add=SYS_ADMIN sswconsulting/codeauditor --token ${{ secrets.CODEAUDITOR_TOKEN }} --url https://www.ssw.com.au/ --maxthread 200'


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

As per https://github.com/SSWConsulting/SSW.CodeAuditor/issues/455

The way to run CodeAuditor has been changed, need to use new option flag `--cap-add=SYS_ADMIN` to enable running lighthouse