### PR TITLE
Added Stripe comment on T&C Credit Cards section

### DIFF
--- a/content/pages/terms-and-conditions.mdx
+++ b/content/pages/terms-and-conditions.mdx
@@ -163,7 +163,7 @@ The Client authorizes SSW to provide the resources suitable for the project. SSW
     
     ### 24 - Credit Card Details
     
-    All payments made by credit card incur a 3.5% surcharge. This is to reflect the cost of fees charged for credit card transactions. When using a credit card, the invoices cannot be split for payment.
+    All payments made by credit card incur a 3.5% surcharge (this is the exact same charge that Stripe charge SSW). This is to reflect the cost of fees charged for credit card transactions. When using a credit card, the invoices cannot be split for payment.
     
     ### 26 - Deadlines
     


### PR DESCRIPTION
As per Adam:

I think it would sound better if you change from
            >24 - Credit Card Details
All payments made by credit card incur a 3.5% surcharge.
 
To
            24 - Credit Card Details
All payments made by credit card incur a 3.5% surcharge (this is the exact same charge that Stripe charge SSW)
 