### PR TITLE
🔗Articles - Added profile link to articles template

### DIFF
--- a/components/articles/articleAuthor.tsx
+++ b/components/articles/articleAuthor.tsx
@@ -22,9 +22,9 @@ const ArticleAuthor = ({ name, position, image, url }: ArticleAuthorProps) => {
       )}
       <div className="font-semibold uppercase">
         {url ? (
-          <a className="no-underline" href={url}>
+          <Link className="no-underline" href={url}>
             {name}
-          </a>
+          </ Link>
         ) : (
           <>{name}</>
         )}

--- a/components/articles/articleAuthor.tsx
+++ b/components/articles/articleAuthor.tsx
@@ -25,7 +25,7 @@ const ArticleAuthor = ({ name, position, image, url }: ArticleAuthorProps) => {
         {url ? (
           <Link className="no-underline" href={url}>
             {name}
-          </ Link>
+          </Link>
         ) : (
           <>{name}</>
         )}

--- a/components/articles/articleAuthor.tsx
+++ b/components/articles/articleAuthor.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Image from "next/image";
+import Link from "next/link";
 
 type ArticleAuthorProps = {
   name?: string;

--- a/components/articles/articleAuthor.tsx
+++ b/components/articles/articleAuthor.tsx
@@ -1,14 +1,14 @@
 "use client";
-
 import Image from "next/image";
 
 type ArticleAuthorProps = {
   name?: string;
   position: string;
   image?: string;
+  url?: string;
 };
 
-const ArticleAuthor = ({ name, position, image }: ArticleAuthorProps) => {
+const ArticleAuthor = ({ name, position, image, url }: ArticleAuthorProps) => {
   return (
     <div className="flex flex-row items-center gap-2 py-1">
       {image && (
@@ -20,7 +20,15 @@ const ArticleAuthor = ({ name, position, image }: ArticleAuthorProps) => {
           className="size-10 rounded-full object-cover"
         />
       )}
-      <div className="font-semibold uppercase">{name}</div>
+      <div className="font-semibold uppercase">
+        {url ? (
+          <a className="no-underline" href={url}>
+            {name}
+          </a>
+        ) : (
+          <>{name}</>
+        )}
+      </div>
 
       {position && (
         <>

--- a/pages/articles/[filename].tsx
+++ b/pages/articles/[filename].tsx
@@ -68,6 +68,7 @@ export default function ArticlesPage(
               name={author?.presenter?.name}
               position={author?.position}
               image={author?.profileImg}
+              url={author?.presenter?.peopleProfileURL}
             />
           </Section>
         )}

--- a/styles.css
+++ b/styles.css
@@ -4,9 +4,11 @@
 
 @layer base {
   a:not(.unstyled) {
-    @apply underline transition duration-300 hover:border-sswRed hover:text-sswRed;
+    @apply transition duration-300 hover:border-sswRed hover:text-sswRed;
   }
-
+  a:not(.no-underline) {
+    @apply underline;
+  }
   html,
   body {
     @apply scroll-smooth;

--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@
   a:not(.unstyled) {
     @apply transition duration-300 hover:border-sswRed hover:text-sswRed;
   }
-  a:not(.no-underline) {
+  a:not(.no-underline)a:not(.unstyled) {
     @apply underline;
   }
   html,


### PR DESCRIPTION
- Affected routes: /articles/*

### Description

This PR adds a link to the author's people profile. If the author does not have a people profile link their name will not be clickable. 

- Fixed #2782 

![presenter-no-url-vs-presenter-url](https://github.com/user-attachments/assets/1414f4d9-4008-43f6-b99a-42deed37f5ee)

**Figure**: **Author with People profile URL (left) vs author with no People profile URL (right)**


![clicking Adam's People profile link](https://github.com/user-attachments/assets/6dd8f7f0-71e3-470c-9333-3e477c7064df)

**Figure**: **Article by Adam linking to his people profile**