### PR TITLE
🎙️ Updating Angular 2day workshop in Melbourne date

### DIFF
--- a/content/events/angular-workshop.mdx
+++ b/content/events/angular-workshop.mdx
@@ -27,7 +27,7 @@ _body:
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-workshop-2-day-training-brisbane-tickets-780288181957
       - city: Melbourne
-        date: 2024-05-13T00:00:00.000Z
+        date: 2024-05-27T00:00:00.000Z
         bookingURL: >-
           https://www.eventbrite.com.au/e/angular-workshop-2-day-training-melbourne-tickets-780299535917
       - city: Sydney


### PR DESCRIPTION
As per my chat with @PennyWalker, we had to change the date of the Melbourne event so it doesn't clash with another internal event.

- Affected routes: https://www.ssw.com.au/events/angular-workshop
