### PR TITLE
PR Linter - ensure TinaCMS changes have better PRs titles

### DIFF
--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -81,8 +81,3 @@ jobs:
           PR_COMMENT: |
             A great PR needs a great descriptive title
             Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information
-
-      - name: Generate summary
-        if: failure()
-        run: |
-          echo "PR title was not descriptive" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -8,10 +8,6 @@ concurrency:
   group: ci-${{ github.event.number }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: pwsh
-
 jobs:
   linked-issue-check:
     runs-on: ubuntu-latest
@@ -39,6 +35,7 @@ jobs:
           echo "sourceDiff=$SourceDiff" >> $env:GITHUB_OUTPUT
 
       - name: Non-content files - 📂
+        shell: pwsh
         run: |
           # Source Difference
           if ( ([string]::IsNullOrEmpty("${{ steps.check_file_changed.outputs.sourceDiff }}"))) {

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -64,11 +64,20 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Check if PR title is not default
+      - name: "Check if PR title is not default #1"
         uses: transferwise/actions-pr-checker@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NOT_CONTAINS_PATTERN: "TinaCMS content update"
+          PR_COMMENT: |
+            A great PR needs a great descriptive title
+            Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information
+
+      - name: "Check if PR title is not default #2"
+        uses: transferwise/actions-pr-checker@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NOT_CONTAINS_PATTERN: "Update from TinaCMS"
           PR_COMMENT: |
             A great PR needs a great descriptive title
             Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -64,20 +64,44 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: "Check if PR title is not default #1"
-        uses: transferwise/actions-pr-checker@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NOT_CONTAINS_PATTERN: "TinaCMS content update"
-          PR_COMMENT: |
-            A great PR needs a great descriptive title
-            Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information
+      - name: Get PR title
+        id: pr_title
+        run: |
+          # array of default PR titles
+          DEFAULT_TITLES=("TinaCMS content update" "Update from TinaCMS")
 
-      - name: "Check if PR title is not default #2"
-        uses: transferwise/actions-pr-checker@v3
+          # use gh cli to get the PR title
+          PR_TITLE=$(gh pr view ${{ github.event.number }} --json title --jq '.title')
+
+          # check if any of the default titles are found in the PR title
+          IS_DEFAULT=false
+          for title in "${DEFAULT_TITLES[@]}"; do
+            echo "Checking if PR title contains $title"
+            if [[ $PR_TITLE == *"$title"* ]]; then
+              echo "❌"
+              IS_DEFAULT=true
+              break
+            else
+              echo "✅"
+            fi
+          done
+
+          if [[ $IS_DEFAULT == true ]]; then
+            echo "Found default PR title" >> $GITHUB_STEP_SUMMARY
+            # exit with a non-zero status code to fail the job
+            exit 1
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NOT_CONTAINS_PATTERN: "Update from TinaCMS"
-          PR_COMMENT: |
+
+      - name: Comment on PR with insights
+        uses: mshick/add-pr-comment@v2
+        if: always()
+        with:
+          message-success: |
+            Great PR title! 🎉
+          message-failure: |
             A great PR needs a great descriptive title
             Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -60,6 +60,8 @@ jobs:
           echo "Linked issue: $success" >> $env:GITHUB_STEP_SUMMARY
           echo "success=$success" >> $env:GITHUB_OUTPUT
           echo "message=$message" >> $env:GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Get PR title
         id: pr_title

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -13,7 +13,7 @@ defaults:
     shell: pwsh
 
 jobs:
-  pr-lint:
+  linked-issue-check:
     runs-on: ubuntu-latest
     name: Check linked issues
     steps:
@@ -57,3 +57,18 @@ jobs:
       - name: Generate summary
         run: |
           echo "Found ${{ steps.check-linked-issues.outputs.linked_issues_count }} issues linked to PR" >> $GITHUB_STEP_SUMMARY
+
+  descriptive-pr-title-check:
+    runs-on: ubuntu-latest
+    name: Check descriptive PR title
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check if PR title is not default
+        uses: transferwise/actions-pr-checker@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NOT_CONTAINS_PATTERN: "TinaCMS content update"
+          PR_COMMENT: |
+            A great PR needs a great descriptive title
+            Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -72,3 +72,8 @@ jobs:
           PR_COMMENT: |
             A great PR needs a great descriptive title
             Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information
+
+      - name: Generate summary
+        if: failure()
+        run: |
+          echo "PR title was not descriptive" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -2,7 +2,7 @@ name: PR - Lint PR
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened]
 
 concurrency:
   group: ci-${{ github.event.number }}
@@ -18,9 +18,9 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Checking non-content changes - 🔎
+      - name: Checking for linked issues
         shell: pwsh
-        id: check_file_changed
+        id: check_linked_issues
         run: |
           # Diff HEAD with the previous commit
           $diff = git diff --name-only HEAD^ HEAD
@@ -28,40 +28,38 @@ jobs:
 
           # TODO: Next time we need to modify which directories we ignore, break this out to a variable which is easy to configure
 
-          $SourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/ISSUE_TEMPLATE/' }
-          $HasDiff = $SourceDiff.Length -gt 0
+          $sourceDiff = $diff | Where-Object { $_ -notmatch '^content/' -and $_ -notmatch '^public/' -and $_ -notmatch '^.github/ISSUE_TEMPLATE/' }
+          $hasCodeChanges = $sourceDiff.Length -gt 0
 
-          echo "hasCodeChanges=$HasDiff" >> $env:GITHUB_OUTPUT
-          echo "sourceDiff=$SourceDiff" >> $env:GITHUB_OUTPUT
+          echo "hasCodeChanges=$hasCodeChanges" >> $env:GITHUB_OUTPUT
+          echo "sourceDiff=$sourceDiff" >> $env:GITHUB_OUTPUT
 
-      - name: Non-content files - 📂
-        shell: pwsh
-        run: |
           # Source Difference
-          if ( ([string]::IsNullOrEmpty("${{ steps.check_file_changed.outputs.sourceDiff }}"))) {
+          if ( ([string]::IsNullOrEmpty($sourceDiff))) {
             echo "🏃 content change only - skipping lint action"
           }
           else {
-            echo "${{ steps.check_file_changed.outputs.sourceDiff }}"
+            echo $sourceDiff
           }
 
-      - uses: nearform-actions/github-action-check-linked-issues@v1.6.1
-        if: ${{steps.check_file_changed.outputs.hasCodeChanges == 'True' }}
-        id: check-linked-issues
-        with:
-          exclude-branches: "dependabot/**"
+          $success = $false
+          if ($hasCodeChanges) {
+            # use gh cli to check if PR has linked issues
+            $success = gh pr list --json linkedIssues --jq '.[].linkedIssues' | ConvertFrom-Json | Where-Object { $_ -ne $null } | ForEach-Object { $_.length -gt 0 }
+          } else {
+            $success = $true
+          }
 
-      - name: Generate summary
-        run: |
-          echo "Found ${{ steps.check-linked-issues.outputs.linked_issues_count }} issues linked to PR" >> $GITHUB_STEP_SUMMARY
+          if ($success) {
+            $message = ''
+          } else {
+            $message = 'Please make sure to link the issue(s) you are working on in the PR description.'
+          }
 
-  descriptive-pr-title-check:
-    runs-on: ubuntu-latest
-    name: Check descriptive PR title
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
+          echo "Success: $success"
+          echo "Linked issue: $success" >> $env:GITHUB_STEP_SUMMARY
+          echo "success=$success" >> $env:GITHUB_OUTPUT
+          echo "message=$message" >> $env:GITHUB_OUTPUT
 
       - name: Get PR title
         id: pr_title
@@ -87,39 +85,28 @@ jobs:
           done
 
           if [[ $IS_DEFAULT == true ]]; then
-            echo "Found default PR title" >> $GITHUB_STEP_SUMMARY
-            # exit with a non-zero status code to fail the job
-            exit 1
+            echo "PR title looks like a default" >> $GITHUB_STEP_SUMMARY
+            echo "message=Please update the PR title to be more descriptive - Check out https://www.ssw.com.au/rules/write-a-good-pull-request/for more information" >> $GITHUB_OUTPUT
+          else
+            echo "PR title looks good" >> $GITHUB_STEP_SUMMARY
+            echo "message=" >> $GITHUB_OUTPUT
           fi
+          success=!$IS_DEFAULT
+          echo "success=$success" >> $GITHUB_OUTPUT
+          echo "message=$message" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Comment on PR with insights
-        uses: mshick/add-pr-comment@v2
-        if: always()
-        with:
-          message-success: |
-            Great PR title! 🎉
-          message-failure: |
-            A great PR needs a great descriptive title
-            Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false
-
-  request-changes:
-    needs: [linked-issue-check, descriptive-pr-title-check]
-    runs-on: ubuntu-latest
-    name: Request changes
-    if: always()
-    permissions:
-      pull-requests: write
-    steps:
       - uses: ntsd/auto-request-changes-action@v3
         if: ${{ github.event.pull_request && failure() }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          review-message: |
+            ${{ steps.check_linked_issues.outputs.message }}
+            ${{ steps.pr_title.outputs.message }}
 
       - uses: hmarr/auto-approve-action@v3
         if: ${{ github.event.pull_request && success() }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          review-message: "LGTM 🚀"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -71,6 +71,7 @@ jobs:
 
           # use gh cli to get the PR title
           PR_TITLE=$(gh pr view ${{ github.event.number }} --json title --jq '.title')
+          echo "PR title: $PR_TITLE"
 
           # check if any of the default titles are found in the PR title
           IS_DEFAULT=false
@@ -104,3 +105,21 @@ jobs:
             Check out https://www.ssw.com.au/rules/write-a-good-pull-request/ for more information
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           allow-repeats: false
+
+  request-changes:
+    needs: [linked-issue-check, descriptive-pr-title-check]
+    runs-on: ubuntu-latest
+    name: Request changes
+    if: always()
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: ntsd/auto-request-changes-action@v3
+        if: ${{ github.event.pull_request && failure() }}
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - uses: hmarr/auto-approve-action@v3
+        if: ${{ github.event.pull_request && success() }}
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-lint-pr.yml
+++ b/.github/workflows/pr-lint-pr.yml
@@ -61,6 +61,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Get PR title
         id: pr_title
         run: |


### PR DESCRIPTION
too many prs are being accepted with default tina text "TinaCMS content update".

This made it difficult to track down a bug.

Adding a PR lint rule to ensure PRs are not merged when they have this title.

See below - adds a comment to the conversation with a link to rules to better prs

![CleanShot 2024-05-03 at 16 24 30](https://github.com/SSWConsulting/SSW.Website/assets/600044/17ce968c-4dac-475a-8a78-59ef1ef54691)


