### PR TITLE
🔧 Quick Fix - Added Longer Date formatting on /events

### DIFF
--- a/components/filter/events.tsx
+++ b/components/filter/events.tsx
@@ -4,7 +4,10 @@ import Image from "next/image";
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { FaSpinner } from "react-icons/fa";
 import { TinaMarkdown, TinaMarkdownContent } from "tinacms/dist/rich-text";
-import { formatEventDate, formatRelativeEventDate } from "../../helpers/dates";
+import {
+  formatEventLongDate,
+  formatRelativeEventDate,
+} from "../../helpers/dates";
 import { EventInfo } from "../../services/server/events";
 import { componentRenderer } from "../blocks/mdxComponentRenderer";
 import { EventsRelativeBox } from "../events/components";
@@ -243,7 +246,7 @@ const Event = ({ visible, event }: EventProps) => {
                 event.StartDateTime,
                 event.EndDateTime
               )}
-              formattedDate={formatEventDate(
+              formattedDate={formatEventLongDate(
                 event.StartDateTime,
                 event.EndDateTime
               )}

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -21,6 +21,25 @@ export const formatEventDate = (start: Date, end: Date) => {
   return isOneDayEvent ? startDate : `${startDate} - ${endDate}`;
 };
 
+export const formatEventLongDate = (start: Date, end: Date) => {
+  if (!start || !end) return "";
+
+  const dateformat = "dddd, MMMM D, YYYY h:mm A";
+
+  const isOneDayEvent = dayjs(start)
+    .startOf("day")
+    .isSame(dayjs(end).startOf("day"));
+
+  const startDate = dayjs(start).format(dateformat);
+  const endDate = dayjs(end).format(dateformat);
+
+  if (isOneDayEvent) {
+    return `${startDate} - ${dayjs(end).format("h:mm A")}`;
+  } else {
+    return `${startDate} - ${endDate}`;
+  }
+};
+
 export const formatRelativeEventDate = (startDate: Date, endDate: Date) => {
   const now = dayjs();
   const start = dayjs(startDate);


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

* Added longer formatting of events on events index page, rather than shortened version for homepage

- Affected routes: 
  - `/events`

- Fixed #1288 

- [x] If adding a new page, I have followed the [SEO checklist](https://www.ssw.com.au/rules/seo-checklist/)

- [x] Include done video or screenshots

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/32b92ed6-7599-4c86-8f64-a524331d6444)
**Figure: Single day event**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/b06cdf1d-8985-4333-8938-642024aea6fc)
**Figure: Multi day event**



