### PR TITLE
Fix - Newsletters link in a new tab

### DIFF
--- a/components/blocks/newslettersTable.tsx
+++ b/components/blocks/newslettersTable.tsx
@@ -95,7 +95,7 @@ export const NewslettersTable: React.FC<{ data: { headerText: string } }> = ({
         {newsletters.map(({ file, month, description }) => (
           <tr key={file} className="mx-4 bg-gray-50">
             <td className="rounded-l px-3 py-1">
-              <CustomLink href={removeTinaFromUrl(file)}>
+              <CustomLink href={removeTinaFromUrl(file)} target="_blank">
                 {transformIntToMonth(month)}
               </CustomLink>
             </td>


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

Adding `_blank` to open newsletter in a new tab to avoid client side exception. 

- Affected routes: `/newsletters` 

- Fixed #1851 


