### PR TITLE
🐛 Bug - Rating range display 

### DIFF
--- a/components/util/consulting/rating.tsx
+++ b/components/util/consulting/rating.tsx
@@ -43,7 +43,7 @@ export const ratingSchema: NumberField = {
     // wrapping our component in wrapFieldsWithMeta renders our label & description.
     component: wrapFieldsWithMeta(({ input, form }) => {
       React.useEffect(() => {
-        if (!isNaN(input.value)) {
+        if (isNaN(input.value)) {
           form.initialize({ ...form.getState().values, rating: -1 });
         }
       }, []);
@@ -65,8 +65,9 @@ export const ratingSchema: NumberField = {
         </div>
       );
     }),
-    validate(value, field) {
-      if (field.required && typeof value !== "number") return "Required";
+    validate(value) {
+      if (typeof value !== "number") return "Rating must be a number";
+      if (value < -1 || value > 5) return "Rating must be between -1 and 5";
     },
   },
 };


### PR DESCRIPTION
**Description**: 
The rating was not showing the current value in the testimonial Edit page. 

**Solution**: 
The rating is now showing the current value in the testimonial Edit page (reason: default value was wrongly called).

- Affected routes: /admin

- Fixed #1607

**Screenshots**

![website-PR-002a](https://github.com/SSWConsulting/SSW.Website/assets/106663901/4d4ddb7c-63ff-4f26-84d3-22f9f2f5adf1)
**Figure**: Stored rating value is 5 in this example.

![website-PR-002b](https://github.com/SSWConsulting/SSW.Website/assets/106663901/12919598-b8ae-478e-bdfc-d7b4cf9284be)
**Figure**: The value 5 is properly rendered in the UI (this was already the case before working on this PBI).

![website-PR-002c](https://github.com/SSWConsulting/SSW.Website/assets/106663901/dfad4539-061a-441f-9c50-d115665afdf7)
**Figure**: Now, the value 5 is also rendered in the testimonial Edit page (it used to be -1 for all testimonials).

**----------------------------------------------------------------------------------------------------------------------------------**
**----------------------------------------------------------------------------------------------------------------------------------**

**Extra fix**: 
I have added an error message if the rating value is not within the range [-1; 5]. 

**Screenshots**:

![website-PR-002d](https://github.com/SSWConsulting/SSW.Website/assets/106663901/9e3ea795-4034-4fd3-9542-962f72b87fd4)
**Figure**: If the rating is outside of the [-1; 5] range ...

![website-PR-002e](https://github.com/SSWConsulting/SSW.Website/assets/106663901/c1d6a921-5f64-455a-810b-8e0dbca411c7)
**Figure**: ... an error message is shown in the UI
