### PR TITLE
Adding - reordering feature for opportunity

### DIFF
--- a/content/employment/index.mdx
+++ b/content/employment/index.mdx
@@ -205,8 +205,8 @@ seo:
 opportunities:
   - opportunityRef: content/opportunities/Senior-Data-Engineer.mdx
   - opportunityRef: content/opportunities/Systems-Administrator.mdx
-  - opportunityRef: content/opportunities/User-Experience-Expert--Web-Designer.mdx
   - opportunityRef: content/opportunities/Senior-Full-Stack-NET-Developer.mdx
+  - opportunityRef: content/opportunities/User-Experience-Expert--Web-Designer.mdx
   - opportunityRef: content/opportunities/Developers.mdx
 opportunitiesBody: >
   # Current **opportunities**

--- a/content/employment/index.mdx
+++ b/content/employment/index.mdx
@@ -203,12 +203,11 @@ technologies:
 seo:
   title: SSW Employment Opportunities
 opportunities:
-  - opportunityRef: content/opportunities/Developers.mdx
-  - opportunityRef: content/opportunities/Systems-Administrator.mdx
   - opportunityRef: content/opportunities/Senior-Data-Engineer.mdx
   - opportunityRef: content/opportunities/Systems-Administrator.mdx
   - opportunityRef: content/opportunities/User-Experience-Expert--Web-Designer.mdx
   - opportunityRef: content/opportunities/Senior-Full-Stack-NET-Developer.mdx
+  - opportunityRef: content/opportunities/Developers.mdx
 opportunitiesBody: >
   # Current **opportunities**
 

--- a/pages/employment/index.tsx
+++ b/pages/employment/index.tsx
@@ -54,6 +54,21 @@ export default function EmploymentPage(
       };
     });
 
+  const chosenOpportunityOrder = data.employment.opportunities
+    .map((chosen) => chosen?.opportunityRef?.title)
+    .filter(Boolean); // Filter out undefined titles
+
+  opportunities.sort((currentOpportunity, nextOpportunity) => {
+    const indexOfChosenCurrentOpportunity = chosenOpportunityOrder.indexOf(
+      currentOpportunity.title
+    );
+    const indexOfChosenNextOpportunity = chosenOpportunityOrder.indexOf(
+      nextOpportunity.title
+    );
+
+    return indexOfChosenCurrentOpportunity - indexOfChosenNextOpportunity;
+  });
+
   return (
     <>
       <SEO seo={props.seo} />


### PR DESCRIPTION
- Affected routes:  `/employment` 

- Fixes #1369

Opportunities are now ordered in a way @PennyWalker requested.



