### PR TITLE
🔍 Added meta description for Hangzhou office page

### DIFF
--- a/content/offices/hangzhou.mdx
+++ b/content/offices/hangzhou.mdx
@@ -3,6 +3,9 @@ type: offices
 heading: SSW Hangzhou
 seo:
   title: SSW Hangzhou Directions
+  description: >-
+    Visit SSW's Hangzhou office for expert help in .Net, Scrum, AI, DevOps,
+    React, & Angular
 thumbnail: /images/offices/thumbnails/offices-hangzhou.jpg
 name: SSW Hangzhou Office
 streetAddress: >-
@@ -14,8 +17,9 @@ addressRegion: Zhejiang Province
 addressCountry: China
 postalCode: 310000
 phone: +86 571 8517 8910
-aboutUs: |
-  <VideoEmbed url="https://www.youtube.com/embed/BioFgITYAFY" caption="SSW Hangzhou - New Office Tour 2022" duration="4 mins" />
+aboutUs: >
+  <VideoEmbed url="https://www.youtube.com/embed/BioFgITYAFY" caption="SSW
+  Hangzhou - New Office Tour 2022" duration="4 mins" />
 localWebsiteLink:
   title: Visit our China website
   url: >-


### PR DESCRIPTION
### Description
A number of pages in our site are using the placeholder meta description we have in Tina. This affects our SEO because Google considers it duplicate content. Therefore I've replaced the placeholder meta description for the Hangzhou office page.

**Note**: I've had this meta description checked by @sethdaily 

- Affected routes: ssw.com.au/offices/hangzhou

- Fixed #2485 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [x] Include done video or screenshots
![image](https://github.com/SSWConsulting/SSW.Website/assets/65635198/906178c0-955a-4147-a15a-ee8154b0b19a)


