### PR TITLE
🐛 .NET UG - Fixed getStaticPaths fallback value

### DIFF
--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -353,6 +353,6 @@ export const getStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true,
+    fallback: false,
   };
 };


### PR DESCRIPTION
**Description**:
When a user accesses a non-existing path (e.g. netug/abc123), it returns a 500 status coder instead of a 404.

**Solution**:
The fallback property in getStaticPaths needs to be set from 'true' to 'false'. Now, the app returns a 404 (see **Figure**).

- Affected routes: `/netug` 

- Fixed #1644

**Screenshots**:

![website-PR-003](https://github.com/SSWConsulting/SSW.Website/assets/106663901/c6a60f1d-9570-4840-8265-25a4106d8ef2)
**Figure**: A 404 status code is returned when accessing a non-existing page
