### PR TITLE
Docker - Tagging Production ACR

### DIFF
--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -121,6 +121,9 @@ jobs:
 
       - name: Tag Production ACR Image
         run: |
+          # Pull the staging image from ACR
+          docker pull ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging
+
           # Tag the Docker image with the production tag
           docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
           ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production

--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -115,10 +115,21 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - run: |
+      - name: Tag Production ACR Image
+        run: |
+          # Tag the Docker image with the production tag
+          docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
+          ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
+
+      - name: Push Production ACR Image
+        run: |
+          # Push the newly tagged image to ACR
+          docker push ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
+
+      - name: ♻️ Swap slots
+        run: |
           az webapp deployment slot swap \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --name ${{ env.APP_SERVICE_NAME }} \
             --slot staging \
             --target-slot production
-        name: ♻️ Swap slots

--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -115,6 +115,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: ACR - Login
+        run: |
+          az acr login --name ${{ env.ACR_LOGIN_SERVER }}
+
       - name: Tag Production ACR Image
         run: |
           # Tag the Docker image with the production tag

--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -13,6 +13,10 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  SOURCE_IMG: staging
+  DESTINATION_IMG: production
+
 jobs:
   run-tests-and-coverage:
     name: Run tests & coverage
@@ -122,16 +126,16 @@ jobs:
       - name: Tag Production ACR Image
         run: |
           # Pull the staging image from ACR
-          docker pull ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging
+          docker pull ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ env.SOURCE_IMG }}
 
           # Tag the Docker image with the production tag
-          docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
-          ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
+          docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ env.SOURCE_IMG}} `
+          ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ env.DESTINATION_IMG }}
 
       - name: Push Production ACR Image
         run: |
           # Push the newly tagged image to ACR
-          docker push ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
+          docker push ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ env.DESTINATION_IMG }}
 
       - name: ♻️ Swap slots
         run: |

--- a/.github/workflows/weekly-acr-images-cleanup.yml
+++ b/.github/workflows/weekly-acr-images-cleanup.yml
@@ -43,6 +43,9 @@ jobs:
 
       - name: Tag Production ACR Image
         run: |
+          # Pull the staging image from ACR
+          docker pull ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging
+
           # Tag the Docker image with the production tag
           docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
           ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production

--- a/.github/workflows/weekly-acr-images-cleanup.yml
+++ b/.github/workflows/weekly-acr-images-cleanup.yml
@@ -1,6 +1,9 @@
 name: Weekly ACR images cleanup
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     # Monday at 2 PM UTC - https://cron.help/#0_14_*_*_MON
     - cron: "0 14 * * MON"
@@ -37,6 +40,17 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Tag Production ACR Image
+        run: |
+          # Tag the Docker image with the production tag
+          docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
+          ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
+
+      - name: Push Production ACR Image
+        run: |
+          # Push the newly tagged image to ACR
+          docker push ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
 
       - name: Delete all untagged images
         run: |

--- a/.github/workflows/weekly-acr-images-cleanup.yml
+++ b/.github/workflows/weekly-acr-images-cleanup.yml
@@ -41,6 +41,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: ACR - Login
+        run: |
+          az acr login --name ${{ env.ACR_LOGIN_SERVER }}
+
       - name: Tag Production ACR Image
         run: |
           # Pull the staging image from ACR

--- a/.github/workflows/weekly-acr-images-cleanup.yml
+++ b/.github/workflows/weekly-acr-images-cleanup.yml
@@ -1,9 +1,6 @@
 name: Weekly ACR images cleanup
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     # Monday at 2 PM UTC - https://cron.help/#0_14_*_*_MON
     - cron: "0 14 * * MON"
@@ -40,24 +37,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: ACR - Login
-        run: |
-          az acr login --name ${{ env.ACR_LOGIN_SERVER }}
-
-      - name: Tag Production ACR Image
-        run: |
-          # Pull the staging image from ACR
-          docker pull ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging
-
-          # Tag the Docker image with the production tag
-          docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
-          ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
-
-      - name: Push Production ACR Image
-        run: |
-          # Push the newly tagged image to ACR
-          docker push ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production
 
       - name: Delete all untagged images
         run: |

--- a/.github/workflows/weekly-acr-images-cleanup.yml
+++ b/.github/workflows/weekly-acr-images-cleanup.yml
@@ -47,6 +47,9 @@ jobs:
 
       - name: Tag Production ACR Image
         run: |
+          # Pull the staging image from ACR
+          docker pull ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging
+
           # Tag the Docker image with the production tag
           docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
           ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production

--- a/.github/workflows/weekly-acr-images-cleanup.yml
+++ b/.github/workflows/weekly-acr-images-cleanup.yml
@@ -47,9 +47,6 @@ jobs:
 
       - name: Tag Production ACR Image
         run: |
-          # Pull the staging image from ACR
-          docker pull ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging
-
           # Tag the Docker image with the production tag
           docker tag ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:staging `
           ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:production


### PR DESCRIPTION
Updates deployment pipeline to tag images with `production` when they are promoted to production

Fixed: #2568

**Screenshot:**

![image](https://github.com/SSWConsulting/SSW.Website/assets/71385247/0f779902-ffc5-4dda-b2eb-f762f35edbd3)

**Figure: Updated production tag with staging sha**

