### PR TITLE
💄 UI - Employment Opportunities Spacing

### DIFF
--- a/components/filter/opportunities.tsx
+++ b/components/filter/opportunities.tsx
@@ -188,8 +188,8 @@ const OpportunityDropdown = ({
               {opportunity.title}
             </h2>
             <span className="flex items-center md:float-right">
-              <FaMapMarkerAlt className="inline" />
-              {opportunity.locations?.join(", ")}
+              <FaMapMarkerAlt className="inline" />&nbsp;
+              {opportunity.locations?.join(", ")}&nbsp;
               {opportunity.status === FILLED && <strong> *FILLED*</strong>}
             </span>
           </Disclosure.Button>

--- a/components/filter/opportunities.tsx
+++ b/components/filter/opportunities.tsx
@@ -188,9 +188,10 @@ const OpportunityDropdown = ({
               {opportunity.title}
             </h2>
             <span className="flex items-center md:float-right">
-              <FaMapMarkerAlt className="inline" />&nbsp;
+              <FaMapMarkerAlt className="inline" />
+              &nbsp;
               {opportunity.locations?.join(", ")}&nbsp;
-              {opportunity.status === FILLED && <strong> *FILLED*</strong>}
+              {opportunity.status === FILLED && <strong>*FILLED*</strong>}
             </span>
           </Disclosure.Button>
 

--- a/components/filter/opportunities.tsx
+++ b/components/filter/opportunities.tsx
@@ -187,7 +187,7 @@ const OpportunityDropdown = ({
             <h2 className="my-0 text-base md:float-left">
               {opportunity.title}
             </h2>
-            <span className="flex items-center md:float-right">
+            <span className="flex justify-center md:float-right">
               <FaMapMarkerAlt className="inline" />
               &nbsp;
               {opportunity.locations?.join(", ")}&nbsp;


### PR DESCRIPTION
* Add spaces between location icon and location name + before "filled"

As per @adamcogan: **SSW Employment Opportunities - add a space** 

Closes: https://github.com/SSWConsulting/SSW.Website/issues/1936

From

<img width="216" alt="Screenshot 2023-12-20 at 10 09 04 AM" src="https://github.com/SSWConsulting/SSW.Website/assets/12601228/68c82a68-12ce-4655-b35e-d446a22b998c">

to

<img width="219" alt="Screenshot 2023-12-20 at 10 09 31 AM" src="https://github.com/SSWConsulting/SSW.Website/assets/12601228/f3eb2321-c2d5-4972-aeac-8957df2b6041">
