### PR TITLE
🔍 Added meta description to Strasbourg office page

### DIFF
--- a/content/offices/strasbourg.mdx
+++ b/content/offices/strasbourg.mdx
@@ -3,6 +3,9 @@ type: offices
 heading: SSW Strasbourg
 seo:
   title: SSW Strasbourg Directions
+  description: >-
+    Visit SSW's Strasbourg office for industry leading support in .NET, DevOps,
+    Azure, AI & Scrum
 thumbnail: /images/offices/thumbnails/offices-strasbourg.jpg
 name: SSW France Office
 streetAddress: Level 4 – 19 Rue du Fossé des Treize


### PR DESCRIPTION
### Description
The Strasbourg  office page was using the placeholder meta description which Google considers duplicate content. I've given it a unique meta description.

**Note**: Meta description checked by @sethdaily 

- Affected routes: ssw.com.au/offices/strasbourg

- Fixed #2485 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [x] Include done video or screenshots
![image](https://github.com/SSWConsulting/SSW.Website/assets/65635198/23fa259b-0cbe-44a9-b9ff-c4681b8f3719)


