### PR TITLE
Fix <span> bug on https://www.ssw.com.au/consulting/video-conferencing

### DIFF
--- a/content/consulting/video-conferencing.mdx
+++ b/content/consulting/video-conferencing.mdx
@@ -27,8 +27,8 @@ technologies:
 solution:
   project: '<span class="text-sswRed">video conferencing</span> '
 callToAction: >-
-  Need help with {{TITLE}} or or <span class="text-sswRed">live
-  streaming</span>?
+  Need help with <span class="text-sswRed">video conferencing</span> or <span
+  class="text-sswRed">live streaming</span>?
 benefits:
   benefitList:
     - image: /images/benefits/sharing-and-collaboration.png


### PR DESCRIPTION
Hey @bradystroud 

I don't know why {{TITLE}} gave this bug in this page... so I just changed to regular text

![image](https://github.com/SSWConsulting/SSW.Website/assets/12601228/321679a7-e08d-4c06-b9ff-427971fad091)
