### PR TITLE
Update Mega Menu 'About Us' tab

### DIFF
--- a/content/megamenu/menu.json
+++ b/content/megamenu/menu.json
@@ -481,8 +481,8 @@
         }
       ],
       "viewAll": {
-        "name": "View all products",
-        "url": "/products"
+        "name": "",
+        "url": ""
       }
     },
     {


### PR DESCRIPTION
Based on email chain: **Re: What’s the worst page? - About Us**

- [x] Remove the “view all products” link from the About Us tab of the Megamenu

![image](https://github.com/SSWConsulting/SSW.Website/assets/33026270/df0fd9b9-cb27-4911-8864-41aec9959068)
**Figure: this shouldn’t be there**

Relates to: [Task 88689](https://dev.azure.com/ssw/SSW.Design/_workitems/edit/88689): SSW.Website - Update Mega Menu 'About Us' tab
