### PR TITLE
Fix - Organizer image is now properly rounded

### DIFF
--- a/components/usergroup/organizer.tsx
+++ b/components/usergroup/organizer.tsx
@@ -33,6 +33,7 @@ export const Organizer = ({
             src={data?.profileImg ?? ""}
             height={68}
             width={68}
+            className="h-17"
           />
         </div>
         <div className="font-sans">

--- a/components/usergroup/organizer.tsx
+++ b/components/usergroup/organizer.tsx
@@ -33,7 +33,7 @@ export const Organizer = ({
             src={data?.profileImg ?? ""}
             height={68}
             width={68}
-            className="h-17"
+            className="w-17"
           />
         </div>
         <div className="font-sans">


### PR DESCRIPTION
Affected routes: 
- `/netug/*` 

- Fixed #1870 


- [ ] Include done video or screenshots
<img width="647" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/0c82a917-f598-438a-aaed-91f3991124eb">

**Figure: Fixed organizer's image on the page**

