### PR TITLE
✨ 965 - Video pages - Migrate training page

### DIFF
--- a/components/blocks/breadcrumbs.tsx
+++ b/components/blocks/breadcrumbs.tsx
@@ -15,10 +15,6 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = (props) => {
   const listItemStyling =
     "breadcrumb_item inline text-xs text-gray-700 no-underline not-first:before:content-bread not-first:before:px-2 before:list-none";
 
-  console.log("logged:" + props.path);
-  console.log("logged:" + props.title);
-  console.log("logged:" + `${props.title}`);
-
   return (
     <div
       {...(props.seoSchema

--- a/components/blocks/breadcrumbs.tsx
+++ b/components/blocks/breadcrumbs.tsx
@@ -14,6 +14,11 @@ interface BreadcrumbsProps {
 export const Breadcrumbs: FC<BreadcrumbsProps> = (props) => {
   const listItemStyling =
     "breadcrumb_item inline text-xs text-gray-700 no-underline not-first:before:content-bread not-first:before:px-2 before:list-none";
+
+  console.log("logged:" + props.path);
+  console.log("logged:" + props.title);
+  console.log("logged:" + `${props.title}`);
+
   return (
     <div
       {...(props.seoSchema
@@ -28,6 +33,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = (props) => {
           { from: "training", to: "Training" },
           { from: "employment", to: "Employment" },
           { from: "video-production", to: "Video Production" },
+          { from: "Training-videos", to: "Training Videos" },
           { from: props.path, to: `${props.title}` },
         ]}
         activeItemClassName={listItemStyling}

--- a/content/video-production/product-videos.mdx
+++ b/content/video-production/product-videos.mdx
@@ -1,11 +1,7 @@
 ---
 seo:
   title: Product Videos
-  description: >-
-    SSW Consulting has over 30 years of Microsoft software and web development
-    experience. We build on top of Angular, React, .NET, Azure, Azure DevOps,
-    SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software
-    consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.
+  description: 'SSW Consulting has over 30 years of Microsoft software and web development experience. We build on top of Angular, React, .NET, Azure, Azure DevOps, SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.'
 callToAction: 'Talk to us about your {{TITLE}} project'
 booking:
   title: Video Production
@@ -16,8 +12,8 @@ solution:
 afterBody:
   - title: SSW Related Services
     content: >
-      #### [Product/Service
-      Video](https://www.ssw.com.au/consulting/video-production/product-videos)
+      #### [Training
+      Video](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Training.aspx)
 
 
       #### [Content Marketing

--- a/content/video-production/product-videos.mdx
+++ b/content/video-production/product-videos.mdx
@@ -1,7 +1,11 @@
 ---
 seo:
   title: Product Videos
-  description: 'SSW Consulting has over 30 years of Microsoft software and web development experience. We build on top of Angular, React, .NET, Azure, Azure DevOps, SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.'
+  description: >-
+    SSW Consulting has over 30 years of Microsoft software and web development
+    experience. We build on top of Angular, React, .NET, Azure, Azure DevOps,
+    SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software
+    consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.
 callToAction: 'Talk to us about your {{TITLE}} project'
 booking:
   title: Video Production
@@ -13,7 +17,7 @@ afterBody:
   - title: SSW Related Services
     content: >
       #### [Training
-      Video](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Training.aspx)
+      Video](https://www.ssw.com.au/consulting/video-production/training-videos)
 
 
       #### [Content Marketing

--- a/content/video-production/product-videos.mdx
+++ b/content/video-production/product-videos.mdx
@@ -1,7 +1,11 @@
 ---
 seo:
   title: Product Videos
-  description: 'SSW Consulting has over 30 years of Microsoft software and web development experience. We build on top of Angular, React, .NET, Azure, Azure DevOps, SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.'
+  description: >-
+    SSW Consulting has over 30 years of Microsoft software and web development
+    experience. We build on top of Angular, React, .NET, Azure, Azure DevOps,
+    SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software
+    consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.
 callToAction: 'Talk to us about your {{TITLE}} project'
 booking:
   title: Video Production
@@ -12,8 +16,8 @@ solution:
 afterBody:
   - title: SSW Related Services
     content: >
-      #### [Training
-      Video](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Training.aspx)
+      #### [Product/Service
+      Video](https://www.ssw.com.au/consulting/video-production/product-videos)
 
 
       #### [Content Marketing

--- a/content/video-production/training-videos.mdx
+++ b/content/video-production/training-videos.mdx
@@ -10,6 +10,7 @@ callToAction: 'Talk to us about your {{TITLE}} project'
 booking:
   title: Training Video
   subTitle: Use the power of online videos for your business
+  videoBackground: /images/MVC_background.mp4
 solution:
   project: Training Video
 afterBody:

--- a/content/video-production/training-videos.mdx
+++ b/content/video-production/training-videos.mdx
@@ -12,6 +12,28 @@ booking:
   subTitle: Use the power of online videos for your business
 solution:
   project: Training Video
+afterBody:
+  - title: SSW Related Services
+    content: >
+      #### [Product
+      Videos](https://www.ssw.com.au/consulting/video-production/product-videos)
+
+
+      #### [Content Marketing
+      Video](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Content-Marketing.aspx)
+
+
+      #### [Live
+      Events](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Training.aspx)
+
+
+      #### [Custom
+      Video](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Custom-Video.aspx)
+
+
+      #### [Reusable
+      Extras](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Reusable-Extras.aspx)
+    _template: Content
 ---
 
 Creating a training/induction video to save time training your staff and increase training efficiency, means they're back to working on activities that will make your business money within less time. At SSW, we specialize in a number of courses, events, user groups, and of course SSW TV. We’re well versed in educating professional people and will work to make the video(s) fit into your company culture, so it can be serious, quirky, humorously cocky, whatever you like!

--- a/content/video-production/training-videos.mdx
+++ b/content/video-production/training-videos.mdx
@@ -1,0 +1,19 @@
+---
+seo:
+  title: Training Videos
+  description: >-
+    SSW Consulting has over 30 years of Microsoft software and web development
+    experience. We build on top of Angular, React, .NET, Azure, Azure DevOps,
+    SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software
+    consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.
+callToAction: 'Talk to us about your {{TITLE}} project'
+booking:
+  title: Training Video
+  subTitle: Use the power of online videos for your business
+solution:
+  project: Training Video
+---
+
+Creating a training/induction video to save time training your staff and increase training efficiency, means they're back to working on activities that will make your business money within less time. At SSW, we specialize in a number of courses, events, user groups, and of course SSW TV. We’re well versed in educating professional people and will work to make the video(s) fit into your company culture, so it can be serious, quirky, humorously cocky, whatever you like!
+
+<VideoEmbed url="https://www.youtube.com/watch?v=z45_IMwslYw" />

--- a/pages/consulting/video-production/[filename].tsx
+++ b/pages/consulting/video-production/[filename].tsx
@@ -94,20 +94,20 @@ export default function VideoProductionPage(
           </Container>
         </Section>
 
-        <Section className="mb-16">
-          <Container padding="px-4" className="flex w-full flex-wrap">
-            {data.videoProduction.afterBody ? (
+        {data.videoProduction.afterBody ? (
+          <Section className="mb-16">
+            <Container padding="px-4" className="flex w-full flex-wrap">
               <div>
                 <Blocks
                   prefix={"VideoProductionAfterBody"}
                   blocks={data.videoProduction.afterBody}
                 />
               </div>
-            ) : (
-              <></>
-            )}
-          </Container>
-        </Section>
+            </Container>
+          </Section>
+        ) : (
+          <></>
+        )}
 
         <Section>
           <BuiltOnAzure data={{ backgroundColor: "default" }} />


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
Migrates https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Training.aspx to the new website.

Fixes #965 

Affected routes:

- `/consulting/video-production/training-videos`

Add done video, screenshots
![image](https://github.com/SSWConsulting/SSW.Website/assets/10693364/d2029982-5d79-494c-be95-be161cb581c5)
![image](https://github.com/SSWConsulting/SSW.Website/assets/10693364/b12a708d-2bad-4586-b616-269033aa6f7a)

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
