### PR TITLE
💄 UI - Clean Up Events Pages

### DIFF
--- a/components/training/presenterBlock.tsx
+++ b/components/training/presenterBlock.tsx
@@ -14,7 +14,7 @@ export const PresenterBlock = ({ data }) => {
       >
         <span className="text-sswRed">{data.header}</span>
       </h2>
-      <div className="flex flex-row flex-wrap justify-center gap-4 md:gap-4">
+      <div className="flex flex-row flex-wrap items-stretch justify-center gap-4 md:gap-4">
         {data.presenterList?.map((p, i) => (
           <PresenterCard
             key={i}
@@ -55,7 +55,7 @@ export const PresenterBlock = ({ data }) => {
 const PresenterCard = ({ presenter, schema, index }) => {
   return (
     <div
-      className="prose flex h-fit flex-col rounded-md border-b-4 border-b-sswRed bg-gray-100 p-10 text-center text-xl md:h-172 md:w-96"
+      className="prose flex flex-col justify-start rounded-md border-b-4 border-b-sswRed bg-gray-100 p-10 text-center text-xl md:w-96"
       data-aos="flip-right"
     >
       <div
@@ -77,7 +77,7 @@ const PresenterCard = ({ presenter, schema, index }) => {
       </div>
       <a
         href={presenter?.presenter?.peopleProfileURL}
-        className="mt-4 min-h-16 font-normal"
+        className="mt-4 font-normal"
         target="_blank"
         rel="noopener noreferrer"
         data-tina-field={tinaField(


### PR DESCRIPTION
* Changed to dynamic height presenter cards instead of fixed height ones (should remove weird height)

<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: <!-- E.g. `/offices/brisbane`  -->

- Fixed #1826


![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/b0d0cae4-925e-4dc2-b04c-b8a93e208818)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/f9e92b2f-3dbd-4077-9c7e-d05ffc773ddd)
**Figure: After**

