### PR TITLE
SEMRUSH - Fixing old links & absolute links

### DIFF
--- a/content/company/news.mdx
+++ b/content/company/news.mdx
@@ -2,7 +2,7 @@
 seo:
   title: SSW News & Press - Australia's Leading .NET and Azure Consultants
   description: >-
-    SSW is a Microsoft gold certified company with a passion for AI that has 
+    SSW is a Microsoft gold certified company with a passion for AI that has
     been developing software since 1990. Check out some of our latest news.
 title: News & Press
 subTitle: >
@@ -49,7 +49,7 @@ subTitle: >
 
   This prestigious achievement is a testament to the incredible talent and
   commitment demonstrated by each member of our amazing team on the [Shepherd
-  Centre](https://www.ssw.com.au/SSW/Consulting/Case-Study/Shepherd-Centre.aspx)
+  Centre](/company/clients/shepherd-centre)
   project. We were finalists in the categories of Education and Inclusion
   Changemaker.
 
@@ -230,7 +230,7 @@ subTitle: >
 
 
   The Sydney office now is automated with the
-  [Control4](https://www.ssw.com.au/ssw/Consulting/Smart-Office-and-Smart-Home.aspx)
+  [Control4](/consulting/smart-office-and-smart-home)
   app. We can control shades, doors, air conditioners, lights, signage, secutiry
   alarms and much more with it.
 
@@ -240,8 +240,8 @@ subTitle: >
 
   **SSW User Groups** - Two more cities have been added to our monthly User
   Groups: [Melbourne .NET User
-  Group](https://www.ssw.com.au/ssw/NETUG/Melbourne.aspx) and the [Brisbane Full
-  Stack User Group](https://www.ssw.com.au/ssw/NETUG/Brisbane.aspx).
+  Group](/netug/melbourne) and the [Brisbane Full
+  Stack User Group](/netug/brisbane).
 
 
   ## NOV 2017 - SSW Hangzhou office is launched!
@@ -254,14 +254,14 @@ subTitle: >
   ## NOV 2017 - SSW Brisbane new location
 
 
-  [SSW Brisbane](https://www.ssw.com.au/ssw/Company/Offices/Brisbane/) moves
+  [SSW Brisbane](/netug/brisbane) moves
   into big and beautiful space on Adelaide St, overlooking the Storey Bridge.
 
 
   ## NOV 2017 - SSW Melbourne new location
 
 
-  [SSW Melbourne](https://www.ssw.com.au/ssw/Company/Offices/Melbourne/) moves
+  [SSW Melbourne](/netug/melbourne) moves
   into big and beautiful space on Little Bourke St, and can now run events.
 
 
@@ -647,7 +647,7 @@ subTitle: >
 
 
   ## JUN 2012 - [SSW is now running on TFS
-  2012](https://www.ssw.com.au/ssw/Consulting/ALM-TFS.aspx)
+  2012](https://www.ssw.com.au/consulting/alm-tooling)
 
 
   As far as we know, SSW is the first company in the world to upgrade to TFS
@@ -1111,7 +1111,7 @@ subTitle: >
 
 
   SSW renames User Group to be the ['Sydney .NET User
-  Group'](https://www.ssw.com.au/SSW/NETUG/Sydney.aspx).
+  Group'](/netug/sydney).
 
 
   ## 2001 - 'Leverage the Power of Rich Windows Applications'


### PR DESCRIPTION
Fix #2669

Affected Route: `/company/news`

