### PR TITLE
CSS - use ssw black as the base color for prose content

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -293,6 +293,7 @@ module.exports = {
         DEFAULT: {
           css: {
             lineHeight: 1.45,
+            color: theme("colors.sswBlack"),
             h1: {
               fontWeight: "300",
               margin: "1rem 0",
@@ -324,7 +325,6 @@ module.exports = {
             },
             p: {
               marginBottom: "10px",
-              color: theme("colors.sswBlack"),
             },
             hr: {
               margin: "30px 0",


### PR DESCRIPTION
Tailwind config - set base prose color to ssw black. Default is a similar yet different color.

- Affected routes: `/employment`

- Fixes #1391

~~- [ ] If adding a new page, I have followed the [SEO checklist](https://www.ssw.com.au/rules/seo-checklist/)~~

- [x] Include done video or screenshots

![CleanShot 2023-11-01 at 11 13 03@2x](https://github.com/SSWConsulting/SSW.Website/assets/600044/ad122441-e11f-4a90-8d30-9da244483982)


