### PR TITLE
Fix - Broken image for upcoming events

### DIFF
--- a/components/blocks/upcomingEvents.tsx
+++ b/components/blocks/upcomingEvents.tsx
@@ -69,6 +69,13 @@ const renderEvent = (e: EventInfo) => {
   const isExternalLink =
     !e.Url.Url.includes("ssw.com.au") || e.Url.Url.includes("/ssw/redirect");
 
+  const isValidImagePath = (imageSrc) => {
+    if (!imageSrc) return false;
+    const imagPath = imageSrc.split("/").pop();
+    const numberOfDots = imagPath.match(/\./g);
+    return numberOfDots.length === 1;
+  };
+
   return (
     <Link
       href={e.Url.Url}
@@ -90,15 +97,17 @@ const renderEvent = (e: EventInfo) => {
             </span>
           )}
         </div>
-        <div className="col-span-1 flex items-center justify-center sm:mr-2 sm:justify-end">
-          <Image
-            className={"rounded-md"}
-            src={e.Thumbnail.Url}
-            alt={`${e.Title} logo`}
-            width={90}
-            height={90}
-          />
-        </div>
+        {isValidImagePath(e.Thumbnail?.Url) && (
+          <div className="col-span-1 flex items-center justify-center sm:mr-2 sm:justify-end">
+            <Image
+              className={"rounded-md"}
+              src={e.Thumbnail.Url}
+              alt={`${e.Title} logo`}
+              width={90}
+              height={90}
+            />
+          </div>
+        )}
       </article>
     </Link>
   );


### PR DESCRIPTION
- Affected routes: `/`

- Fixed #1633  

This fix handles if the image Path contains multiple dots or if there is not associated image with the events. 

⚠️ It doesn't handle if the image is giving 404 error

- [ ] Include done video or screenshots
<img width="671" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/39bf4ab1-148a-4c87-abd1-1f02fa82ae1e">

**Figure: Hiding img if it has not a valid path**

