### PR TITLE
🐛 1045 - Add default width and height values to custom image

### DIFF
--- a/components/blocks/customImage.tsx
+++ b/components/blocks/customImage.tsx
@@ -7,8 +7,8 @@ export const CustomImage = ({ data }) => {
       <Image
         src={data.src}
         alt={data.altText}
-        height={data.height}
-        width={data.width}
+        height={data.height ?? 400}
+        width={data.width ?? 400}
         className="inline-block"
       />
     </LinkWrapper>


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
Adds a default width and height value to the Image in the Custom Image component to prevent an exception when there is no value set.

Related to #1045 

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
