### PR TITLE
Home - Fixing Banner height

### DIFF
--- a/components/blocks/carousel.tsx
+++ b/components/blocks/carousel.tsx
@@ -98,6 +98,7 @@ const CarouselItemImage = (props: CarouselItemImageProps) => {
         alt={label}
         height={388}
         width={1080}
+        sizes="100vw"
         priority={index === 0}
       />
       {/* `legend` required so that the carousel works properly */}

--- a/components/blocks/carousel.tsx
+++ b/components/blocks/carousel.tsx
@@ -98,7 +98,7 @@ const CarouselItemImage = (props: CarouselItemImageProps) => {
         alt={label}
         height={388}
         width={1080}
-        sizes="75vw"
+        sizes="100vw"
         priority={index === 0}
       />
       {/* `legend` required so that the carousel works properly */}

--- a/components/blocks/carousel.tsx
+++ b/components/blocks/carousel.tsx
@@ -98,7 +98,7 @@ const CarouselItemImage = (props: CarouselItemImageProps) => {
         alt={label}
         height={388}
         width={1080}
-        sizes="100vw"
+        sizes="75vw"
         priority={index === 0}
       />
       {/* `legend` required so that the carousel works properly */}

--- a/components/blocks/carousel.tsx
+++ b/components/blocks/carousel.tsx
@@ -92,14 +92,13 @@ const CarouselItemImage = (props: CarouselItemImageProps) => {
         carouselSchema,
         carouselBlock.items.value + `[${index}]`
       )}
-      className="h-97"
     >
       <Image
         src={imgSrc ?? ""}
         alt={label}
-        fill
+        height={388}
+        width={1080}
         priority={index === 0}
-        className="object-cover"
       />
       {/* `legend` required so that the carousel works properly */}
       <p className="legend sr-only">{label}</p>

--- a/components/blocks/serviceCards.tsx
+++ b/components/blocks/serviceCards.tsx
@@ -84,7 +84,8 @@ const BigCards = ({ title, cards, schema }) => {
                     src={card.imgSrc ?? ""}
                     width="100"
                     height="100"
-                    alt=""
+                    sizes="(max-width: 768px) 50vw, 33vw"
+                    alt={`Icon for ${card.title}`}
                   />
                 </div>
                 <div className="relative flex grow flex-col p-8">
@@ -162,7 +163,8 @@ const SmallCardContent = ({ card, schema, index }) => {
           src={card.imgSrc ?? ""}
           width="50"
           height="50"
-          alt=""
+          sizes="(max-width: 768px) 50vw, 33vw"
+          alt={`Icon for ${card.title}`}
         />{" "}
       </span>
       <h3

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,6 @@ const config = {
   poweredByHeader: false,
   images: {
     deviceSizes: [384, 640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-    formats: ["image/webp"],
     minimumCacheTTL: 60,
     remotePatterns: [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -78,6 +78,17 @@ const config = {
   },
   experimental: {
     optimizePackageImports: ["tinacms", "@fortawesome/fontawesome-svg-core"],
+    turbo: {
+      resolveExtensions: [
+        ".mdx",
+        ".tsx",
+        ".ts",
+        ".jsx",
+        ".js",
+        ".mjs",
+        ".json",
+      ],
+    },
   },
   productionBrowserSourceMaps: true,
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,8 @@ const config = {
   poweredByHeader: false,
   images: {
     deviceSizes: [384, 640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+    formats: ["image/webp"],
+    minimumCacheTTL: 60,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Fixed: #2588

Affected Route: `/`

Reverted the changes made by this pr - https://github.com/SSWConsulting/SSW.Website/pull/2531, we can't use `fill` with `object-fit:cover` as it will crop the image and as a result, some objects in the image will be cut off. 

✅ Also added Turbo in config to improve the local development
✅ Reducing the icons size to reduce the image load 
 
**Screenshot:**

![image](https://github.com/SSWConsulting/SSW.Website/assets/71385247/02572ad1-6f74-4628-b45e-6de7ab3b1a12)

**Figure: Banner image with fixed height and width**



