### PR TITLE
Employment page - Fix title typo

### DIFF
--- a/content/employment/index.mdx
+++ b/content/employment/index.mdx
@@ -201,7 +201,7 @@ technologies:
     - technologyCard: content/technologies/medium-businesses.mdx
     - technologyCard: content/technologies/small-businesses.mdx
 seo:
-  title: SSW Employment Oppurtunities
+  title: SSW Employment Opportunities
 opportunities:
   - opportunityRef: content/opportunities/Senior-Data-Engineer.mdx
   - opportunityRef: content/opportunities/Microsoft-Power-Platform-Developer.mdx


### PR DESCRIPTION
Affected routes:

- `/employment` 

