### PR TITLE
🚑 Add missing react module in file rating.tsx

### DIFF
--- a/components/util/consulting/rating.tsx
+++ b/components/util/consulting/rating.tsx
@@ -1,4 +1,5 @@
 import type { NumberField } from "@tinacms/schema-tools/dist/types/index";
+import * as React from "react";
 
 import classNames from "classnames";
 import { AiFillStar } from "react-icons/ai";


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: /admin

- Fixed #1294 

- [ ] If adding a new page, I have followed the [SEO checklist](https://www.ssw.com.au/rules/seo-checklist/)

- [ ] Include done video or screenshots

When we develop custom field component for tinacms, we used wrapFieldsWIthMeta like below

```tyepscript
export const ratingSchema: NumberField = {
  type: "number",
  label: "Rating",
  name: "rating",
  description: "Rating from 0 to 5. Rating of -1 means no rating.",
  // As per https://tina.io/docs/extending-tina/custom-field-components/#custom-component-example
  ui: {
    parse: (val) => Number(val),

    // wrapping our component in wrapFieldsWithMeta renders our label & description.
    component: wrapFieldsWithMeta(({ input }) => {
      return (
        <div>
          <input
            name="rating"
            id="rating"
            type="range"
            min="-1"
            max="5"
            step="1"
            // This will pass along props.input.onChange to set our form values as this input changes.
            {...input}
          />
          <br />
          Value: {input.value}
        </div>
      );
    }),
  },
};
```

When the code is been built with vite, jsx will be transformed into React.createElement(... etc)

Adding `import React from "react"` solve it.

