### PR TITLE
🔍 Added meta descriptions to all User Group pages

### DIFF
--- a/content/netug/canberra.mdx
+++ b/content/netug/canberra.mdx
@@ -2,11 +2,8 @@
 seo:
   title: Canberra's .NET User Group
   description: >-
-    Attend the Melbourne .NET User Group meetings hosted by SSW to engage with
-    top experts in .NET, Azure, and DevOps. Explore advancements in full stack
-    and mobile development with .NET MAUI, uncover new industry trends, and
-    receive invaluable presentation tips. Perfect for developers looking to
-    boost their skills in Melbourne!
+    Join SSW’s Canberra User Group for monthly meetups on .NET, Azure, DevOps,
+    GitHub, MAUI, GitHub, SharePoint, and more.
 registerUrl: 'https://www.meetup.com/en-AU/canberra-net-user-group/'
 joinGithub:
   title: Canberra .NET User Group GitHub Discussions

--- a/content/netug/canberra.mdx
+++ b/content/netug/canberra.mdx
@@ -1,6 +1,12 @@
 ---
 seo:
   title: Canberra's .NET User Group
+  description: >-
+    Attend the Melbourne .NET User Group meetings hosted by SSW to engage with
+    top experts in .NET, Azure, and DevOps. Explore advancements in full stack
+    and mobile development with .NET MAUI, uncover new industry trends, and
+    receive invaluable presentation tips. Perfect for developers looking to
+    boost their skills in Melbourne!
 registerUrl: 'https://www.meetup.com/en-AU/canberra-net-user-group/'
 joinGithub:
   title: Canberra .NET User Group GitHub Discussions

--- a/content/netug/melbourne.mdx
+++ b/content/netug/melbourne.mdx
@@ -2,12 +2,8 @@
 seo:
   title: Melbourne's .NET User Group
   description: >- 
-   Join the Melbourne .NET User Group hosted by SSW every month
-   to connect with leading experts on .NET, Azure, DevOps, and more. Discover
-   the latest in full stack development and mobile apps with .NET MAUI, learn
-   about emerging industry trends, and get presentation tips from world-class
-   speakers. Elevate your development skills in Melbourne!
-
+   Join the SSW Melbourne User Group for monthly insights on .NET, Azure, 
+   DevOps, Maui GitHub, and more with industry leaders.
 registerUrl: 'https://www.meetup.com/en-AU/melbourne-net-user-group/'
 joinGithub:
   title: Melbourne .NET User Group GitHub Discussions

--- a/content/netug/melbourne.mdx
+++ b/content/netug/melbourne.mdx
@@ -1,6 +1,13 @@
 ---
 seo:
   title: Melbourne's .NET User Group
+  description: >- 
+   Join the Melbourne .NET User Group hosted by SSW every month
+   to connect with leading experts on .NET, Azure, DevOps, and more. Discover
+   the latest in full stack development and mobile apps with .NET MAUI, learn
+   about emerging industry trends, and get presentation tips from world-class
+   speakers. Elevate your development skills in Melbourne!
+
 registerUrl: 'https://www.meetup.com/en-AU/melbourne-net-user-group/'
 joinGithub:
   title: Melbourne .NET User Group GitHub Discussions

--- a/content/netug/sydney.mdx
+++ b/content/netug/sydney.mdx
@@ -6,10 +6,9 @@ joinUs:
 seo:
   title: Sydney's .NET User Group
   description: >-
-    Join SSW's Sydney .NET User Group monthly meetings to explore the latest in .NET, Azure,
-    GitHub, and more with top local and international experts. Dive into full stack and mobile
-    app development, learn industry trends, and gain presentation insights. Don’t miss out on
-    advancing your tech skills in Sydney!
+    Join SSW's Sydney .NET User Group monthly for the latest in .NET, Azure, 
+    DevOps, Github, MAUI and more with top experts. Learn trends and 
+    development insights. 
 registerUrl: 'https://www.meetup.com/en-AU/sydney-net-user-group/'
 joinGithub:
   title: Sydney .NET User Group GitHub Discussions

--- a/content/netug/sydney.mdx
+++ b/content/netug/sydney.mdx
@@ -5,6 +5,11 @@ joinUs:
   img: /images/people/ulysses.png
 seo:
   title: Sydney's .NET User Group
+  description: >-
+    Join SSW's Sydney .NET User Group monthly meetings to explore the latest in .NET, Azure,
+    GitHub, and more with top local and international experts. Dive into full stack and mobile
+    app development, learn industry trends, and gain presentation insights. Don’t miss out on
+    advancing your tech skills in Sydney!
 registerUrl: 'https://www.meetup.com/en-AU/sydney-net-user-group/'
 joinGithub:
   title: Sydney .NET User Group GitHub Discussions


### PR DESCRIPTION
Fixes #2485

- [x] Meta descriptions checked by @sethdaily 

### Description 
The Canberra, Melbourne and Sydney user group pages are all using the default meta description. This is affecting the site's SEO because all of the pages have the same meta description.


### Affected routes: 
- ssw.com.au/netug/melbourne
- ssw.com.au/netug/sydney
- ssw.com.au/netug/canberra
- Relevant Issue #2485 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template (N/A)

- [x] Include done video or screenshots



![image](https://github.com/SSWConsulting/SSW.Website/assets/65635198/4db57b47-0b05-4635-9eb9-e2bf1df559e9)
**Figure**: **❌Bad example - placeholder meta description being used for the Canberra UG page**
<br>
![image](https://github.com/SSWConsulting/SSW.Website/assets/65635198/90552f54-ea7d-4b7c-85d5-6210eb56f956)
**Figure** **✅Good example - custom meta description being used for ug Canberra page**