### PR TITLE
Fixing Adam's image on home page 

### DIFF
--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -137,7 +137,7 @@ SSW Consulting has over 30 years of experience developing awesome Microsoft solu
 />
 
 <VerticalImageLayout
-  imageSrc="/images/verticalImageLayout/MAPA.jpg"
+  imageSrc="/images/verticalImageLayout/MAPA_Logo.jpg"
   altText="Microsoft Australia Partner Award"
   imageLink="https://www.firebootcamp.com"
   width={255}


### PR DESCRIPTION
Renaming the image name fixes the issue.

- Affected routes: /

<img width="825" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/ec957636-ac05-46e6-87dc-8b99185af52e">

**Figure: Homepage - Before the change** 

<img width="869" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/8b46b1a1-7675-49fc-8e55-8cac77d252ef">

**Figure: Homepage - After the Change**


