### PR TITLE
🐛 Footer - DayJS RelativeTime Error

### DIFF
--- a/components/blocks/aboutUs.tsx
+++ b/components/blocks/aboutUs.tsx
@@ -1,7 +1,5 @@
 import classNames from "classnames";
 import dayjs from "dayjs";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { Template } from "tinacms";
@@ -13,9 +11,6 @@ import layoutData from "../../content/global/index.json";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 import { VideoModal } from "../videoModal";
-
-dayjs.extend(timezone);
-dayjs.extend(utc);
 
 const DAY_KEYS = {
   Sunday: 0,

--- a/components/blocks/upcomingEvents.tsx
+++ b/components/blocks/upcomingEvents.tsx
@@ -1,7 +1,5 @@
 import dayjs from "dayjs";
-import isBetween from "dayjs/plugin/isBetween";
-import relativeTime from "dayjs/plugin/relativeTime";
-import utc from "dayjs/plugin/utc";
+// import relativeTime from "dayjs/plugin/relativeTime";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -10,10 +8,6 @@ import { tinaField } from "tinacms/dist/react";
 
 import axios from "axios";
 import { EventInfo, LiveStreamBannerInfo } from "../../services/server/events";
-
-dayjs.extend(utc);
-dayjs.extend(isBetween);
-dayjs.extend(relativeTime);
 
 export const UpcomingEvents = ({ data }) => {
   const [events, setEvents] = useState([]);

--- a/components/blocks/upcomingEvents.tsx
+++ b/components/blocks/upcomingEvents.tsx
@@ -1,5 +1,4 @@
 import dayjs from "dayjs";
-// import relativeTime from "dayjs/plugin/relativeTime";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,16 +1,12 @@
 import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
+// import relativeTime from "dayjs/plugin/relativeTime";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { Container } from "../util/container";
 import { SocialIcons, SocialTypes } from "../util/socialIcons";
 
-dayjs.extend(timezone);
-dayjs.extend(utc);
-dayjs.extend(relativeTime);
+// dayjs.extend(relativeTime);
 
 export const Footer = () => {
   return (

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,12 +1,9 @@
 import dayjs from "dayjs";
-// import relativeTime from "dayjs/plugin/relativeTime";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { Container } from "../util/container";
 import { SocialIcons, SocialTypes } from "../util/socialIcons";
-
-// dayjs.extend(relativeTime);
 
 export const Footer = () => {
   return (

--- a/components/liveStream/liveStreamBanner.tsx
+++ b/components/liveStream/liveStreamBanner.tsx
@@ -1,21 +1,10 @@
 import classNames from "classnames";
 import dayjs from "dayjs";
-import advancedFormat from "dayjs/plugin/advancedFormat";
-import isBetween from "dayjs/plugin/isBetween";
-import relativeTime from "dayjs/plugin/relativeTime";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { FC, useEffect, useState } from "react";
 import countdownTextFormat from "../../helpers/countdownTextFormat";
 import { LiveStreamProps } from "./useLiveStreamProps";
-
-dayjs.extend(utc);
-dayjs.extend(isBetween);
-dayjs.extend(relativeTime);
-dayjs.extend(advancedFormat);
-dayjs.extend(timezone);
 
 export const LiveStreamBanner: FC<LiveStreamProps> = ({
   countdownMins,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,10 +5,10 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import "react-responsive-modal/styles.css";
 import "react-tooltip/dist/react-tooltip.css";
+import "ssw.megamenu/dist/style.css";
 import { Analytics } from "../components/layout/analytics";
 import * as gtag from "../lib/gtag";
 import { NEXT_SEO_DEFAULT } from "../next-seo.config";
-import "ssw.megamenu/dist/style.css";
 import "../styles.css";
 
 import ZendeskButton from "../components/zendeskButton/zendeskButton";
@@ -16,6 +16,20 @@ const zendesk = process.env.NEXT_PUBLIC_ZENDESK_CHAT_KEY;
 // Hack as per https://stackoverflow.com/a/66575373 to stop font awesome icons breaking
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import AzureAppInsights from "../context/app-insight-client";
+
+// DayJS module addition as per https://github.com/iamkun/dayjs/issues/1577
+import dayjs from "dayjs";
+import advancedFormat from "dayjs/plugin/advancedFormat";
+import isBetween from "dayjs/plugin/isBetween";
+import relativeTime from "dayjs/plugin/relativeTime";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(relativeTime);
+dayjs.extend(timezone);
+dayjs.extend(utc);
+dayjs.extend(advancedFormat);
+dayjs.extend(isBetween);
 
 const isDev = process.env.NODE_ENV === "development";
 

--- a/pages/consulting/index.tsx
+++ b/pages/consulting/index.tsx
@@ -12,11 +12,12 @@ import { wrapGrid } from "animate-css-grid";
 import { useTina } from "tinacms/dist/react";
 import { client } from "../../.tina/__generated__/client";
 
+import { InferGetStaticPropsType } from "next";
+import { Blocks } from "../../components/blocks-renderer";
 import { Breadcrumbs } from "../../components/blocks/breadcrumbs";
 import { Layout } from "../../components/layout";
 import { Container } from "../../components/util/container";
 import { SEO } from "../../components/util/seo";
-import { InferGetStaticPropsType } from "next";
 
 const allServices = "All SSW Services";
 
@@ -97,6 +98,7 @@ export default function ConsultingIndex(
     <Layout>
       <SEO seo={{ ...seo, canonical: "/consulting" }} />
       <Container className="flex-1 pt-2">
+        <Blocks prefix={"ConsultingAfterBody"} blocks={[]} />
         <Breadcrumbs path={"/consulting"} suffix="" title={"Services"} />
         <h1 className="pt-0 text-3xl">Consulting Services</h1>
         <div className="flex flex-col md:flex-row">


### PR DESCRIPTION
* Added global DayJS plugin additions to ensure bug cannot occur again

From my investigation, the reason why the `/consulting` route had a bug with `.fromNow()` function from the `dayjs/plugin/relativeTime` module, but not the other pages was because the `UpcomingEvents` component was imported by using the `<Blocks>` component, which contains `dayjs.extend(relativeTime)`. This wasn't noticed as most of the pages have the `<Blocks>` component in the page, which therefore loaded `UpcomingEvents` and the DayJS module extension. I have fixed this by having a single source of truth in the root app file for which DayJS modules have been loaded, which should make it clear to both devs and the TypeScript compiler which modules are available for use in the project.

I found the desired configuration at https://github.com/iamkun/dayjs/issues/1577. This means that by using `dayjs.extend()`, each subsequent use of DayJS will have the plugin used with the function.

Fixes #899

Affected routes:

- All (`<Footer />`)
