### PR TITLE
Staging Slot - Enabling Health Check

### DIFF
--- a/infra/appService.bicep
+++ b/infra/appService.bicep
@@ -173,6 +173,7 @@ resource stagingSlot 'Microsoft.Web/sites/slots@2023-01-01' = {
     siteConfig: {
       appSettings: appSettings
       acrUseManagedIdentityCreds: true
+      healthCheckPath: healthCheckPath
     }
     clientAffinityEnabled: false
   }


### PR DESCRIPTION

- Fixed #2533 

I've added a health check for the Production slot. However, during the swap, the settings were also swapped, which inadvertently disabled the health check for the Production slot. With this PR, I'm enabling the Health Check for staging slot so that when it swaps, it will be enabled.

