### PR TITLE
💄UI - Fixing Presenters' image

### DIFF
--- a/components/usergroup/sections/header.tsx
+++ b/components/usergroup/sections/header.tsx
@@ -58,7 +58,7 @@ export const UserGroupHeader = ({
     <section
       className={classNames(
         className,
-        "bg-polygons border-b-8 border-sswRed bg-cover bg-no-repeat"
+        "bg-polygons border-b-8 border-sswRed bg-cover bg-no-repeat md:max-h-112"
       )}
     >
       <Container
@@ -110,7 +110,7 @@ export const UserGroupHeader = ({
           </div>
         </div>
         {presenter.image && (
-          <div className="flex max-w-xl shrink-0 flex-col justify-end self-end max-md:mx-auto">
+          <div className="flex max-w-xl shrink-0 flex-col justify-end self-end max-md:mx-auto md:h-112">
             <Image
               className="!relative align-bottom"
               src={presenter.image}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,7 @@ module.exports = {
         22: "5.5rem",
         62: "15.5rem",
         102: "25.5rem",
+        112: "28rem",
         172: "43rem",
       },
       width: {


### PR DESCRIPTION
Fixed #2026
Affected Route: `/netug/*`

**Screenshot:** 

<img width="867" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/d4ed44f4-2d55-448b-a268-49d8d2c70a8a">

**Figure: Presenter's image on user group page**


