### PR TITLE
PR - fixing the bug for the linked issue

### DIFF
--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           # Diff HEAD with the previous commit
           $diff = git diff --name-only HEAD^ HEAD
-          $diff = $diff -replace '["'']', ''
+          $diff = $diff -replace '["'']', ''  #Clean-up for the file paths of the newsletter's images.(i.e double & single quotes)
 
           # TODO: Next time we need to modify which directories we ignore, break this out to a variable which is easy to configure
 

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           # Diff HEAD with the previous commit
           $diff = git diff --name-only HEAD^ HEAD
+          $diff = $diff -replace '["'']', ''
 
           # TODO: Next time we need to modify which directories we ignore, break this out to a variable which is easy to configure
 


### PR DESCRIPTION
Fixes #1108 

**Description:**
The issue was caused by the presence of double quotes and single quotes in the file paths of the newsletter's images. This discrepancy was identified during the investigation. By cleaning up the git differences, we were able to resolve the problem effectively and ensure that the file paths no longer contained any conflicting quotes, thereby resolving the issue.

**Testing** 
Once, PR is merged, rebase this https://github.com/SSWConsulting/SSW.Website/pull/1071 with main to test if it works. 
