### PR TITLE
fixed employment index page having multiple headings

### DIFF
--- a/content/employment/index.mdx
+++ b/content/employment/index.mdx
@@ -75,7 +75,7 @@ benefits:
         and in our office. We have a flexible policy where our people feel
         empowered.
 benefitsBody: >
-  # **Perks** of working at SSW
+  ## **Perks** of working at SSW
 
 
   Working for SSW has many excellent perks and benefits.
@@ -109,7 +109,7 @@ benefitsBody: >
   />
 
 
-  # **SSW Getaway** / Retreat
+  **SSW Getaway** / Retreat
 
 
   Once or twice a year the SSW folks and their families attend the SSW Getaway
@@ -129,7 +129,7 @@ benefitsBody: >
   link="https://www.youtube.com/playlist?list=PLpiOR7CBNvlr8T3fyYVxeKbmRp93xTCPM"
   />
 afterBody: >
-  # **Recruitment** process at SSW
+  ## **Recruitment** process at SSW
 
 
   <CustomImage src="/images/Employment/recruitment_doodle.png" altText="SSW
@@ -195,7 +195,7 @@ afterBody: >
     title=""
   />
 opportunitiesBody: >
-  # Current **opportunities**
+  ## Current **opportunities**
 
 
   You will be working with expert Microsoft stack developers and designers in a
@@ -212,7 +212,7 @@ opportunities:
   - opportunityRef: content/opportunities/DevOps-DotNET-Software-Engineer.mdx
   - opportunityRef: content/opportunities/Developers.mdx
 callToActionBody: >
-  # Don't fit any of the available positions?
+  Don't fit any of the available positions?
 
 
   ##### We may still be a match! Tell us why you want to join the SSW team.
@@ -222,7 +222,7 @@ callToActionBody: >
   link="mailto:pennywalker@ssw.com.au?subject=Employment" />
 ---
 
-# Things you will ❤️ about SSW
+## Things you will ❤️ about SSW
 
 <VideoEmbed url="https://www.youtube.com/watch?v=tWuutobJtdg" caption="Why work at SSW?" duration="9 mins" />
 


### PR DESCRIPTION
### Description
I was doing the weeklt SEMrush audit when i realized a number or our pages had duplicate h1 tags. 


- Affected routes: /employment

- Fixed #2485 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [ ] Include done video or screenshots


![image](https://github.com/SSWConsulting/SSW.Website/assets/65635198/b26167c4-eae7-45a0-a45e-6570b903543f)
**Figure**: Employment page using h2 for subheadings instead of h1

