### PR TITLE
Fixing broken image link

### DIFF
--- a/components/company/rdPanel.tsx
+++ b/components/company/rdPanel.tsx
@@ -9,7 +9,7 @@ export const RDPanel = () => {
         Australia!
       </strong>
       <Image
-        src="/images/company/regional-director.png"
+        src="/images/company/Microsoft_Regional_Director.png"
         alt="Microsoft Regional Director logo"
         width={124}
         height={50}


### PR DESCRIPTION
A linked image was removed in #2432
Updating that image reference to the same image with a different name

- Affected routes: `/company/about-us`

- Related #2695 

- [ ] Include done video or screenshots
TODO

