### PR TITLE
💄UI - Add Employment Spacing

### DIFF
--- a/components/filter/opportunities.tsx
+++ b/components/filter/opportunities.tsx
@@ -184,10 +184,10 @@ const OpportunityDropdown = ({
             }}
             id={transformTitleToId(opportunity.title)}
           >
-            <h2 className="my-0 text-base md:float-left">
+            <h2 className="my-0 text-base font-semibold md:float-left">
               {opportunity.title}
             </h2>
-            <span className="flex justify-center md:float-right">
+            <span className="flex items-center justify-center md:float-right">
               <FaMapMarkerAlt className="inline" />
               &nbsp;
               {opportunity.locations?.join(", ")}&nbsp;

--- a/components/filter/opportunities.tsx
+++ b/components/filter/opportunities.tsx
@@ -187,10 +187,11 @@ const OpportunityDropdown = ({
             <h2 className="my-0 text-base md:float-left">
               {opportunity.title}
             </h2>
-            <span className="flex items-center md:float-right">
+            <span className="flex justify-center md:float-right">
               <FaMapMarkerAlt className="inline" />
-              {opportunity.locations?.join(", ")}
-              {opportunity.status === FILLED && <strong> *FILLED*</strong>}
+              &nbsp;
+              {opportunity.locations?.join(", ")}&nbsp;
+              {opportunity.status === FILLED && <strong>*FILLED*</strong>}
             </span>
           </Disclosure.Button>
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

As per my conversation with @tiagov8 - this is a duplicate https://github.com/SSWConsulting/SSW.Website/pull/1935, which was closed. It can't be reopened due to a conflict with branch names. 

* Fixes spacing between elements
* Fixes centering on mobile viewports
* Made position titles bold

- Affected routes: `/employment`

- Fixed #1936

From:
![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/16ccdcdd-08a3-400a-a67c-e2d2d2000957)

To:
![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/2c1b4e2a-919f-4693-8a49-341eea9ba111)

From:
![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/f21b5f47-4bf2-4ced-b6a4-7f7eed4785ad)

To:
![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/02f7a776-84b1-4899-a72a-660cd2fe8288)
