### PR TITLE
Open presenter link in new tab

### DIFF
--- a/pages/live.tsx
+++ b/pages/live.tsx
@@ -60,7 +60,10 @@ export default function LivePage(
             <>
               <div className="pb-3 text-lg">
                 With{" "}
-                <Link href={props.speaker?.PresenterProfileLink}>
+                <Link
+                  href={props.speaker?.PresenterProfileLink}
+                  target="_blank"
+                >
                   {props.speaker?.Title}
                 </Link>
               </div>


### PR DESCRIPTION
**Description**: on [ssw.com.au/live](https://www.ssw.com.au/live), when the user clicks on the presenter name, he is redirected to an error page.

**Solution**: Open the presenter profile in a new tab fixed the problem. It is also better UX, as some presenter profiles will be on LinkedIn, so it makes sense to open a new tab when navigating to a new domain.

- Affected routes: /live

- Fixed #1800

- [x] Include done video or **screenshots**

![image](https://github.com/SSWConsulting/SSW.Website/assets/106663901/e6c6fa68-ba37-49d3-b3cd-b68487dfd07f)
**Figure**: When a user clicks on the presenter name on the /live page...

![image](https://github.com/SSWConsulting/SSW.Website/assets/106663901/58b2a830-3ba2-4968-bbaf-4ea4bf8658ca)
**Figure**: ...it opens the presenter page in a new tab
