### PR TITLE
🔒Events - added access control allow origin header for the ssw poeple staging environment

### DIFF
--- a/app/api/events/past/route.ts
+++ b/app/api/events/past/route.ts
@@ -13,6 +13,8 @@ export async function GET(req: NextRequest) {
     status: 200,
     headers: {
       "Content-Type": "application/json",
+      "Access-Control-Allow-Origin":
+        "https://sapeoplestagjthgmptzb46i.z8.web.core.windows.net",
     },
   });
 }

--- a/app/api/events/upcoming/route.ts
+++ b/app/api/events/upcoming/route.ts
@@ -14,6 +14,8 @@ export async function GET(req: NextRequest) {
     status: 200,
     headers: {
       "Content-Type": "application/json",
+      "Access-Control-Allow-Origin":
+        "https://sapeoplestagjthgmptzb46i.z8.web.core.windows.net",
     },
   });
 }


### PR DESCRIPTION
### Description

We need to test the events APIs in the staging environment for SSW People but the requests are being blocked by CORS since the staging environment is a different domain to SSW People,

- Fixed [#2785](https://github.com/SSWConsulting/SSW.Website/issues/2785)