### PR TITLE
💄UI - Fixed Centering of Benefits

### DIFF
--- a/components/util/consulting/benefits.tsx
+++ b/components/util/consulting/benefits.tsx
@@ -8,18 +8,18 @@ const BenefitCard = (props) => {
   return (
     <article
       className={classNames(
-        "px-14 py-11 max-md:mx-auto md:flex",
+        "px-14 py-11 max-md:mx-auto md:flex justify-center",
         props.className
       )}
       data-aos={props.aosType}
     >
       <figure
         data-tina-field={tinaField(props.data, "image")}
-        className="relative mx-auto select-none md:mr-5"
+        className="relative select-none md:mr-5"
       >
         {image && (
           <Image
-            className="mx-auto max-w-max"
+            className="max-w-max max-md:mx-auto"
             src={image}
             width={120}
             height={120}
@@ -42,7 +42,7 @@ const BenefitCard = (props) => {
           <TinaMarkdown content={description} />
         </section>
         {linkURL && (
-          <p className="pt-4 text-left">
+          <p className="pt-4 text-center md:text-left">
             <a
               data-tina-field={tinaField(props.data, "linkName")}
               className="text-left text-white"


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

* Fixed centering by using `justify-center` instead of `mx-auto`s in the wrong place
* Fixed broken centering of additional link when on mobile 

- Affected routes: `/consulting/*`

- Fixed #1678

- [x] Include done video or screenshots

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/eeeb536d-c650-431f-a87f-02cac1b7fbdb)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/0af658f6-4194-461f-a044-b86ca0120cde)
**Figure: After**


