### PR TITLE
Fix - Added null handling for tags

### DIFF
--- a/pages/consulting/index.tsx
+++ b/pages/consulting/index.tsx
@@ -267,7 +267,9 @@ const processData = (data) => {
             title: p.title,
             description: p.description,
             logo: p.logo,
-            tags: [allServices, ...p.tags.map((t) => t.tag.name)],
+            tags: p.tags
+              ? [allServices, ...p.tags.map((t) => t.tag?.name)]
+              : [allServices],
           };
         }),
       };


### PR DESCRIPTION
Fixed #1432 

Affected routes: 
`/consulting` 

Added null handling for the tags solved the issue. 
