### PR TITLE
📄 Brisbane Office page -  Fix heading body

### DIFF
--- a/content/offices/brisbane.mdx
+++ b/content/offices/brisbane.mdx
@@ -20,8 +20,8 @@ seo:
     Angular, and Microsoft Azure Development Consultancy,  with expertise across
     Scrum and Application Lifecycle Management.
 aboutUs: >
-  #### SSW Brisbane was our 2nd Australian office. It is the home base for some
-  of our best [web
+  **SSW Brisbane was our 2nd Australian office. It is the home base for some of
+  our best [web
   developers](https://www.ssw.com.au/ssw/Consulting/Web-Applications.aspx) and
   consultants. We are experts in building responsive websites with ASP.NET MVC,
   [Angular](https://www.ssw.com.au/ssw/Consulting/Angular.aspx),
@@ -30,7 +30,7 @@ aboutUs: >
   Additionally, our developers and designers are interested in mobile technology
   and can build both mobile-targeted websites, as well as [ingenious mobile apps
   (for Android and Apple's
-  iOS)](https://www.ssw.com.au/ssw/Consulting/Mobile-Application-Development.aspx).
+  iOS)](https://www.ssw.com.au/ssw/Consulting/Mobile-Application-Development.aspx).**
 
 
   The Brisbane office has a number of experts in [application lifecycle

--- a/content/offices/melbourne.mdx
+++ b/content/offices/melbourne.mdx
@@ -20,12 +20,12 @@ seo:
     MVC, Angular, and Microsoft Azure Development Consultancy,  with expertise
     across Scrum and Application Lifecycle Management.
 aboutUs: >
-  #### SSW Melbourne is our 3rd successfully opened Australian office. With
+  **SSW Melbourne is our 3rd successfully opened Australian office. With
   Melbourne being home to more than half of Australia’s top 20 technology
   companies. Some of Melbourne’s key digital technology strengths include
   software development, market platforms, cloud technology, and data analytics.
   These capabilities support Victoria’s continuing emergence as a tech hub. As
-  such, it seemed a logical step to open an office there.
+  such, it seemed a logical step to open an office there.**
 
 
   SSW Consulting has over 30 years of Microsoft software and web development

--- a/content/offices/newcastle.mdx
+++ b/content/offices/newcastle.mdx
@@ -21,18 +21,18 @@ seo:
   description: >
     Software developer in Newcastle NSW | SSW is Newcastle's leading ASP.NET
     MVC, Angular, and Microsoft Azure Development Consultancy, with expertise
-    across Scrum and Application Lifecycle Management.
-    Software developer in Newcastle NSW | SSW is Newcastle's leading ASP.NET
-    MVC, Angular, and Microsoft Azure Development Consultancy, with expertise
-    across Scrum and Application Lifecycle Management.
+    across Scrum and Application Lifecycle Management. Software developer in
+    Newcastle NSW | SSW is Newcastle's leading ASP.NET MVC, Angular, and
+    Microsoft Azure Development Consultancy, with expertise across Scrum and
+    Application Lifecycle Management.
 aboutUs: >
-  #### SSW Newcastle is our 4th Australian office. We chose Newcastle because of
+  **SSW Newcastle is our 4th Australian office. We chose Newcastle because of
   its vibrant, enthusiastic, and up-and-coming tech community, as well as the
   presence of a world-class university. Newcastle University is ranked within
   the top 200 in the world and is within in the top 8 in Australia for research.
   With so much potential, and a city-wide commitment to technology and
   digitisation (with the city committing to be a smart and sustainable city by
-  2030), it is the perfect place for SSW to continue to grow.
+  2030), it is the perfect place for SSW to continue to grow.**
 
 
   The office boasts some of our best [web

--- a/content/offices/sydney.mdx
+++ b/content/offices/sydney.mdx
@@ -23,8 +23,8 @@ seo:
     Angular, and Microsoft Azure Development Consultancy, with expertise across
     Scrum and Application Lifecycle Management.
 aboutUs: >
-  #### Sydney is the original home of SSW, and it remains the location of the
-  company's head office.
+  **Sydney is the original home of SSW, and it remains the location of the
+  company's head office.**
 
 
   SSW began as a one-man company in 1990, run from a home office in Forestville.


### PR DESCRIPTION
See thread - _RE: Brisbane photos of Brainstorming event_

- The long heading looked bad
- Change it to bold

Fixes N/A

Affected routes:

- `/offices/brisbane`

<img width="877" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/38869720/e8ad3233-f9c6-4f74-9c16-108d08d9ba31">

**Figure: Bold text looks much better than heading**
