### PR TITLE
Updated training page email

### DIFF
--- a/content/training/fullstack.mdx
+++ b/content/training/fullstack.mdx
@@ -165,8 +165,10 @@ _body:
 
 
           <RecurringEvent day="monday"
-          applyLinkRedirect="mailto:pennywalker@ssw.com.au?cc=lukecook@ssw.com.au,
-          pierssinclair@ssw.com.au, luciasirtori@ssw.com.au" />
+          applyLinkRedirect="mailto:pennywalker@ssw.com.au?subject=New
+          application for
+          SSW&cc=lukecook@ssw.com.au;pierssinclair@ssw.com.au;luciasirtori@ssw.com.au"
+          />
     _template: TrainingInformation
   - header: <span class="text-sswRed">What</span> will you learn?
     listItems:
@@ -220,6 +222,8 @@ trainingHeaderCarousel:
           mailto:pennywalker@ssw.com.au?cc=lukecook@ssw.com.au,
           pierssinclair@ssw.com.au, luciasirtori@ssw.com.au
 ---
+
+
 
 
 


### PR DESCRIPTION
- Added subject
- Separated CC's with ;

Fixes #906 

Affected routes:
- <!-- E.g. `/offices/brisbane`  --> /training/fullstack

![MicrosoftTeams-image](https://github.com/SSWConsulting/SSW.Website/assets/25432120/0ee2576e-aa25-4022-b6db-8c44f71ea70b)

