### PR TITLE
🐛 Events - Past Events Not Showing Relative Time

### DIFF
--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -57,6 +57,7 @@ export const formatRelativeEventDate = (startDate: Date, endDate: Date) => {
   } else if (days > 0) {
     return `${days} ${days === 1 ? "day" : "days"} to go`;
   } else {
-    return "";
+    const normalisedDays = Math.abs(days);
+    return `${normalisedDays} ${normalisedDays === 1 ? "day" : "days"} ago`;
   }
 };


### PR DESCRIPTION
* Added output from relative event formatter for past dates

- Affected routes: 
  - `/events`
  - `/`

- Fixed #1347

- [x] Include done video or screenshots

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/ce8325ae-048e-481d-8a3f-3384e5d4eab3)

