### PR TITLE
Fixing - Playwright Image tests

### DIFF
--- a/ui-tests/images.spec.ts
+++ b/ui-tests/images.spec.ts
@@ -7,20 +7,21 @@ test("Images load successfully on index", async ({ page }) => {
     }
   });
 
-  const response = await page.goto("/", { waitUntil: "commit" });
+  const response = await page.goto("/", { waitUntil: "load" });
   expect(response.ok()).toBeTruthy();
 
   // Taken from https://github.com/microsoft/playwright/issues/19277
   const sizes = await page.evaluate(() => {
     return {
       browserHeight: window.innerHeight,
-      pageHeight: document.body.scrollHeight,
+      pageHeight:
+        document.body.scrollHeight || document.documentElement.scrollHeight,
     };
   });
 
   for (let i = 0; i < sizes.pageHeight; i += sizes.browserHeight) {
     await page.mouse.wheel(0, i);
-    await page.waitForTimeout(100);
+    await page.waitForTimeout(1000);
   }
 });
 
@@ -32,7 +33,7 @@ test("Images load successfully on consulting page", async ({ page }) => {
   });
 
   const response = await page.goto("/consulting/react", {
-    waitUntil: "commit",
+    waitUntil: "load",
   });
   expect(response.ok()).toBeTruthy();
 
@@ -40,12 +41,13 @@ test("Images load successfully on consulting page", async ({ page }) => {
   const sizes = await page.evaluate(() => {
     return {
       browserHeight: window.innerHeight,
-      pageHeight: document.body.scrollHeight,
+      pageHeight:
+        document.body.scrollHeight || document.documentElement.scrollHeight,
     };
   });
 
   for (let i = 0; i < sizes.pageHeight; i += sizes.browserHeight) {
     await page.mouse.wheel(0, i);
-    await page.waitForTimeout(100);
+    await page.waitForTimeout(1000);
   }
 });


### PR DESCRIPTION
Fixed: #2362 

- Increasing page timeout size for evaluation 
- Changing the waituntil prop till `load` instead of `commit`



