### PR TITLE
2515 updating menu links

### DIFF
--- a/components/filter/events.tsx
+++ b/components/filter/events.tsx
@@ -22,6 +22,7 @@ const EVENTS_JSON_LD_LIMIT = 5;
 
 interface EventsFilterProps {
   sidebarBody: TinaMarkdownContent;
+  defaultToPastTab?: boolean;
 }
 
 export type EventTrimmed = {
@@ -48,8 +49,11 @@ export type EventTrimmed = {
   EventShortDescription: string;
 };
 
-export const EventsFilter = ({ sidebarBody }: EventsFilterProps) => {
-  const [pastSelected, setPastSelected] = useState<boolean>(false);
+export const EventsFilter = ({
+  sidebarBody,
+  defaultToPastTab,
+}: EventsFilterProps) => {
+  const [pastSelected, setPastSelected] = useState<boolean>(defaultToPastTab);
 
   const {
     events,
@@ -78,7 +82,10 @@ export const EventsFilter = ({ sidebarBody }: EventsFilterProps) => {
       }
       groups={!pastSelected ? filters : pastFilters}
     >
-      <Tab.Group onChange={(index) => setPastSelected(index === 1)}>
+      <Tab.Group
+        onChange={(index) => setPastSelected(index === 1)}
+        defaultIndex={defaultToPastTab ? 1 : 0}
+      >
         <Tab.List className="mb-8 flex flex-row">
           <EventTab>Upcoming Events</EventTab>
           <EventTab>Past Events</EventTab>

--- a/content/megamenu/menu.json
+++ b/content/megamenu/menu.json
@@ -371,11 +371,6 @@
               "name": "Evaluation Survey",
               "url": "https://www.ssw.com.au/ssw/NETUG/Evaluation-Survey/",
               "widgetType": "standardLink"
-            },
-            {
-              "name": "Developer Links",
-              "url": "https://www.ssw.com.au/ssw/NETUG/Developerlinks.aspx",
-              "widgetType": "standardLink"
             }
           ]
         }

--- a/content/megamenu/menu.json
+++ b/content/megamenu/menu.json
@@ -364,7 +364,7 @@
             },
             {
               "name": "Past Sessions",
-              "url": "https://www.ssw.com.au/ssw/NETUG/PastSessions.aspx",
+              "url": "/events?past=1",
               "widgetType": "standardLink"
             },
             {

--- a/content/megamenu/menu.json
+++ b/content/megamenu/menu.json
@@ -368,8 +368,8 @@
               "widgetType": "standardLink"
             },
             {
-              "name": "Evaluation Survey",
-              "url": "https://www.ssw.com.au/ssw/NETUG/Evaluation-Survey/",
+              "name": "Past User Groups",
+              "url": "https://www.youtube.com/playlist?list=PLpiOR7CBNvlpmhfwQeIVhbqZKxV-do0wY",
               "widgetType": "standardLink"
             }
           ]

--- a/content/megamenu/menu.json
+++ b/content/megamenu/menu.json
@@ -212,7 +212,7 @@
             },
             {
               "name": "Report a bug",
-              "url": "https://www.ssw.com.au/ssw/Standards/Support/BugReportOrEnhancement.aspx",
+              "url": "https://www.ssw.com.au/rules/report-bugs-and-suggestions",
               "widgetType": "standardLink"
             }
           ]

--- a/pages/events/index.tsx
+++ b/pages/events/index.tsx
@@ -4,6 +4,7 @@ import {
   QueryClient,
   dehydrate,
 } from "@tanstack/react-query";
+import { useRouter } from "next/router";
 import * as appInsights from "applicationinsights";
 import { AxiosError } from "axios";
 import { EVENTS_QUERY_KEY } from "hooks/useFetchEvents";
@@ -29,6 +30,10 @@ export default function EventsIndexPage(
     variables: props.variables,
   });
 
+  const router = useRouter();
+  const defaultToPastTab =
+    new URLSearchParams(router.asPath.split(/\?/)[1]).get("past") === "1";
+
   return (
     <HydrationBoundary state={props.dehydratedState}>
       <SEO seo={data.eventsIndex.seo} />
@@ -43,7 +48,10 @@ export default function EventsIndexPage(
               />
             </div>
           </div>
-          <EventsFilter sidebarBody={data.eventsIndex.sidebarBody} />
+          <EventsFilter
+            sidebarBody={data.eventsIndex.sidebarBody}
+            defaultToPastTab={defaultToPastTab}
+          />
         </Container>
         <Blocks
           prefix="EventsIndexAfterEvents"


### PR DESCRIPTION
- Add query params to /events route to display past events on load
- Update MegaMenu link for Report a bug
- Update MegaMenu link for Past Sessions
- Change MegaMenu link from Evaluation Survey to Past User Groups
- Remove Developer Links link

- Affected routes: `/events` and all with MegaMenu

- Fixed #2515 

- [x] Include done video or screenshots

![image](https://github.com/SSWConsulting/SSW.Website/assets/87786621/eb9ffc37-cc37-4470-9f8c-1b60fd27db71)
**Figure: Changed items in MegaMenu (changes only viewable in Tina edit mode)**

![image](https://github.com/SSWConsulting/SSW.Website/assets/87786621/3649c654-c7fc-48dd-a8ea-e34cb5192b3c)
**Figure: Events page with querystring**

