### PR TITLE
T&C - increase our credit card surcharges from 2.5% to 3.5%.

### DIFF
--- a/content/pages/terms-and-conditions.mdx
+++ b/content/pages/terms-and-conditions.mdx
@@ -163,7 +163,7 @@ The Client authorizes SSW to provide the resources suitable for the project. SSW
     
     ### 24 - Credit Card Details
     
-    All payments made by credit card incur a 2.5% surcharge. This is to reflect the cost of fees charged for credit card transactions. When using a credit card, the invoices cannot be split for payment.
+    All payments made by credit card incur a 3.5% surcharge. This is to reflect the cost of fees charged for credit card transactions. When using a credit card, the invoices cannot be split for payment.
     
     ### 26 - Deadlines
     


### PR DESCRIPTION
as per email **RE: Stripe pricing changes starting from 15 October 2023**
