### PR TITLE
Pipeline - Fixing weekly clean up slots

### DIFF
--- a/.github/workflows/weekly-slots-cleanup.yml
+++ b/.github/workflows/weekly-slots-cleanup.yml
@@ -1,9 +1,6 @@
 name: Weekly app service slot cleanup
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     # Monday at 12 PM UTC - https://cron.help/#0_12_*_*_MON
     - cron: "0 12 * * MON"

--- a/.github/workflows/weekly-slots-cleanup.yml
+++ b/.github/workflows/weekly-slots-cleanup.yml
@@ -49,7 +49,7 @@ jobs:
             --name ${{ env.APP_SERVICE_NAME }} `
             --resource-group ${{env.AZURE_RESOURCE_GROUP }} `
             --query '[].name' `
-            --output tsv | grep -v 'staging' | `
+            --output tsv | `
             sed 's/pr-//g')
           echo "slots=$slots" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/weekly-slots-cleanup.yml
+++ b/.github/workflows/weekly-slots-cleanup.yml
@@ -46,7 +46,8 @@ jobs:
             --name ${{ env.APP_SERVICE_NAME }} `
             --resource-group ${{env.AZURE_RESOURCE_GROUP }} `
             --query '[].name' `
-            --output tsv | grep -v 'staging' | `
+            --output tsv | `
+            grep -v 'staging' | `
             sed 's/pr-//g')
           echo "slots=$slots" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/weekly-slots-cleanup.yml
+++ b/.github/workflows/weekly-slots-cleanup.yml
@@ -1,6 +1,9 @@
 name: Weekly app service slot cleanup
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     # Monday at 12 PM UTC - https://cron.help/#0_12_*_*_MON
     - cron: "0 12 * * MON"
@@ -46,7 +49,7 @@ jobs:
             --name ${{ env.APP_SERVICE_NAME }} `
             --resource-group ${{env.AZURE_RESOURCE_GROUP }} `
             --query '[].name' `
-            --output tsv | `
+            --output tsv | grep -v 'staging' | `
             sed 's/pr-//g')
           echo "slots=$slots" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/weekly-slots-cleanup.yml
+++ b/.github/workflows/weekly-slots-cleanup.yml
@@ -49,7 +49,7 @@ jobs:
             --name ${{ env.APP_SERVICE_NAME }} `
             --resource-group ${{env.AZURE_RESOURCE_GROUP }} `
             --query '[].name' `
-            --output tsv | `
+            --output tsv | grep -v 'staging' | `
             sed 's/pr-//g')
           echo "slots=$slots" >> $env:GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixed #2148

Adding `grep` with `-v` to not have staging slot in the slotlist to prevent it from delete.