### PR TITLE
Consulting list - add .NET 8 to more service offerings

### DIFF
--- a/content/consulting/index/index.json
+++ b/content/consulting/index/index.json
@@ -64,13 +64,25 @@
           ]
         },
         {
-          "title": "Mobile Apps",
-          "description": "We can build your mobile app using React Native, MAUI (was Xamarin), Flutter, Cordova, PWA, or Ionic!",
-          "logo": "/images/thumbs/thumb-mobiles-apps-icon.jpg",
-          "page": "content/consulting/mobile-application-development.mdx",
+          "title": ".NET 8",
+          "description": ".NET 8 is the latest LTS (Long Term Support) version of the platform. It provides enterprise functionality and cloud-native development all within a stable ecosystem backed by Microsoft.",
+          "logo": "/images/thumbs/thumb-net-8.jpg",
+          "page": "content/consulting/net-8.mdx",
           "tags": [
             {
+              "tag": "content/consulting/tag/platform-development.json"
+            },
+            {
+              "tag": "content/consulting/tag/cloud-and-infrastructure.json"
+            },
+            {
+              "tag": "content/consulting/tag/web-development.json"
+            },
+            {
               "tag": "content/consulting/tag/mobile-development.json"
+            },
+            {
+              "tag": "content/consulting/tag/ai-development.json"
             }
           ]
         },
@@ -126,6 +138,17 @@
           "tags": [
             {
               "tag": "content/consulting/tag/web-development.json"
+            }
+          ]
+        },
+        {
+          "title": "Mobile Apps",
+          "description": "We can build your mobile app using React Native, MAUI (was Xamarin), Flutter, Cordova, PWA, or Ionic!",
+          "logo": "/images/thumbs/thumb-mobiles-apps-icon.jpg",
+          "page": "content/consulting/mobile-application-development.mdx",
+          "tags": [
+            {
+              "tag": "content/consulting/tag/mobile-development.json"
             }
           ]
         },
@@ -202,23 +225,6 @@
           "tags": [
             {
               "tag": "content/consulting/tag/database-development.json"
-            }
-          ]
-        },
-        {
-          "title": ".NET 8",
-          "description": ".NET 8 is the latest LTS (Long Term Support) version of the platform. It provides enterprise functionality and cloud-native development all within a stable ecosystem backed by Microsoft.",
-          "logo": "/images/thumbs/thumb-net-8.jpg",
-          "page": "content/consulting/net-8.mdx",
-          "tags": [
-            {
-              "tag": "content/consulting/tag/web-development.json"
-            },
-            {
-              "tag": "content/consulting/tag/mobile-development.json"
-            },
-            {
-              "tag": "content/consulting/tag/ai-development.json"
             }
           ]
         }


### PR DESCRIPTION
CC @UlyssesMaclaren @PennyWalker @Marxoz @JeanThirion @adamcogan 

As per our conversation in the management meeting:

- Added .NET 8 to platform and cloud/infra consulting services
- Moved .NET 8 to the top of the developer team list (it was last before and below the fold)

Ensemble'd with @william-liebenberg on this

- Affected routes: /consulting

- [x] Include done video or screenshots

![CleanShot 2023-12-13 at 12 44 34](https://github.com/SSWConsulting/SSW.Website/assets/600044/ea99aa34-7e7d-4a83-b2df-d16d2d468626)

