### PR TITLE
💸 SEO | Fixing page titles

### DIFF
--- a/content/live/index.mdx
+++ b/content/live/index.mdx
@@ -1,4 +1,6 @@
 ---
+seo:
+  title: SSW Live Stream
 title: SSW <span class="text-sswRed">Live</span> Stream Channel
 nextEvent: Upcoming Session Details
 sswTvButton:

--- a/content/netug/index.mdx
+++ b/content/netug/index.mdx
@@ -1,6 +1,7 @@
 ---
 seo:
-  title: SSW User Groups Index
+  title: SSW User Groups
+  showBreadcrumb: true
 _template: contentPage
 ---
 
@@ -17,49 +18,49 @@ Every month SSW hosts the Sydney .NET User Group, where developers come together
     thumbnailAlt="Sydney .NET User Group"
     content={<>
     ### Sydney .NET User Group
-
+    
     Every month, SSW hosts the Sydney .NET User Group where developers meet to exchange ideas and listen to presentations by industry experts.
     </>}
     link="https://www.ssw.com.au/netug/sydney"
     />
-
+    
     <EventLink
     link="https://www.ssw.com.au/ssw/NETUG/Canberra.aspx"
     eventThumbnail="/images/events/canberra-ug-thumb.jpg"
     thumbnailAlt="Canberra .NET User Group"
     content={<>
     ### Canberra .NET User Group
-
+    
     Every month, SSW hosts the Canberra .NET User Group where developers meet to exchange ideas and listen to presentations by industry experts.
     </>}
     />
-
+    
     <EventLink
     link="https://www.ssw.com.au/netug/brisbane"
     eventThumbnail="/images/events/brisbane-ug-thumb.jpg"
     thumbnailAlt="Brisbane Full Stack User Group"
     content={<>
     ### Brisbane Full Stack User Group
-
+    
     Every month, SSW hosts the Brisbane Full Stack User Group where developers meet to exchange ideas and listen to presentations by industry experts.
     </>}
     />
-
-   <EventLink
+    
+    <EventLink
     content={<>
     ### Fire User Group  <Flag country="China" />
-
+    
     Every month, SSW hosts the Fire User Group, in Beijing and Hangzhou - China, where developers meet to exchange ideas and listen to presentations by industry experts.
     </>}
     eventThumbnail="/images/events/fire-ug-thumb.jpg"
     thumbnailAlt="Fire User Group"
     link="http://fireusergroup.com/"
     />
-
+    
     <EventLink
     content={<>
     ### Monthly SSW Newsletters
-
+    
     By signing up for our newsletter you'll be kept informed about the latest upcoming developer events and news.
     </>}
     link="https://www.ssw.com.au/newsletters"
@@ -69,40 +70,40 @@ Every month SSW hosts the Sydney .NET User Group, where developers come together
     <EventLink
     content={<>
     ### .NET User Group Livestream
-
+    
     Live every 3rd Wednesday of the month at 6PM AEDT (UTC+11). Join Sydney .NET UG from the comfort of your own home in your underpants.
     </>}
     link="https://www.ssw.com.au/ssw/NETUG/Live.aspx"
     eventThumbnail="/images/events/live-ug-thumb.jpg"
     thumbnailAlt=".NET User Group Livestream"
     />
-
+    
     <EventLink
     link="https://www.ssw.com.au/ssw/NETUG/Melbourne.aspx"
     eventThumbnail="/images/events/melbourne-ug-thumb.jpg"
     thumbnailAlt="Melbourne .NET User Group"
     content={<>
     ### Melbourne .NET User Group
-
+    
     Every month, SSW hosts the Melbourne .NET User Group where developers meet to exchange ideas and listen to presentations by industry experts.
     </>}
     />
-
+    
     <EventLink
     content={<>
     ### Gold Coast Azure .NET User Group
-
+    
     Every month, SSW hosts the Gold Coast Azure .NET User Group, where developers come together to learn about the latest technologies from local and internationally renowned experts.
     </>}
     link="/netug/gold-coast"
     eventThumbnail="/images/events/sydney-ug-thumb.jpg"
     thumbnailAlt="Gold Coast Azure .NET User Group "
     />
-
+    
     <EventLink
     content={<>
     ### User Group Evaluation Survey
-
+    
     Fill the form to evaluate the session you have attended.
     </>}
     link="https://www.ssw.com.au/ssw/NETUG/Evaluation-Survey/"

--- a/content/netug/present.mdx
+++ b/content/netug/present.mdx
@@ -1,10 +1,12 @@
 ---
-_template: contentPage
 seo:
   title: Present for the .NET User Group
+  showBreadcrumb: true
+_template: contentPage
 ---
 
 # I Would Like to Present at the .NET User Group
+
 Most speakers present in all cities - Melbourne, Brisbane, Newcastle and last is Sydney which is live streamed the recording is posted on [tv.ssw.com](https://tv.ssw.com/) a couple of days later.
 
 Every month the User Group is full of highly technical early adopters of technology and our attendees are always open to seeing presentations on the latest technologies. We welcome companies and guest presenters to present new topics and new gadgets. We do encourage you to delve beyond the sales and marketing pitch and show us how it was built, not just why it was built. Here's a quick list of some tips for presenters:
@@ -16,7 +18,7 @@ Every month the User Group is full of highly technical early adopters of technol
 * Send a summary of your presentation for inclusion into the SSW Newsletter (one week prior to the User Group)
 * Your session will be recorded by the guys from [SSW TV](https://tv.ssw.com/) straight from the projector cable. Very simpler for presenters
 
-If you think you're up for the challenge and have something new to show us please contact [Adam Cogan](mailto:info@ssw.com.au?subject=I%20Want%20To%20Present%20At%20The%20Sydney%20User%20Group).
+If you think you're up for the challenge and have something new to show us please contact [Adam Cogan](mailto\:info@ssw.com.au?subject=I%20Want%20To%20Present%20At%20The%20Sydney%20User%20Group).
 
 For the scheduled presenters, we will send you an email before the Sydney .NET User Group to remind you of things you need to bring/do.
 

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -292,6 +292,16 @@ export default function NETUGPage(
     return (
       <>
         <Layout menu={data.megamenu}>
+          <SEO seo={data.userGroupPage.seo} />
+          {data.userGroupPage.seo.showBreadcrumb && (
+            <Section className="mx-auto w-full max-w-9xl px-8 py-5">
+              <Breadcrumbs
+                path={removeExtension(props.variables.relativePath)}
+                suffix={data.global.breadcrumbSuffix}
+                title={data.userGroupPage.seo?.title}
+              />
+            </Section>
+          )}
           <Container className="prose py-4 prose-h1:pt-2" size="custom">
             <TinaMarkdown
               content={data.userGroupPage._body}


### PR DESCRIPTION
Semrush has detected pages with duplicate Page Titles. This PR addresses fixing 3 of those pages that shared a Page Title with the landing page.

- Adding in SEO and Breadcrumb component for /netug index pages
- Updating title for User Group page
- Adding title for Live page

- Affected routes: `/netug`, `/netug/present`, `/live`

- Related: #2602

- [x] Include done video or screenshots

![image](https://github.com/SSWConsulting/SSW.Website/assets/87786621/9c8a7761-7fdd-4f9d-a203-e78a408e56f1)**Figure: New title on `/netug`**

![image](https://github.com/SSWConsulting/SSW.Website/assets/87786621/89a735a1-7368-4c76-b928-4348984c3d78)**Figure: New title on `/netug/present`**

![image](https://github.com/SSWConsulting/SSW.Website/assets/87786621/46ba2219-f767-459d-ab42-0f3e3ca8aa74)**Figure: New title on `/live`**