### PR TITLE
Fixing - Wordpress page mdx formatting

### DIFF
--- a/content/consulting/wordpress.mdx
+++ b/content/consulting/wordpress.mdx
@@ -5,17 +5,17 @@ seo:
     WordPress is an open-source CMS that is highly customizable, expandable, and
     multi-user capable, to manage your website content with ease.
 booking:
-  title: Want <span class="text-sswRed">performance</span>, <span class="text-sswRed">security</span>, and <span class="text-sswRed">ease of use</span>?
-  subTitle: 'Manage your content professionally with Wordpress - it's easy to learn, to use, and to be awesome'
+  title: >-
+    Want <span class="text-sswRed">performance</span>, <span
+    class="text-sswRed">security</span>, and <span class="text-sswRed">ease of
+    use</span>?
+  subTitle: >-
+    Manage your content professionally with Wordpress - it's easy to learn, to
+    use, and to be awesome
   videoBackground: /images/videos/MVC_background.mp4
-technologies:
-  header: Other Technologies
-  technologyCards:
-    - technologyCard: content/technologies/ms-sql-server.mdx
-    - technologyCard: content/technologies/power-bi.mdx
-    - technologyCard: content/technologies/seopack.mdx
-    - technologyCard: content/technologies/beaverbuilder.mdx
-    - technologyCard: content/technologies/angular.mdx
+solution:
+  project: web project
+callToAction: 'Talk to us about your {{TITLE}}'
 benefits:
   benefitList:
     - image: /images/benefits/low-startup-cost.png
@@ -49,9 +49,14 @@ benefits:
   rule:
     - name: SSW Rules to Better WordPress.
       url: 'https://rules.ssw.com.au/rules-to-better-wordpress'
-solution:
-  project: web project
-callToAction: 'Talk to us about your {{TITLE}}'
+technologies:
+  header: Other Technologies
+  technologyCards:
+    - technologyCard: content/technologies/ms-sql-server.mdx
+    - technologyCard: content/technologies/power-bi.mdx
+    - technologyCard: content/technologies/seopack.mdx
+    - technologyCard: content/technologies/beaverbuilder.mdx
+    - technologyCard: content/technologies/angular.mdx
 ---
 
 # The benefits of managing your content with WordPress


### PR DESCRIPTION
Build pipeline was failing due to inconsistent mdx formatting.
<img width="1210" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/07e85b3c-41f8-4f21-91cc-d1a45c276ad3">

**Figure: GitHub Action failing to create a build** 

Upon running it locally, the issue was identified as a formatting problem on the `/consulting/wordpress` page, causing hindrance in running the server. 

<img width="372" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/67aaa75d-5a2e-45df-951b-592a36771a04">

**Figure: Local failure in visual code's cmd**