### PR TITLE
💄 UI - Fixed Text Colour, Changed to use `next/image` for background image

### DIFF
--- a/components/marketing/Marketing.tsx
+++ b/components/marketing/Marketing.tsx
@@ -1,4 +1,6 @@
+import { getImageProps } from "next/image";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { getBackgroundImage } from "../../helpers/images";
 import { sanitiseXSS, spanWhitelist } from "../../helpers/validator";
 import { componentRenderer } from "../blocks/mdxComponentRenderer";
 import { Container } from "../util/container";
@@ -13,12 +15,20 @@ export const Marketing = (props) => {
     return <></>;
   }
 
+  const {
+    props: { srcSet },
+  } = getImageProps({
+    src: content?.backgroundImage,
+    alt: "Marketing background",
+    height: 537,
+    width: 1920,
+  });
+
+  const backgroundImage = getBackgroundImage(srcSet);
+
   return (
-    <Section
-      style={{ backgroundImage: `url(${content?.backgroundImage})` }}
-      className="h-full bg-cover"
-    >
-      <Container size="custom" className="h-full py-16 text-center">
+    <Section style={{ backgroundImage }} className="h-full bg-cover">
+      <Container size="custom" className="h-full py-16 text-center text-white">
         <h1
           className="mt-0 pt-0 text-5xl text-white"
           dangerouslySetInnerHTML={{

--- a/content/marketing/why-choose-ssw.mdx
+++ b/content/marketing/why-choose-ssw.mdx
@@ -3,7 +3,9 @@ title: Why should you choose <span class="text-sswRed">SSW</span>?
 backgroundImage: /images/marketings/sswMarketingBackground.jpg
 mediaComponent: >
   <VideoEmbed removeMargin={true}
-  url="https://www.youtube.com/watch?v=Jveq6VFjWTA" videoWidth="w-full" caption="The people behind SSW - Australia's leading software consultancy." duration="4 mins" />
+  url="https://www.youtube.com/watch?v=Jveq6VFjWTA" videoWidth="w-full"
+  caption="The people behind SSW - Australia's leading software consultancy."
+  duration="4 mins"/>
 textSide: right
 ---
 

--- a/helpers/images.ts
+++ b/helpers/images.ts
@@ -1,0 +1,11 @@
+// from https://nextjs.org/docs/pages/api-reference/components/image#background-css
+export function getBackgroundImage(srcSet = "") {
+  const imageSet = srcSet
+    .split(", ")
+    .map((str) => {
+      const [url, dpi] = str.split(" ");
+      return `url("${url}") ${dpi}`;
+    })
+    .join(", ");
+  return `image-set(${imageSet})`;
+}


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

* Fixed incorrect text on all consulting pages
* Added `next/image` to background of marketing components

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/6accd19d-a96c-4971-9e51-a688f26626e9)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/076fe833-13bb-4012-900e-a144aec58007)
**Figure: After**

- Affected routes: <!-- E.g. `/offices/brisbane`  -->

- Fixed #2237 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [x] Include done video or screenshots


