### PR TITLE
Content Change - Events banner redesign

### DIFF
--- a/content/events/customized-courses.mdx
+++ b/content/events/customized-courses.mdx
@@ -8,8 +8,13 @@ eventHeader:
   heroBackground: /images/background/polygonBackground.png
   altText: Customized Courses
   imgOverlay: /images/background/SSW-Training.png
-title: ''
-subTitle: ''
+title: Custom Training for Microsoft Technologies
+subTitle: |
+  Tailored to your unique business challenges and
+  opportunities, Adam Cogan, SSW Chief Architect and Microsoft Regional Director
+  will provide you with practical skills to maximise the potential of Microsoft
+  technologies. This one-day course is perfect for those wanting to dig deeper
+  into a particular technology or upskill a team with custom needs.
 _body:
   - eventDurationInDays: 1
     price: 5200

--- a/content/events/professional-tailored-scrum-training.mdx
+++ b/content/events/professional-tailored-scrum-training.mdx
@@ -8,8 +8,16 @@ eventHeader:
   heroBackground: /images/background/polygonBackground.png
   altText: Professional Tailored Scrum Training
   imgOverlay: /images/background/Scrum.png
-title: ''
-subTitle: ''
+title: Professional Scrum Training
+subTitle: >
+  Whether you're a seasoned Scrum Master
+
+  or new to the Scrum framework, become an expert in Scrum during this one-day
+
+  course. Learn how top technology companies enhance team collaboration and
+  drive successful projects across a wide range of
+
+  applications.
 _body:
   - eventDurationInDays: 1
     price: 5200


### PR DESCRIPTION
From: @ae-cher-ssw 
Subject: RE: SSW Event pages - Banner redesign 

Affected routes:
- `/events/customized-courses`
- `/events/professional-tailored-scrum-training` 


**Screenshots:**

<img width="732" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/81612a0e-29ee-4ce8-89f8-bf46f28850ef">

**Figure: Events - Scrum page** 

<img width="684" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/9e12a4a3-4a1f-41a2-a9d3-67836085640f">

**Figure: Events - Customized training page** 

