### PR TITLE
🐛 Added correct reverse order of newsletters

### DIFF
--- a/components/blocks/newslettersTable.tsx
+++ b/components/blocks/newslettersTable.tsx
@@ -57,7 +57,7 @@ export const NewslettersTable: React.FC<{ data: { headerText: string } }> = ({
           };
         }) || [];
 
-      setNewsletters(sortedNewslettersYears);
+      setNewsletters(sortedNewslettersYears.reverse());
       setHasLoaded(true);
     });
   };


### PR DESCRIPTION
* Fixes order of newsletter table

Fixes #1094

Affected routes:

- `/newsletters`
