### PR TITLE
✨Increase the text size of the date field on events page.

### DIFF
--- a/components/blocks/upcomingEvents.tsx
+++ b/components/blocks/upcomingEvents.tsx
@@ -82,6 +82,7 @@ const renderEvent = (e: EventInfo) => {
           <EventsRelativeBox
             relativeDate={e.RelativeDate}
             formattedDate={e.FormattedDate}
+            dateFontSize="text-xxs"
           />
           {!!e.Presenter && (
             <span className="mt-1 inline-flex items-center text-xxs text-black">

--- a/components/events/components.tsx
+++ b/components/events/components.tsx
@@ -30,7 +30,7 @@ export const EventsRelativeBox = ({
       <span
         className={classNames(
           "text-gray-500",
-          dateFontSize,
+          dateFontSize ? dateFontSize : "text-xxs",
           relativeDate ? "ml-2" : ""
         )}
       >

--- a/components/events/components.tsx
+++ b/components/events/components.tsx
@@ -4,11 +4,13 @@ import { EventStatus } from "../../helpers/dates";
 type EventsRelativeBoxProps = {
   relativeDate: string;
   formattedDate: string;
+  dateFontSize: string;
 };
 
 export const EventsRelativeBox = ({
   relativeDate,
   formattedDate,
+  dateFontSize,
 }: EventsRelativeBoxProps) => {
   return (
     <time className="my-1 flex items-center">
@@ -27,7 +29,8 @@ export const EventsRelativeBox = ({
       )}
       <span
         className={classNames(
-          "text-xxs text-gray-500",
+          "text-gray-500",
+          dateFontSize,
           relativeDate ? "ml-2" : ""
         )}
       >

--- a/components/filter/events.tsx
+++ b/components/filter/events.tsx
@@ -194,6 +194,7 @@ const Event = ({ visible, event }: EventProps) => {
                 event.StartDateTime,
                 event.EndDateTime
               )}
+              dateFontSize="text-s"
             />
 
             <div>


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
As per the conversation with @Harry-Ross and @bradystroud , we need to increase the date's text size only on the events page.

- Affected routes:  `/events`,  `/`

- Fixed #1349 

![image](https://github.com/SSWConsulting/SSW.Website/assets/52522913/3fea7cf5-d7ae-4a9e-8ae0-f8a746b31dc9)
**Figure: Date field on the events page**

![image](https://github.com/SSWConsulting/SSW.Website/assets/52522913/518bf60a-340d-4f99-91c5-d52e9c297703)
**Figure: Date field on the homepage**
