### PR TITLE
Pipeline - Setting default Host URL

### DIFF
--- a/.github/workflows/weekly-ui-tests.yml
+++ b/.github/workflows/weekly-ui-tests.yml
@@ -13,11 +13,11 @@ on:
     inputs:
       HOST_URL:
         type: string
-        description: "Host URL"
-        default: "https://ssw.com.au"
+        description: "Host URL (default https://ssw.com.au)"
 
 env:
   GH_TOKEN: ${{ github.token }}
+  HOST_URL: ${{ inputs.HOST_URL || 'https://ssw.com.au' }}
 
 defaults:
   run:
@@ -70,7 +70,7 @@ jobs:
       - name: Run Playwright tests
         run: yarn playwright test
         env:
-          HOST_URL: ${{ inputs.HOST_URL }}
+          HOST_URL: ${{ env.HOST_URL }}
           RECAPTCHA_BYPASS_SECRET: ${{ steps.KeyVaultSecrets.outputs.RECAPTCHA_BYPASS_SECRET }}
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
- fixed #1504 

**Description:**
Adding `HOST URL` env for the default values for both workflow_dispatch and schedule events. 
