### PR TITLE
🐛 Bug - Home Page - Rules Link prefetch returns 404

### DIFF
--- a/components/blocks/serviceCards.tsx
+++ b/components/blocks/serviceCards.tsx
@@ -136,10 +136,7 @@ const SmallCards = ({ title, cards, schema }) => {
               bgColor[card.color]
             } hover:opacity-80`}
           >
-            <Link
-              href={card.link ?? ""}
-              className="unstyled flex h-full flex-col"
-            >
+            <a href={card.link ?? ""} className="unstyled flex h-full flex-col">
               <div className="flex flex-1 flex-col items-center px-2 py-8 pb-4 sm:justify-center md:flex-row md:pb-8">
                 <span
                   data-tina-field={tinaField(
@@ -165,7 +162,7 @@ const SmallCards = ({ title, cards, schema }) => {
                   {card.title}
                 </h3>
               </div>
-            </Link>
+            </a>
           </li>
         ))}
       </ul>

--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -73,7 +73,7 @@ beforeBody:
         color: darkgray
         imgSrc: /images/service-cards/Expert.png
       - title: Rules
-        link: 'https://www.ssw.com.au/rules'
+        link: 'https://ssw.com.au/rules/'
         color: darkgray
         imgSrc: /images/service-cards/Rules.png
     links:

--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -73,7 +73,7 @@ beforeBody:
         color: darkgray
         imgSrc: /images/service-cards/Expert.png
       - title: Rules
-        link: 'https://ssw.com.au/rules/'
+        link: 'https://www.ssw.com.au/rules'
         color: darkgray
         imgSrc: /images/service-cards/Rules.png
     links:


### PR DESCRIPTION
As per the issue #1344, prefetch requests to SSW Rules link by the Next.JS link component always return 404, because the next/data files are not generated for /rules page, since it comes from a different repo.

Changing the link in the card for Rules page from:
    https://www.ssw.com.au/rules
To:
    https://ssw.com.au/rules
    
Since Next.JS link will only prefetch the pages with the same domain, I am hoping this is enough to stop prefetching, and so the constant 404 errors

- Affected routes: https://www.ssw.com.au/

- Fixed #1344 

![image](https://github.com/SSWConsulting/SSW.Website/assets/54652701/91ede946-668d-4c1a-a4f9-8d60e7b3fc40)
Figure: Link for Rules is the source of error.


