### PR TITLE
🔍 SEO - Added Archive Sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -19,6 +19,7 @@ module.exports = {
       // 'https://www.ssw.com.au/people/sitemap.xml',
       // 'https://www.ssw.com.au/rules/sitemap.xml',
       "https://www.ssw.com.au/ssw/sitemap.xml",
+      "https://www.ssw.com.au/history/sitemap.xml",
     ],
   },
 };


### PR DESCRIPTION
Now that the `/history` Blob Storage static site has been deployed, we can now use the generated sitemap from the Azure Storage archive. 

<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: `/sitemap.xml`

- Fixed #1767


