### PR TITLE
🏎️ Performance - Reduce Size of `_app.tsx`

### DIFF
--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -12,6 +12,7 @@ import { Open_Sans } from "next/font/google";
 import { useReportWebVitals } from "next/web-vitals";
 import { MegaMenuLayout, NavMenuGroup } from "ssw.megamenu";
 import { CustomLink } from "../customLink";
+import { ErrorBoundary } from "../util/error-boundary";
 
 const openSans = Open_Sans({
   variable: "--open-sans-font",
@@ -155,10 +156,12 @@ export const Layout = ({
               />
             </div>
           </header>
-          <main className={classNames("grow bg-white")}>{children}</main>
+          <ErrorBoundary key={router.asPath}>
+            <main className={classNames("grow bg-white")}>{children}</main>
 
-          {showAzureBanner && <PreFooter />}
-          <Footer />
+            {showAzureBanner && <PreFooter />}
+            <Footer />
+          </ErrorBoundary>
         </div>
       </Theme>
     </>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -13,7 +13,7 @@ import { useReportWebVitals } from "next/web-vitals";
 import { MegaMenuLayout, NavMenuGroup } from "ssw.megamenu";
 import { CustomLink } from "../customLink";
 
-export const openSans = Open_Sans({
+const openSans = Open_Sans({
   variable: "--open-sans-font",
   subsets: ["latin"],
 });

--- a/components/liveStream/liveStreamWidget.tsx
+++ b/components/liveStream/liveStreamWidget.tsx
@@ -1,3 +1,5 @@
+import "react-tooltip/dist/react-tooltip.css";
+
 import axios from "axios";
 import classNames from "classnames";
 import Image from "next/image";

--- a/components/util/error-boundary.tsx
+++ b/components/util/error-boundary.tsx
@@ -2,15 +2,8 @@ import {
   AppInsightsContext,
   ReactPlugin,
 } from "@microsoft/applicationinsights-react-js";
-import { Open_Sans } from "next/font/google";
 import React, { ErrorInfo } from "react";
-import { MegaMenuLayout } from "ssw.megamenu";
 import { ErrorPage } from "./error-page";
-
-const openSans = Open_Sans({
-  variable: "--open-sans-font",
-  subsets: ["latin"],
-});
 
 class ErrorBoundary extends React.Component<
   { children?: React.ReactNode },
@@ -48,10 +41,7 @@ class ErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       return (
-        <div className={openSans.className}>
-          <div className="mx-auto max-w-9xl px-8">
-            <MegaMenuLayout />
-          </div>
+        <>
           <ErrorPage
             tipText={
               <div>
@@ -70,7 +60,7 @@ class ErrorBoundary extends React.Component<
               JSON.stringify(this.state.error.message, null, 2)
             }
           />
-        </div>
+        </>
       );
     }
 

--- a/components/util/error-boundary.tsx
+++ b/components/util/error-boundary.tsx
@@ -2,8 +2,15 @@ import {
   AppInsightsContext,
   ReactPlugin,
 } from "@microsoft/applicationinsights-react-js";
+import { Open_Sans } from "next/font/google";
 import React, { ErrorInfo } from "react";
+import { MegaMenuLayout } from "ssw.megamenu";
 import { ErrorPage } from "./error-page";
+
+const openSans = Open_Sans({
+  variable: "--open-sans-font",
+  subsets: ["latin"],
+});
 
 class ErrorBoundary extends React.Component<
   { children?: React.ReactNode },
@@ -41,24 +48,29 @@ class ErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       return (
-        <ErrorPage
-          tipText={
-            <div>
-              <p className="pt-4 text-xl">
-                For help, please submit a bug report issue on our GitHub at{" "}
-                <a href="https://github.com/SSWConsulting/SSW.Website/issues/new/choose">
-                  github.com/SSWConsulting/SSW.Website
-                </a>{" "}
-                or send us an email at{" "}
-                <a href="mailto:info@ssw.com.au">info@ssw.com.au</a>.
-              </p>
-            </div>
-          }
-          details={
-            this.state.error &&
-            JSON.stringify(this.state.error.message, null, 2)
-          }
-        />
+        <div className={openSans.className}>
+          <div className="mx-auto max-w-9xl px-8">
+            <MegaMenuLayout />
+          </div>
+          <ErrorPage
+            tipText={
+              <div>
+                <p className="pt-4 text-xl">
+                  For help, please submit a bug report issue on our GitHub at{" "}
+                  <a href="https://github.com/SSWConsulting/SSW.Website/issues/new/choose">
+                    github.com/SSWConsulting/SSW.Website
+                  </a>{" "}
+                  or send us an email at{" "}
+                  <a href="mailto:info@ssw.com.au">info@ssw.com.au</a>.
+                </p>
+              </div>
+            }
+            details={
+              this.state.error &&
+              JSON.stringify(this.state.error.message, null, 2)
+            }
+          />
+        </div>
       );
     }
 

--- a/components/util/error-page.tsx
+++ b/components/util/error-page.tsx
@@ -1,7 +1,5 @@
 import classNames from "classnames";
-import { NavMenuGroup } from "ssw.megamenu";
 import { CustomLink } from "../customLink";
-import { Layout } from "../layout";
 import { Container } from "./container";
 
 import { Disclosure } from "@headlessui/react";
@@ -10,9 +8,6 @@ import { BiChevronRight } from "react-icons/bi";
 import { FaXmark } from "react-icons/fa6";
 
 type ErrorPageProps = {
-  menu?: {
-    menuGroups: NavMenuGroup[];
-  };
   code?: string;
   title?: string;
   tipText?: React.ReactNode;
@@ -22,59 +17,57 @@ type ErrorPageProps = {
 
 export const ErrorPage = (props: ErrorPageProps) => {
   return (
-    <Layout menu={props.menu || { menuGroups: [] }}>
-      <Container
-        width="large"
-        size="custom"
-        className={classNames(
-          "w-full",
-          "select-none",
-          "bg-[url('/images/404/broken-chain.png')] bg-center bg-no-repeat md:bg-bottom"
-        )}
-      >
-        <div className="flex min-h-screen-4/5 flex-col md:flex-row">
-          <div className="px-7 pt-7">
-            <p className="text-center">
-              <span className="font-sans text-9xl font-extrabold leading-none text-sswRed">
-                {props.code || "Error"}
-              </span>
-            </p>
+    <Container
+      width="large"
+      size="custom"
+      className={classNames(
+        "w-full",
+        "select-none",
+        "bg-[url('/images/404/broken-chain.png')] bg-center bg-no-repeat md:bg-bottom"
+      )}
+    >
+      <div className="flex min-h-screen-4/5 flex-col md:flex-row">
+        <div className="px-7 pt-7">
+          <p className="text-center">
+            <span className="font-sans text-9xl font-extrabold leading-none text-sswRed">
+              {props.code || "Error"}
+            </span>
+          </p>
 
-            <div className="mx-auto">
-              <div className="my-4 bg-gray-200 px-5 py-4">
-                Visit{" "}
-                <CustomLink href="/" className="text-sswRed no-underline">
-                  SSW homepage
-                </CustomLink>{" "}
-                to find out how we can help you.
-              </div>
-
-              {props.code === "404" && (
-                <div className="my-4 bg-gray-200 px-5 py-4">
-                  Learn more about{" "}
-                  <CustomLink
-                    href="/rules/404-useful-error-page"
-                    className="text-sswRed no-underline"
-                  >
-                    having a useful 404 error page
-                  </CustomLink>
-                  .
-                </div>
-              )}
+          <div className="mx-auto">
+            <div className="my-4 bg-gray-200 px-5 py-4">
+              Visit{" "}
+              <CustomLink href="/" className="text-sswRed no-underline">
+                SSW homepage
+              </CustomLink>{" "}
+              to find out how we can help you.
             </div>
+
+            {props.code === "404" && (
+              <div className="my-4 bg-gray-200 px-5 py-4">
+                Learn more about{" "}
+                <CustomLink
+                  href="/rules/404-useful-error-page"
+                  className="text-sswRed no-underline"
+                >
+                  having a useful 404 error page
+                </CustomLink>
+                .
+              </div>
+            )}
           </div>
-
-          <div className="hidden grow md:block"></div>
-
-          <ErrorText
-            title={props.title}
-            tipText={props.tipText}
-            details={props.details}
-            exitButtonCallback={props.exitButtonCallback}
-          />
         </div>
-      </Container>
-    </Layout>
+
+        <div className="hidden grow md:block"></div>
+
+        <ErrorText
+          title={props.title}
+          tipText={props.tipText}
+          details={props.details}
+          exitButtonCallback={props.exitButtonCallback}
+        />
+      </div>
+    </Container>
   );
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,4 @@
-// import bundleAnalyser from "@next/bundle-analyzer";
+import bundleAnalyser from "@next/bundle-analyzer";
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -80,8 +80,8 @@ const config = {
   productionBrowserSourceMaps: true,
 };
 
-// const withBundleAnalyzer = bundleAnalyser({
-//   enabled: process.env.BUNDLE_ANALYSE === "true",
-// });
+const withBundleAnalyzer = bundleAnalyser({
+  enabled: process.env.BUNDLE_ANALYSE === "true",
+});
 
-export default config;
+export default withBundleAnalyzer(config);

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,11 +1,13 @@
+import { Layout } from "@/components/layout";
 import { ErrorPage } from "@/components/util/error-page";
-// import { InferGetStaticPropsType } from "next";
+import { InferGetStaticPropsType } from "next";
 import client from "../.tina/__generated__/client";
 
-export default function FourOhFour() {
-  // props: InferGetStaticPropsType<typeof getStaticProps>
+export default function FourOhFour(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
   return (
-    <>
+    <Layout menu={props.data.megamenu}>
       <ErrorPage
         code="404"
         title="PAGE NOT FOUND!"
@@ -13,7 +15,7 @@ export default function FourOhFour() {
           <>Sorry, we couldn&apos;t find the page you were looking for...</>
         }
       />
-    </>
+    </Layout>
   );
 }
 

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,15 +1,13 @@
 import { ErrorPage } from "@/components/util/error-page";
-import { InferGetStaticPropsType } from "next";
+// import { InferGetStaticPropsType } from "next";
 import client from "../.tina/__generated__/client";
 
-export default function FourOhFour(
-  props: InferGetStaticPropsType<typeof getStaticProps>
-) {
+export default function FourOhFour() {
+  // props: InferGetStaticPropsType<typeof getStaticProps>
   return (
     <>
       <ErrorPage
         code="404"
-        menu={props.data.megamenu}
         title="PAGE NOT FOUND!"
         tipText={
           <>Sorry, we couldn&apos;t find the page you were looking for...</>

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,12 +1,11 @@
 import { ErrorPage } from "@/components/util/error-page";
 import { useAppInsightsContext } from "@microsoft/applicationinsights-react-js";
-import { InferGetStaticPropsType } from "next";
+// import { InferGetStaticPropsType } from "next";
 import { useEffect } from "react";
 import client from "../.tina/__generated__/client";
 
-export default function FiveHundred(
-  props: InferGetStaticPropsType<typeof getStaticProps>
-) {
+export default function FiveHundred() {
+  // props: InferGetStaticPropsType<typeof getStaticProps>
   const appInsights = useAppInsightsContext();
 
   useEffect(() => {
@@ -21,13 +20,7 @@ export default function FiveHundred(
     }
   }, [appInsights]);
 
-  return (
-    <ErrorPage
-      code="500"
-      menu={props.data.megamenu}
-      title="INTERNAL SERVER ERROR!"
-    />
-  );
+  return <ErrorPage code="500" title="INTERNAL SERVER ERROR!" />;
 }
 
 export const getStaticProps = async () => {

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,11 +1,13 @@
+import { Layout } from "@/components/layout";
 import { ErrorPage } from "@/components/util/error-page";
 import { useAppInsightsContext } from "@microsoft/applicationinsights-react-js";
-// import { InferGetStaticPropsType } from "next";
+import { InferGetStaticPropsType } from "next";
 import { useEffect } from "react";
 import client from "../.tina/__generated__/client";
 
-export default function FiveHundred() {
-  // props: InferGetStaticPropsType<typeof getStaticProps>
+export default function FiveHundred(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
   const appInsights = useAppInsightsContext();
 
   useEffect(() => {
@@ -20,7 +22,11 @@ export default function FiveHundred() {
     }
   }, [appInsights]);
 
-  return <ErrorPage code="500" title="INTERNAL SERVER ERROR!" />;
+  return (
+    <Layout menu={props.data.megamenu}>
+      <ErrorPage code="500" title="INTERNAL SERVER ERROR!" />
+    </Layout>
+  );
 }
 
 export const getStaticProps = async () => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,7 +18,6 @@ import { NEXT_SEO_DEFAULT } from "../next-seo.config";
 // Hack as per https://stackoverflow.com/a/66575373 to stop font awesome icons breaking
 import "@fortawesome/fontawesome-svg-core/styles.css";
 
-import { ErrorBoundary } from "@/components/util/error-boundary";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import isBetween from "dayjs/plugin/isBetween";
@@ -84,9 +83,7 @@ const App = ({ Component, pageProps }) => {
       <DefaultSeo {...NEXT_SEO_DEFAULT} />
       <AppInsightsProvider>
         <QueryClientProvider client={queryClient}>
-          <ErrorBoundary key={router.asPath}>
-            <Component {...pageProps} />
-          </ErrorBoundary>
+          <Component {...pageProps} />
           {process.env.NODE_ENV === "development" && (
             <ReactQueryDevtools
               initialIsOpen={false}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,16 +1,19 @@
-import AOS from "aos";
 import "aos/dist/aos.css";
-import { DefaultSeo } from "next-seo";
-import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
 import "react-tooltip/dist/react-tooltip.css";
-import { Analytics } from "../components/layout/analytics";
-import * as gtag from "../lib/gtag";
-import { NEXT_SEO_DEFAULT } from "../next-seo.config";
 import "../styles.css";
 
+import AOS from "aos";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DefaultSeo } from "next-seo";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { Analytics } from "../components/layout/analytics";
 import { AppInsightsProvider } from "../context/app-insight-client";
+import * as gtag from "../lib/gtag";
+import { NEXT_SEO_DEFAULT } from "../next-seo.config";
 
 // Hack as per https://stackoverflow.com/a/66575373 to stop font awesome icons breaking
 import "@fortawesome/fontawesome-svg-core/styles.css";
@@ -22,7 +25,6 @@ import isBetween from "dayjs/plugin/isBetween";
 import relativeTime from "dayjs/plugin/relativeTime";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import dynamic from "next/dynamic";
 
 const FIVE_MINS = 1000 * 60 * 5;
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,4 @@
 import "aos/dist/aos.css";
-import "react-tooltip/dist/react-tooltip.css";
 import "../styles.css";
 
 import AOS from "aos";

--- a/styles.css
+++ b/styles.css
@@ -48,8 +48,6 @@
 }
 
 @layer components {
-  @import "aos/dist/aos.css";
-
   .icon::before {
     @apply inline-block;
     text-rendering: auto;


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

* Moved error boundary location to reduce the duplication of code, `<Layout>` used to be nested inside, which was causing the abnormally large bundle sizes

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/bbff117b-166e-4e60-8d61-f8c34897f6f1)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/c28a416f-e6b5-4139-81e9-c49bb17d2e75)
**Figure: After**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/734c14d4-a1b6-4466-a234-ac2154378bcf)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/89500dc8-2239-41e0-92ec-64664f158565)
**Figure: After**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/209f8b4b-70db-4d8a-9f65-5ea666c31f5d)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.Website/assets/20507092/1e5d3066-059b-4e1b-bef5-2cdbc8ab1a3f)
**Figure: After**

* Moved `react-tooltip` CSS from `_app.tsx` to where it's used

- Affected routes: `*`

- Fixed #2447 



