### PR TITLE
🐛 CodeAuditor - Removed AARAffinity from Prod and PR deployments

### DIFF
--- a/infra/appSerivce-create-slot.bicep
+++ b/infra/appSerivce-create-slot.bicep
@@ -85,6 +85,7 @@ resource prSlot 'Microsoft.Web/sites/slots@2021-02-01' = {
       appSettings: appSettings
       acrUseManagedIdentityCreds: true
     }
+    clientAffinityEnabled: false
   }
 }
 

--- a/infra/appService.bicep
+++ b/infra/appService.bicep
@@ -132,6 +132,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
       minTlsVersion: '1.2'
       linuxFxVersion: 'DOCKER|${acr.properties.loginServer}/${dockerImage}:production'
     }
+    clientAffinityEnabled: false
   }
 }
 


### PR DESCRIPTION
As per https://azure.github.io/AppService/2016/05/16/Disable-Session-affinity-cookie-(ARR-cookie)-for-Azure-web-apps.html, this will remove the AARAfinity cookie from the deployments

![MicrosoftTeams-image (1)](https://github.com/SSWConsulting/SSW.Website/assets/600044/5ce78128-c66a-480d-8978-59744555c4ee)


Fixes #1146

Affected routes: N/A
