### PR TITLE
🐛 Bug - Fixed Client Side Error

### DIFF
--- a/components/blocks/upcomingEvents.tsx
+++ b/components/blocks/upcomingEvents.tsx
@@ -87,7 +87,7 @@ const UpcomingEvent = ({ event }: UpcomingEventProps) => {
     event.Url.Url.includes("/ssw/redirect");
 
   return (
-    <Link
+    <a
       href={event.Url.Url}
       className="unstyled no-underline"
       target={isExternalLink ? "_blank" : "_self"}
@@ -121,7 +121,7 @@ const UpcomingEvent = ({ event }: UpcomingEventProps) => {
           </div>
         )}
       </article>
-    </Link>
+    </a>
   );
 };
 


### PR DESCRIPTION
* Fixed issue with some links to the v1 site on the home page displaying an error when navigated to

<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: `/`

- Fixed #1824


