### PR TITLE
Update 'SSW Partners' title tag

### DIFF
--- a/content/partners/index/index.json
+++ b/content/partners/index/index.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "SSW Consulting Services "
+    "title": "SSW Partners"
   },
   "title": "SSW Partners",
   "subTitle": "At SSW, we have several strategic partnerships that allow us to access knowledge, innovation and expertise around the globe.  ",


### PR DESCRIPTION
Based on email chain: **Re: What’s the worst page? - About Us**

1. Changed the tag from
     SSW Consulting Services to
To
     SSW Partners

Affected routes: /company/partners

Relates to: [Task 88690](https://dev.azure.com/ssw/SSW.Design/_workitems/edit/88690): SSW.Website - Update 'SSW Partners' title tag