### PR TITLE
Removed headings from technology cards and added descriptive blurbs

### DIFF
--- a/content/technologies/ai.mdx
+++ b/content/technologies/ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bots/AI
-name: ai
+name: AI logo
 readMoreSlug: 'https://www.ssw.com.au/consulting/artificial-intelligence'
 thumbnail: /images/thumbs/thumb-bots-ai-icon.png
 ---

--- a/content/technologies/ai.mdx
+++ b/content/technologies/ai.mdx
@@ -1,10 +1,8 @@
 ---
-name: ai
 title: Bots/AI
-thumbnail: /images/thumbs/thumb-bots-ai-icon.png
+name: ai
 readMoreSlug: 'https://www.ssw.com.au/consulting/artificial-intelligence'
+thumbnail: /images/thumbs/thumb-bots-ai-icon.png
 ---
 
-### Bots/AI
-
-SSW are experts at building mobile and cross platform chat apps. We have spent hours integrating, training, and fine-tuning advanced AI and AI chatbots into custom software solutions.
+We're AI experts at SSW. We have spent hours integrating, training, and fine-tuning advanced AI chatbots and integrating them into our mobile apps, cross-platform apps, and custom software solutions.

--- a/content/technologies/dotnet-maui.mdx
+++ b/content/technologies/dotnet-maui.mdx
@@ -1,10 +1,8 @@
 ---
-name: dotnet-maui
 title: .NET MAUI (was Xamarin)
+name: dotnet-maui
+readMoreSlug: null
 thumbnail: /images/thumbs/thumb-net-maui-icon.png
-readMoreSlug:
 ---
 
-### .NET MAUI (was Xamarin)
-
-.NET Multi-platform App UI (.NET MAUI) is a framework for building modern, multi-platform, natively compiled iOS, Android, macOS, and Windows apps using C### and XAML in a single codebase.
+.NET MAUI is a framework for building modern, multi-platform, natively compiled iOS, Android, macOS, and Windows apps using C# and XAML in a single codebase.

--- a/content/technologies/dotnet-maui.mdx
+++ b/content/technologies/dotnet-maui.mdx
@@ -1,6 +1,6 @@
 ---
 title: .NET MAUI (was Xamarin)
-name: dotnet-maui
+name: Dotnet MAUI logo
 readMoreSlug: null
 thumbnail: /images/thumbs/thumb-net-maui-icon.png
 ---

--- a/content/technologies/electron.mdx
+++ b/content/technologies/electron.mdx
@@ -1,10 +1,8 @@
 ---
-name: electron
 title: Electron
+name: electron
+readMoreSlug: null
 thumbnail: /images/thumbs/thumb-electron-icon.png
-readMoreSlug:
 ---
-
-### Electron
 
 Electron allows for the development of desktop GUI applications using web technologies: it combines the Chromium rendering engine and the Node.js runtime.

--- a/content/technologies/electron.mdx
+++ b/content/technologies/electron.mdx
@@ -1,6 +1,6 @@
 ---
 title: Electron
-name: electron
+name: Electron Logo
 readMoreSlug: null
 thumbnail: /images/thumbs/thumb-electron-icon.png
 ---

--- a/content/technologies/flutter.mdx
+++ b/content/technologies/flutter.mdx
@@ -1,10 +1,8 @@
 ---
-name: flutter
 title: Flutter
+name: flutter
+readMoreSlug: null
 thumbnail: /images/thumbs/thumb-flutter-banner.png
-readMoreSlug:
 ---
-
-### Flutter
 
 Flutter is Google's UI toolkit for building beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.

--- a/content/technologies/flutter.mdx
+++ b/content/technologies/flutter.mdx
@@ -1,6 +1,6 @@
 ---
 title: Flutter
-name: flutter
+name: Flutter logo
 readMoreSlug: null
 thumbnail: /images/thumbs/thumb-flutter-banner.png
 ---

--- a/content/technologies/hardware-integration.mdx
+++ b/content/technologies/hardware-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hardware Integration
-name: hardware-integration
+name: Hardware Integration logo
 readMoreSlug: null
 thumbnail: /images/thumbs/thumb-hardware-integration-icon.png
 ---

--- a/content/technologies/hardware-integration.mdx
+++ b/content/technologies/hardware-integration.mdx
@@ -1,10 +1,8 @@
 ---
-name: hardware-integration
 title: Hardware Integration
+name: hardware-integration
+readMoreSlug: null
 thumbnail: /images/thumbs/thumb-hardware-integration-icon.png
-readMoreSlug:
 ---
 
-### Hardware Integration
-
-Use hardware features in the phone such as GPS, cameras, rugged devices, RFID, and NFC.
+We use Phone hardware features such as GPS, cameras, rugged devices, RFID, and NFC to deliver high-quality, modern, intuitive mobile apps.

--- a/content/technologies/native-angular.mdx
+++ b/content/technologies/native-angular.mdx
@@ -1,6 +1,6 @@
 ---
 title: Angular and NativeScript
-name: native-angular
+name: Angular logo
 readMoreSlug: /consulting/angular
 thumbnail: /images/thumbs/thumb-angular-banner.png
 ---

--- a/content/technologies/native-angular.mdx
+++ b/content/technologies/native-angular.mdx
@@ -1,10 +1,8 @@
 ---
-name: native-angular
 title: Angular and NativeScript
-thumbnail: /images/thumbs/thumb-angular-banner.png
+name: native-angular
 readMoreSlug: /consulting/angular
+thumbnail: /images/thumbs/thumb-angular-banner.png
 ---
-
-### Angular and NativeScript
 
 Build rich native applications with the same toolkit as your responsive websites

--- a/content/technologies/native-app.mdx
+++ b/content/technologies/native-app.mdx
@@ -1,10 +1,8 @@
 ---
-name: native-app
 title: Hybrid vs Per-Platform Native
+name: native-app
+readMoreSlug: null
 thumbnail: /images/thumbs/thumb-native-apps-icon.png
-readMoreSlug:
 ---
 
-###  Hybrid vs Per-Platform Native
-
-Hybrid development take the web's most popular development frameworks and compiling the code into a native UI format for each relevant platform. This brings the best of both worlds - fast development and code reuse, using familiar technologies, and the performance and consistency of a native rendering engine.
+We use Hybrid development over per-platform native development. Hybrid development takes the web's most popular development frameworks and compiles the code into a native UI format for each relevant platform. This gives us the best of both worlds - fast development, code reuse, familiar technologies, and the performance and consistency of a native rendering.

--- a/content/technologies/native-app.mdx
+++ b/content/technologies/native-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hybrid vs Per-Platform Native
-name: native-app
+name: Native App logo
 readMoreSlug: null
 thumbnail: /images/thumbs/thumb-native-apps-icon.png
 ---

--- a/content/technologies/native-react.mdx
+++ b/content/technologies/native-react.mdx
@@ -1,10 +1,8 @@
 ---
-name: native-react
 title: React Native
-thumbnail: /images/thumbs/thumb-react-native-banner.png
+name: native-react
 readMoreSlug: /consulting/react
+thumbnail: /images/thumbs/thumb-react-native-banner.png
 ---
-
-### React Native
 
 Build native mobile apps using only JavaScript. It uses the same design as React, letting you compose a rich mobile UI from declarative components.

--- a/content/technologies/pwa.mdx
+++ b/content/technologies/pwa.mdx
@@ -1,10 +1,8 @@
 ---
-name: pwa
 title: Progressive Web Apps (PWAs)
+name: pwa
+readMoreSlug: null
 thumbnail: /images/thumbs/thumb-pwa-banner.png
-readMoreSlug:
 ---
-
-### Progressive Web Apps
 
 Building a high-quality Progressive Web App has incredible benefits, making it easy to delight your users, grow engagement and increase conversions.

--- a/content/technologies/pwa.mdx
+++ b/content/technologies/pwa.mdx
@@ -1,6 +1,6 @@
 ---
 title: Progressive Web Apps (PWAs)
-name: pwa
+name: Progressive Web Apps logo
 readMoreSlug: null
 thumbnail: /images/thumbs/thumb-pwa-banner.png
 ---

--- a/content/technologies/react-native.mdx
+++ b/content/technologies/react-native.mdx
@@ -1,6 +1,6 @@
 ---
 name: react-native
-title: React Native
+title: React Native logo
 thumbnail: /images/thumbs/thumb-react-native-banner.png
 readMoreSlug:
 ---

--- a/content/technologies/responsive-websites.mdx
+++ b/content/technologies/responsive-websites.mdx
@@ -1,10 +1,8 @@
 ---
-name: responsive-websites
 title: Responsive Websites
+name: responsive-websites
+readMoreSlug: null
 thumbnail: /images/thumbs/thumb-responsive-websites-icon.png
-readMoreSlug:
 ---
 
-### Responsive Websites
-
-Mobile-targeted websites using Responsive Design. Doesn't have an installable app, but is instead accessed through the phone's browser.
+We use Responsive Design to create mobile-targeted websites. These websites can't be installed through the app store but, still look great on mobile devices.

--- a/content/technologies/responsive-websites.mdx
+++ b/content/technologies/responsive-websites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Responsive Websites
-name: responsive-websites
+name: graphic containing 3 progressive smaller screns
 readMoreSlug: null
 thumbnail: /images/thumbs/thumb-responsive-websites-icon.png
 ---


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->


### Affected routes
https://ssw.com.au/consulting/tinacms
https://www.ssw.com.au/consulting/mobile-application-development

- Fixed #2481 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [x] Include done video or screenshots


![image](https://github.com/SSWConsulting/SSW.Website/assets/65635198/e2984dd4-8a33-4f8d-9610-e2c727911d0e)

**Figure**: **Before - technology cards use redundant and occasionally inconsistent headings**

![image](https://github.com/SSWConsulting/SSW.Website/assets/65635198/18c497ca-025a-4d4e-af05-95b593a0b557)

**Figure**: **After - technology cards use descriptive blurbs instead of headings**



