### PR TITLE
Cleanup - Remove broken link in newsletters

### DIFF
--- a/appInsight-api.js
+++ b/appInsight-api.js
@@ -12,8 +12,9 @@ if (!!process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING) {
   appInsights.defaultClient.addTelemetryProcessor((envelope, context) => {
     if (envelope.data.baseType === "RequestData") {
       envelope.data.baseData.properties ??= {};
-      envelope.data.baseData.properties.userAgent =
-        context["http.ServerRequest"].headers["user-agent"];
+      if (context["http.ServerRequest"].headers["user-agent"])
+        envelope.data.baseData.properties.userAgent =
+          context["http.ServerRequest"].headers["user-agent"];
     }
   });
   appInsights.start();

--- a/public/images/newsletter-uploads/2023/_2023_01__Adams 2022 - A Year in Review__.html
+++ b/public/images/newsletter-uploads/2023/_2023_01__Adams 2022 - A Year in Review__.html
@@ -20,8 +20,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
     <style type="text/css">
         /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_02__5 Key Video Production Editing Terms (aka speak the lingo of a videographer)!__.html
+++ b/public/images/newsletter-uploads/2023/_2023_02__5 Key Video Production Editing Terms (aka speak the lingo of a videographer)!__.html
@@ -20,8 +20,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
     <style type="text/css">
         /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_03__Managing your Azure Costs – How to Avoid Ballooning Budgets__.html
+++ b/public/images/newsletter-uploads/2023/_2023_03__Managing your Azure Costs – How to Avoid Ballooning Budgets__.html
@@ -20,8 +20,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
     <style type="text/css">
         /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_04__Introducing SSW’s Cultural Exchange__.html
+++ b/public/images/newsletter-uploads/2023/_2023_04__Introducing SSW’s Cultural Exchange__.html
@@ -20,8 +20,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
     <style type="text/css">
         /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_05__Unleash the Power of ChatGPT - SSW's Ultimate Cheat Sheet__.html
+++ b/public/images/newsletter-uploads/2023/_2023_05__Unleash the Power of ChatGPT - SSW's Ultimate Cheat Sheet__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_06__NDC Oslo – Introducing the best of ChatGPT and Open AI API to the Vikings__.html
+++ b/public/images/newsletter-uploads/2023/_2023_06__NDC Oslo – Introducing the best of ChatGPT and Open AI API to the Vikings__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_07__Microsoft Fabric – Unifying your Data Analytics__.html
+++ b/public/images/newsletter-uploads/2023/_2023_07__Microsoft Fabric – Unifying your Data Analytics__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_08__Solving Business Puzzles with Tech A Look at SSW Melbourne’s Brainstorming Day and Retreat__.html
+++ b/public/images/newsletter-uploads/2023/_2023_08__Solving Business Puzzles with Tech A Look at SSW Melbourne’s Brainstorming Day and Retreat__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_09__Combine AI Models and Custom Software with Microsoft’s Semantic Kernel__.html
+++ b/public/images/newsletter-uploads/2023/_2023_09__Combine AI Models and Custom Software with Microsoft’s Semantic Kernel__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_10__Unleashing GPT-Powered Website ChatBots__.html
+++ b/public/images/newsletter-uploads/2023/_2023_10__Unleashing GPT-Powered Website ChatBots__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_11__Effective Feedback When and How to Offer It__.html
+++ b/public/images/newsletter-uploads/2023/_2023_11__Effective Feedback When and How to Offer It__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2023/_2023_12__.NET Aspire – The Future of Microservices made simple for .NET 8__.html
+++ b/public/images/newsletter-uploads/2023/_2023_12__.NET Aspire – The Future of Microservices made simple for .NET 8__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2024/_2024_01__Adams 2023 - Year in Review__.html
+++ b/public/images/newsletter-uploads/2024/_2024_01__Adams 2023 - Year in Review__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2024/_2024_02__NDC Sydney 2024 - so many Microsoft Heavyweights__.html
+++ b/public/images/newsletter-uploads/2024/_2024_02__NDC Sydney 2024 - so many Microsoft Heavyweights__.html
@@ -16,8 +16,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2024/_2024_03__.NET Migrations Made Easy__.html
+++ b/public/images/newsletter-uploads/2024/_2024_03__.NET Migrations Made Easy__.html
@@ -20,8 +20,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
     <style type="text/css">
         /* Outlook link fix */

--- a/public/images/newsletter-uploads/2024/_2024_04__AI Saved My Life - My Melanoma Journey__.html
+++ b/public/images/newsletter-uploads/2024/_2024_04__AI Saved My Life - My Melanoma Journey__.html
@@ -19,8 +19,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
     <style type="text/css">
         /* Outlook link fix */

--- a/public/images/newsletter-uploads/2024/_2024_05__Announcing the SSW Clean Architecture Template__.html
+++ b/public/images/newsletter-uploads/2024/_2024_05__Announcing the SSW Clean Architecture Template__.html
@@ -15,8 +15,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */

--- a/public/images/newsletter-uploads/2024/_2024_05__SSW purchases TinaCMS – the No 1 CMS on GitHub – we love Markdown__.html
+++ b/public/images/newsletter-uploads/2024/_2024_05__SSW purchases TinaCMS – the No 1 CMS on GitHub – we love Markdown__.html
@@ -15,8 +15,6 @@
 
     <meta name="color-scheme" content="light dark">
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */
@@ -352,8 +350,6 @@
     <title>SSW purchases TinaCMS – the #1 CMS on GitHub – we love Markdown ❤️</title>
 
     <meta name="color-scheme" content="light dark">
-
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
 
 
           <style type="text/css">

--- a/public/images/newsletter-uploads/_2023_11__Effective Feedback When and How to Offer It__.html
+++ b/public/images/newsletter-uploads/_2023_11__Effective Feedback When and How to Offer It__.html
@@ -16,8 +16,6 @@
     <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 
-    <link href="./10 Security Tips for CEOs and SysAdmins_files/css" rel="stylesheet" type="text/css">
-
 
           <style type="text/css">
             /* Outlook link fix */


### PR DESCRIPTION
- Removed the reference to a non-existent link tag which was causing failed requests on some newsletters
- Adding guard to prevent console errors on client side logging. Introduced in #2670 

- Affected routes: 
  - `images/newsletter-uploads/2023/*`
  - `images/newsletter-uploads/2024/*`

- Fixed #2668 

- [ ] Include done video or screenshots
TODO
