### PR TITLE
📄 Change dates to be the same as Sharepoint events

### DIFF
--- a/content/events/angular-superpowers-tour.mdx
+++ b/content/events/angular-superpowers-tour.mdx
@@ -19,15 +19,15 @@ _body:
     gstText: inc GST
     eventList:
       - city: Brisbane
-        date: 2024-04-02
+        date: 2024-04-03
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-superpowers-tour-brisbane-tickets-77590542401
       - city: Melbourne
-        date: 2024-04-03
+        date: 2024-04-04
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-superpowers-tour-melbourne-tickets-77590422041
       - city: Sydney
-        date: 2024-04-04
+        date: 2024-04-05
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-superpowers-tour-sydney-tickets-147451430197
     _template: EventBooking

--- a/content/events/angular-workshop.mdx
+++ b/content/events/angular-workshop.mdx
@@ -27,11 +27,11 @@ _body:
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-workshop-2-day-training-brisbane-tickets-717647873107
       - city: Melbourne
-        date: 2023-11-12T00:00:00.000Z
+        date: 2023-11-13T00:00:00.000Z
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-workshop-2-day-training-melbourne-tickets-717649006497
       - city: Sydney
-        date: 2023-11-15T00:00:00.000Z
+        date: 2023-11-16T00:00:00.000Z
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-workshop-2-day-training-sydney-tickets-717635445937
     _template: EventBooking


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

I thought I did this yesterday but according to git i didn't.

Affected routes: 
- `/events/angular-workshop`

- Fixed #1664 

- [x] If adding a new page, I have followed the [SEO checklist](https://www.ssw.com.au/rules/seo-checklist/)

- [x] Include done video or screenshots

<img width="1196" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/38869720/b8cf26c5-397b-4fb6-b58a-91d52d7cb659">

**Figure: Angular Workshop dates**

<img width="1201" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/38869720/90fd11c9-8e3e-469d-83b8-424bf07a2165">

**Figure: Angular Superpowers dates**

