### PR TITLE
Fix - Links for Case study

### DIFF
--- a/components/customLink.tsx
+++ b/components/customLink.tsx
@@ -10,7 +10,7 @@ interface CustomLinkProps extends PropsWithChildren {
 }
 
 const externalSSWSitePatterns =
-  /^(https:\/\/(?:www\.)?ssw\.com\.au\/(?:people|rules|ssw)(?:\/|$))/;
+  /^(https:\/\/(?:www\.)?ssw\.com\.au\/(?:people|rules|ssw)(?:\/|$))/i;
 
 const isExternalLink = (href: string): boolean => {
   // i.e. href = https://anydomain.com.au => true | href = https://ssw.com.au/rule/* => true for SSW External Site | href = /company => false for relative path


### PR DESCRIPTION
Adding case-insensitive tag to check all the routes. 
For case-studies, it starts with `/SSW/*` (i.e ssw in uppercase) 

Fixed: #1866


- Affected routes:  `/company/client` 


