### PR TITLE
💄 UI/UX - .NET UG Quick Fixes

### DIFF
--- a/components/usergroup/sections/header.tsx
+++ b/components/usergroup/sections/header.tsx
@@ -61,18 +61,33 @@ export const UserGroupHeader = ({
       )}
     >
       <Container
-        className="flex-row justify-between py-0 text-white md:flex"
+        className={classNames(
+          "flex-row  py-0 text-white md:flex",
+          presenter.image
+            ? "justify-between max-md:text-center"
+            : "text-center justify-center"
+        )}
         size="custom"
       >
         <div className="flex max-w-3xl flex-col pb-10">
-          <div className="flex flex-row items-center pt-10 text-lg">
+          <div
+            className={classNames(
+              "flex flex-row items-center pt-10 text-lg",
+              !presenter.image ? "justify-center" : "max-md:justify-center"
+            )}
+          >
             {formattedDate} <OnlineBadge online={online} />
           </div>
           <h1 className="mb-2 pb-1 pt-3 text-5xl font-semibold">{title}</h1>
           <span className="mb-12 text-lg">
             With <a href={presenter.url}>{presenter.name}</a>
           </span>
-          <div className="mb-5 mt-auto flex-row md:flex">
+          <div
+            className={classNames(
+              "mb-5 mt-auto flex-row ",
+              presenter.image ? "md:flex" : "flex items-center justify-center"
+            )}
+          >
             <UtilityButton
               className="!mt-0"
               link={link}

--- a/content/netug/brisbane.mdx
+++ b/content/netug/brisbane.mdx
@@ -32,6 +32,8 @@ organizer:
 latestTech:
   badges: content/netug/global/global.json
 sections:
+  - globalUserGroupInfo: content/netug/global/global.json
+    _template: VideosSection
   - heading: I'm Sold... What's Next?
     content: |
       RSVP to the event and receive Full Stack UG updates!
@@ -47,8 +49,6 @@ sections:
     eventSponsors:
       - /images/consulting/octopusdeploy-logo.png
     _template: ActionSection
-  - globalUserGroupInfo: content/netug/global/global.json
-    _template: VideosSection
   - socialButtons:
       - url: 'https://github.com/netusergroup/brisbane-user-group/discussions'
         label: Join GitHub Discussion

--- a/content/netug/canberra.mdx
+++ b/content/netug/canberra.mdx
@@ -32,6 +32,8 @@ organizer:
 latestTech:
   badges: content/netug/global/global.json
 sections:
+  - globalUserGroupInfo: content/netug/global/global.json
+    _template: VideosSection
   - heading: I'm Sold... What's Next?
     content: |
       RSVP to the event and receive NETUG updates!
@@ -47,16 +49,14 @@ sections:
     eventSponsors:
       - /images/consulting/octopusdeploy-logo.png
     _template: ActionSection
-  - globalUserGroupInfo: content/netug/global/global.json
-    _template: VideosSection
   - socialButtons:
       - url: 'https://github.com/netusergroup/canberra-user-group/discussions'
         label: Join GitHub Discussion
         platform: github
-      - url: 'https://www.facebook.com/groups/NetUG/'
+      - url: 'https://www.facebook.com/groups/CanberraNetUG'
         label: Join Facebook Group
         platform: facebook
-      - url: 'https://www.linkedin.com/groups/1520317/'
+      - url: 'https://www.linkedin.com/groups/1520387/'
         label: Join LinkedIn Group
         platform: linkedin
       - url: 'https://www.meetup.com/canberra-net-user-group/join/'

--- a/content/netug/melbourne.mdx
+++ b/content/netug/melbourne.mdx
@@ -9,7 +9,7 @@ whenAndWhere:
   content: |
     We meet on the 3rd Wednesday of every month from 6:30 pm AEDT.
 
-    **[SSW Melbourne Chapel](https://sswchapel.com.au/sydney/)**
+    **[SSW Melbourne Chapel](https://sswchapel.com.au/melbourne/)**
   googleMapsEmbedUrl: >-
     https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3152.007339456588!2d144.95901201211748!3d-37.81329707185888!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x6ad642b52a701573%3A0x609aa8f6d5bdb7cb!2sSSW%20Melbourne%20-%20Enterprise%20Software%20Development!5e0!3m2!1sen!2sau!4v1698041734093!5m2!1sen!2sau
 agenda:
@@ -28,6 +28,8 @@ organizer:
 latestTech:
   badges: content/netug/global/global.json
 sections:
+  - globalUserGroupInfo: content/netug/global/global.json
+    _template: VideosSection
   - heading: I'm Sold... What's Next?
     content: |
       RSVP to the event and receive NETUG updates!
@@ -43,16 +45,14 @@ sections:
     eventSponsors:
       - /images/consulting/octopusdeploy-logo.png
     _template: ActionSection
-  - globalUserGroupInfo: content/netug/global/global.json
-    _template: VideosSection
   - socialButtons:
       - url: 'https://github.com/netusergroup/melbourne-user-group/discussions'
         label: Join GitHub Discussion
         platform: github
-      - url: 'https://www.facebook.com/groups/NetUG/'
+      - url: 'https://www.facebook.com/groups/MelbourneNetUG/'
         label: Join Facebook Group
         platform: facebook
-      - url: 'https://www.linkedin.com/groups/1520317/'
+      - url: 'https://www.linkedin.com/groups/10373000/'
         label: Join LinkedIn Group
         platform: linkedin
       - url: 'https://www.meetup.com/Melbourne-NET-User-Group/'

--- a/content/netug/sydney.mdx
+++ b/content/netug/sydney.mdx
@@ -38,6 +38,8 @@ organizer:
 latestTech:
   badges: content/netug/global/global.json
 sections:
+  - globalUserGroupInfo: content/netug/global/global.json
+    _template: VideosSection
   - heading: I'm Sold... What's Next?
     content: |
       RSVP to the event and receive NETUG updates!
@@ -53,8 +55,6 @@ sections:
     eventSponsors:
       - /images/consulting/octopusdeploy-logo.png
     _template: ActionSection
-  - globalUserGroupInfo: content/netug/global/global.json
-    _template: VideosSection
   - socialButtons:
       - url: 'https://github.com/netusergroup/sydney-user-group/discussions'
         label: Join GitHub Discussion

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -212,11 +212,6 @@ export default function NETUGPage(
             </section>
           </Container>
 
-          <SectionRenderer
-            prefix="UserGroupPageLocationPageSections"
-            blocks={data.userGroupPage.sections}
-          />
-
           <section className="bg-ssw-black py-8">
             <Container className="text-center">
               <h2
@@ -238,6 +233,11 @@ export default function NETUGPage(
               </div>
             </Container>
           </section>
+
+          <SectionRenderer
+            prefix="UserGroupPageLocationPageSections"
+            blocks={data.userGroupPage.sections}
+          />
 
           <section>
             <Container>


### PR DESCRIPTION
cc @camillars 

<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

* Corrected order as per conversation with Camilla to have the about section before the other sections 
* Created fallback centering of header when there is no torso image for a presenter 
* Added responsive centering of header when on a mobile device

- Affected routes: `/netug/brisbane`, `/netug/sydney`, `/netug/melbourne`, `/netug/canberra`

- Fixed #1653

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/605ede4a-a59b-4095-bf16-fb5dd1a9d7fa)
**Figure: Centering when there is no torso image**


