### PR TITLE
🐛 Megamenu - Removed Next/link for Menu Items

### DIFF
--- a/components/megamenu/DesktopMenu/menu-item-link.tsx
+++ b/components/megamenu/DesktopMenu/menu-item-link.tsx
@@ -1,15 +1,14 @@
-import Link from "next/link";
 import React from "react";
 
 export const MenuItemLink: React.FC<{
   item: { href?: string; name: string };
 }> = ({ item }) => {
   return (
-    <Link
+    <a
       href={item.href}
       className="unstyled flex items-center justify-center rounded-md px-3 py-1"
     >
       {item.name}
-    </Link>
+    </a>
   );
 };

--- a/components/megamenu/MobileMenu/mobile-menu.tsx
+++ b/components/megamenu/MobileMenu/mobile-menu.tsx
@@ -1,6 +1,5 @@
 import { Dialog } from "@headlessui/react";
 import { ChevronRightIcon } from "@heroicons/react/24/solid";
-import Link from "next/link";
 import React from "react";
 import { AvailableIcons } from "../../../models/megamanu/config.consts";
 import { NavMenuItem } from "../../../models/megamanu/menuItem.model";
@@ -82,13 +81,13 @@ const MenuBarItems: React.FC<{
       <div className="space-y-2">
         {menuBarItems.map((item) => {
           return item.href ? (
-            <Link
+            <a
               key={item.name}
               href={item.href}
               className="unstyled -mx-3 flex w-full items-center px-3 py-2 text-left text-lg leading-7 text-ssw-black hover:bg-gray-50"
             >
               {item.name}
-            </Link>
+            </a>
           ) : (
             <button
               key={item.name}


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

* Removed `next/link` for standalone megamenu links (they are all external links anyway)

- Affected routes: *

- Fixed #1753 


