### PR TITLE
Internship UI - adding responsiveness for mobile

### DIFF
--- a/components/subNewsletter/subNewsletterRow.tsx
+++ b/components/subNewsletter/subNewsletterRow.tsx
@@ -12,10 +12,10 @@ export const SubNewsletterRow = (props: SubNewsletterRowProps) => {
   return (
     <div
       className={
-        "flex h-min w-full items-center bg-subscribeBackground bg-cover bg-center bg-no-repeat text-center font-light after:absolute sm:h-80"
+        "flex h-min w-full items-center bg-subscribeBackground bg-cover bg-center bg-no-repeat text-center font-light after:absolute md:h-80"
       }
     >
-      <Container padding="px-4" className="w-full">
+      <Container padding="md:px-4 px-8" className="w-full">
         <SubNewsLettersForm
           headerText={props.headerText}
           subscribeButtonText={props.subscribeButtonText || "Sign Up"}

--- a/components/testimonials/TestimonialRow.tsx
+++ b/components/testimonials/TestimonialRow.tsx
@@ -21,7 +21,7 @@ export const TestimonialRow = ({ testimonialsResult }) => {
 const TestimonialCard = ({ testimonial }) => {
   return (
     <div
-      className="flex flex-col rounded-md border-b-4 border-b-sswRed bg-gray-100 p-10 text-center text-xl drop-shadow sm:h-96 md:h-full"
+      className="flex flex-col rounded-md border-b-4 border-b-sswRed bg-gray-100 p-8 text-center text-xl drop-shadow sm:h-96 md:h-full md:p-10"
       data-aos="flip-right"
     >
       <div className="flex flex-col items-center">

--- a/components/training/trainingInformation.tsx
+++ b/components/training/trainingInformation.tsx
@@ -32,7 +32,11 @@ const TrainingInformationItem: FC<TrainingInformationItemProps> = ({
 export const TrainingInformation = ({ data }) => {
   return (
     <Section color="white">
-      <Container size={"xsmall"} className={"flex-1 pb-12"}>
+      <Container
+        padding={"md:px-8 px-2"}
+        size={"xsmall"}
+        className={"flex-1 pb-12"}
+      >
         <div className="grid grid-cols-1 justify-between lg:grid-cols-3">
           {data.trainingInformationItems?.map(
             (item: TrainingInformationItemProps, key: Key) => (

--- a/pages/training/[filename].tsx
+++ b/pages/training/[filename].tsx
@@ -36,7 +36,7 @@ export default function TrainingPage(
       <SEO seo={data.training.seo} />
       <Layout>
         <TrainingCarousel data={data.training.trainingHeaderCarousel} />
-        <Container className="pt-2">
+        <Container padding={"md:px-8 px-2"} className="pt-2">
           <Breadcrumbs
             path={removeExtension(props.variables.relativePath)}
             suffix={data.global.breadcrumbSuffix}
@@ -57,7 +57,7 @@ export default function TrainingPage(
           />
 
           <Section color="white" className="">
-            <Container className={"flex-1 pt-0"}>
+            <Container padding={"md:px-8 px-2"} className={"flex-1 pt-0"}>
               <div className="mx-auto flex max-w-9xl flex-col items-center">
                 <TestimonialRow testimonialsResult={props.testimonialResult} />
               </div>
@@ -65,7 +65,7 @@ export default function TrainingPage(
           </Section>
 
           <Section color="white">
-            <Container className={"flex-1 pt-0"}>
+            <Container padding={"md:px-8 px-4"} className={"flex-1 pt-0"}>
               <div className="flex flex-col items-center pb-15 text-center">
                 <h2>
                   Trusted by more than{" "}

--- a/pages/training/[filename].tsx
+++ b/pages/training/[filename].tsx
@@ -36,7 +36,7 @@ export default function TrainingPage(
       <SEO seo={data.training.seo} />
       <Layout>
         <TrainingCarousel data={data.training.trainingHeaderCarousel} />
-        <Container padding={"md:px-8 px-2"} className="pt-2">
+        <Container padding={"md:px-8 px-0"} className="pt-2">
           <Breadcrumbs
             path={removeExtension(props.variables.relativePath)}
             suffix={data.global.breadcrumbSuffix}


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

Fixes #982 

Affected routes:

- `/training/internship-fullstack`
- `/consulting/*`

Screenshots:

<img width="512" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/f1292682-826b-4170-adba-bf3127d6dadb">

**Figure: After change, on left, before change on right**

<img width="512" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/639f3207-cbc8-4472-8ca1-3729563fd0d7">

**Figure: Testominials After change, on left, before change on right**

<img width="513" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/9d7b5a25-8152-46e3-b01e-858ef3031b8d">

**Figure: Newsletters After change, on left, before change on right**