### PR TITLE
Internship page - Use Ben's image

### DIFF
--- a/content/training/fullstack.mdx
+++ b/content/training/fullstack.mdx
@@ -212,16 +212,17 @@ trainingHeaderCarousel:
         url: >-
           mailto:pennywalker@ssw.com.au?cc=lukecook@ssw.com.au,
           pierssinclair@ssw.com.au, luciasirtori@ssw.com.au
-    - tagline: Learn how to be a
+    - tagline: Become a
       secondaryTagline: First Class Microsoft Developer
       heroBackground: /images/polygonBackground.png
-      person: /images/people/piers.png
+      person: /images/ben-intern-2.png
       link:
         linkText: Apply Now
         url: >-
           mailto:pennywalker@ssw.com.au?cc=lukecook@ssw.com.au,
           pierssinclair@ssw.com.au, luciasirtori@ssw.com.au
 ---
+
 
 
 


### PR DESCRIPTION
A few changes with Ken

Fixes N/A

Affected routes:

- `training/fullstack`

<img width="1800" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/38869720/cbcbc96f-cefd-4b6e-9979-eebfdfe0286a">

