### PR TITLE
🐛 Carousel menu - Fixed broken links 

### DIFF
--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -22,11 +22,11 @@ beforeBody:
         openIn: sameWindow
         imgSrc: /images/carousel/Alix-banner.jpg
       - label: Why should you choose to build your SSW web application?
-        link: 'https://www.ssw.com.au/ssw/Company/AboutUs.aspx'
+        link: /company/about-us
         openIn: sameWindow
         imgSrc: /images/carousel/Hero_SSW.jpg
       - label: Case Study - Helping deaf children reach their full potential
-        link: 'https://www.ssw.com.au/SSW/Consulting/Case-Study/Shepherd-Centre.aspx'
+        link: /company/clients/shepherd-centre
         openIn: sameWindow
         imgSrc: /images/carousel/The-Shepherd-Centre.jpg
       - label: SSW TV


### PR DESCRIPTION
Description: When the user clicked on "Watch the video" in the homepage carousel, he was redirected to a broken page.

Solution: The broken links have been fixed with Tina.

- Affected routes: /

- Fixed #1757

- Screenshots

![website-PR-006a](https://github.com/SSWConsulting/SSW.Website/assets/106663901/8cec0007-0cff-4c80-b365-7a15f485a1b4)
Figure: Step 1.

![website-PR-006b](https://github.com/SSWConsulting/SSW.Website/assets/106663901/98c5703e-5bd3-4dde-aad5-9e2c8fb4efae)
Figure: Step 2.
