### PR TITLE
✨ 885 - Video Production - Migrate reusable extras page

### DIFF
--- a/content/video-production/reusable-extras.mdx
+++ b/content/video-production/reusable-extras.mdx
@@ -1,0 +1,56 @@
+---
+seo:
+  title: Reusable Extras
+  description: >-
+    SSW Consulting has over 30 years of Microsoft software and web development
+    experience. We build on top of Angular, React, .NET, Azure, Azure DevOps,
+    SharePoint, Office 365, Dynamics 365 CRM and SQL Server. We have software
+    consultants located in Sydney, Brisbane, Melbourne, Newcastle, and China.
+callToAction: 'Talk to us about your {{TITLE}} project'
+booking:
+  title: Reusable Extras
+  subTitle: Add consistent branding to your videos
+  videoBackground: /images/MVC_background.mp4
+solution:
+  project: Reusable Video
+afterBody:
+  - title: SSW Related Services
+    content: >
+      #### [Training
+      Video](https://www.ssw.com.au/consulting/video-production/training-videos)
+
+
+      #### [Product
+      Videos](https://www.ssw.com.au/consulting/video-production/product-videos)
+
+
+      #### [Content Marketing
+      Video](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Content-Marketing.aspx)
+
+
+      #### [Live
+      Events](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Training.aspx)
+
+
+      #### [Custom
+      Video](https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Custom-Video.aspx)
+    _template: Content
+---
+
+## Overview
+
+### Logo Stings: $400 + GST
+
+Animated sting, based on a template, to grab the user’s attention and add branding to the video. This will go at the beginning of all of your videos, but only needs to be created once.
+
+### SSW TV logo sting
+
+<VideoEmbed url="https://www.youtube.com/watch?v=TSHFQW624ww" />
+
+### Call to Action: $600 + GST
+
+This will go on the end of all of your videos, and will direct viewers to take action, call you, subscribe, or anything else you decide.
+
+### Quiz CTA:
+
+<VideoEmbed url="https://www.youtube.com/watch?v=OQVY46f-BEM" />


### PR DESCRIPTION
Migrates https://www.ssw.com.au/ssw/Consulting/Video-Production/Video-Production-Reusable-Extras.aspx to the new website.
Fixes #885 

Affected routes:

- `/consulting/video-production/reusable-extras`

![image](https://github.com/SSWConsulting/SSW.Website/assets/10693364/2de3a788-2cb5-410a-b2b5-70584416746c)
![image](https://github.com/SSWConsulting/SSW.Website/assets/10693364/db1379bd-5d85-401d-9fd7-e13e4d3ad6fd)
![image](https://github.com/SSWConsulting/SSW.Website/assets/10693364/b1e6606b-cf25-4343-97f5-ef4cb1f8d13c)

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
