### PR TITLE
💄 Update AboutUs to have a HideMap feature

### DIFF
--- a/components/blocks/aboutUs.tsx
+++ b/components/blocks/aboutUs.tsx
@@ -133,7 +133,7 @@ export const AboutUs = ({ data }) => {
                 setMapClickedTrigger={setMapClickedTrigger}
                 mapClickedTrigger={mapClickedTrigger}
               />
-              {(!data.hideMap ?? false) && (
+              {(data.showMap ?? true) && (
                 <Map
                   className="hidden sm:block"
                   offices={offices}
@@ -472,8 +472,9 @@ export const aboutUsBlockSchema: Template = {
     },
     {
       type: "boolean",
-      label: "Hide Map",
-      name: "hideMap",
+      label: "Show Map",
+      name: "showMap",
+      required: false,
     },
   ],
 };

--- a/components/blocks/aboutUs.tsx
+++ b/components/blocks/aboutUs.tsx
@@ -118,7 +118,9 @@ export const AboutUs = ({ data }) => {
         <div className="grid grid-cols-3 gap-6">
           <TV className="col-span-3 max-md:hidden sm:col-span-1" />
           <div className="col-span-3 md:col-span-2">
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            <div
+              className={`grid grid-cols-1 gap-6 ${!data.hideMap ? "sm:grid-cols-2" : ""}`}
+            >
               <ContactUs
                 className=""
                 offices={offices}
@@ -131,17 +133,19 @@ export const AboutUs = ({ data }) => {
                 setMapClickedTrigger={setMapClickedTrigger}
                 mapClickedTrigger={mapClickedTrigger}
               />
-              <Map
-                className="hidden sm:block"
-                offices={offices}
-                selectedOffice={selectedOffice}
-                setSelectedOffice={setSelectedOffice}
-                stateBeingHovered={stateBeingHovered}
-                setOfficeBeingHovered={setOfficeBeingHovered}
-                setStateBeingHovered={setStateBeingHovered}
-                setMapHoveredTrigger={setMapHoveredTrigger}
-                setMapClickedTrigger={setMapClickedTrigger}
-              />
+              {(!data.hideMap ?? false) && (
+                <Map
+                  className="hidden sm:block"
+                  offices={offices}
+                  selectedOffice={selectedOffice}
+                  setSelectedOffice={setSelectedOffice}
+                  stateBeingHovered={stateBeingHovered}
+                  setOfficeBeingHovered={setOfficeBeingHovered}
+                  setStateBeingHovered={setStateBeingHovered}
+                  setMapHoveredTrigger={setMapHoveredTrigger}
+                  setMapClickedTrigger={setMapClickedTrigger}
+                />
+              )}
             </div>
           </div>
         </div>
@@ -465,6 +469,11 @@ export const aboutUsBlockSchema: Template = {
         { label: "Red", value: "red" },
         { label: "Black", value: "black" },
       ],
+    },
+    {
+      type: "boolean",
+      label: "Hide Map",
+      name: "hideMap",
     },
   ],
 };

--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -101,6 +101,7 @@ sideBar:
     _template: UpcomingEvents
 afterBody:
   - backgroundColor: lightgray
+    hideMap: false
     _template: AboutUs
   - content: >
       <ClientLogos />

--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -101,7 +101,7 @@ sideBar:
     _template: UpcomingEvents
 afterBody:
   - backgroundColor: lightgray
-    hideMap: false
+    showMap: true
     _template: AboutUs
   - content: >
       <ClientLogos />


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

Temporary compromise for #2867 
- Affected routes: /<!-- E.g. `/offices/brisbane`  -->

Adds the ability to hide/show the Map in the AboutUs.tsx. This is in order to hopefully let ssw.fr add the accordion to their site, and include links to all other offices.

- [x] Include done video or screenshots

![image](https://github.com/user-attachments/assets/ef329125-9e1b-4e49-8040-4dfaf90642e3)


