### PR TITLE
Consulting - Tina doesn't show up when filtering by CMS

### DIFF
--- a/content/consulting/index/index.json
+++ b/content/consulting/index/index.json
@@ -720,7 +720,15 @@
           "title": "TinaCMS",
           "description": "TinaCMS is the world's leading open source, headless CMS that is powered by Markdown and GitHub.",
           "logo": "/images/thumbs/tina-logo-icon.jpg",
-          "page": "content/consulting/tinacms.mdx"
+          "page": "content/consulting/tinacms.mdx",
+          "tags": [
+            {
+              "tag": "content/consulting/tag/web-development.json"
+            },
+            {
+              "tag": "content/consulting/tag/cms.json"
+            }
+          ]
         },
         {
           "title": "WordPress",


### PR DESCRIPTION
When I went to check the consulting list, Tina wouldn't show up under CMS.

So I fixed it.

- Affected routes: `/consulting`

~- [] Include done video or screenshots~


