### PR TITLE
Fix deployments

### DIFF
--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -55,6 +55,7 @@ jobs:
           ACR_LOGIN_SERVER: ${{ env.ACR_LOGIN_SERVER }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           AZURE_SERVICE_PRINCIPAL_OBJECT_ID: ${{ secrets.AZURE_SERVICE_PRINCIPAL_OBJECT_ID }}
+
   test:
     name: Run Playwright Tests
     needs: deploy-staging
@@ -67,19 +68,27 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2
+        with:
+          path: ./.github
+          load-mode: strict
+
       - name: Azure CLI - Login
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Azure CLI Swap Deployments
-        uses: azure/CLI@v1
-        with:
-          azcliversion: 2.53.1
-          inlineScript: |
+
+      - run: |
             az webapp deployment slot swap \
               --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
               --name ${{ env.APP_SERVICE_NAME }} \
               --slot staging \
               --target-slot production
+          displayName: ♻️ Swap slots
+
+

--- a/.github/workflows/template-ui-tests.yml
+++ b/.github/workflows/template-ui-tests.yml
@@ -29,6 +29,13 @@ jobs:
         run: yarn playwright install --with-deps chromium
         working-directory: ./ui-tests
 
+      - name: Check that ${{ inputs.deploy_url }} is running
+        uses: jtalk/url-health-check-action@v3
+        with:
+          url: ${{ inputs.deploy_url }}
+          max-attempts: 12
+          retry-delay: 10s
+
       - name: Run Playwright image tests
         run: yarn playwright test images
         env:

--- a/ui-tests/.gitignore
+++ b/ui-tests/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 /test-results/
 /playwright/.cache/
+/playwright-report
 
 # yarn v2
 .yarn/*

--- a/ui-tests/images.spec.ts
+++ b/ui-tests/images.spec.ts
@@ -7,7 +7,8 @@ test("Images load successfully on index", async ({ page }) => {
     }
   });
 
-  await page.goto("/", { waitUntil: "networkidle" });
+  const response = await page.goto("/", { waitUntil: "networkidle" });
+  expect(response.ok()).toBeTruthy();
 
   // Taken from https://github.com/microsoft/playwright/issues/19277
   const sizes = await page.evaluate(() => {
@@ -30,7 +31,10 @@ test("Images load successfully on consulting page", async ({ page }) => {
     }
   });
 
-  await page.goto("/consulting/react", { waitUntil: "networkidle" });
+  const response = await page.goto("/consulting/react", {
+    waitUntil: "networkidle",
+  });
+  expect(response.ok()).toBeTruthy();
 
   // Taken from https://github.com/microsoft/playwright/issues/19277
   const sizes = await page.evaluate(() => {


### PR DESCRIPTION
UI tests - added step to ensure that the home page returns a 200 OK before executing tests (site may not be ready to be tested)
UI tests - fixed issue where tests would pass when the page served was not 200
Deploy - swapping slots - env variables were used that were not hydrated


- Affected routes: n/a
- Fixes #1568
- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template
- [ ] Include done video or screenshots


