### PR TITLE
Adding Microsoft Azure and Removing .Net 8 in Cloud and Infrastructure 

### DIFF
--- a/content/consulting/index/index.json
+++ b/content/consulting/index/index.json
@@ -73,9 +73,6 @@
               "tag": "content/consulting/tag/platform-development.json"
             },
             {
-              "tag": "content/consulting/tag/cloud-and-infrastructure.json"
-            },
-            {
               "tag": "content/consulting/tag/web-development.json"
             },
             {

--- a/content/consulting/index/index.json
+++ b/content/consulting/index/index.json
@@ -311,6 +311,9 @@
           "page": "content/consulting/azure.mdx",
           "tags": [
             {
+              "tag": "content/consulting/tag/cloud-and-infrastructure.json"
+            },
+            {
               "tag": "content/consulting/tag/platform-development.json"
             }
           ]


### PR DESCRIPTION
Change requested from @piers-sinclair. 

After discussing with @william-liebenberg, @wicksipedia, @UlyssesMaclaren, and others on Teams, we've decided to remove ".Net 8" from the "Cloud and Infrastructure" section. It currently appears at the top of the page, and we lack the capability to reorder it. We'll address this through the following issue: https://github.com/SSWConsulting/SSW.Website/issues/2388.

**Screenshot:**
 
<img width="1106" alt="image" src="https://github.com/SSWConsulting/SSW.Website/assets/71385247/bef9786c-a859-48d3-9fea-2659109b5002">

**Figure: Consulting index after adding Azure** 