### PR TITLE
2911 update health check sitemap links

### DIFF
--- a/components/layout/footer/site-info.tsx
+++ b/components/layout/footer/site-info.tsx
@@ -6,14 +6,14 @@ export const SiteInfo = () => (
   <div>
     <CustomLink
       // TODO: Implementation
-      href="https://www.ssw.com.au/ssw/MenuMap.aspx"
+      href="/ssw/MenuMap.aspx"
     >
       SITEMAP
     </CustomLink>
     <Divider />
     <CustomLink
       // TODO: Implementation
-      href="https://www.ssw.com.au/ssw/HealthCheck"
+      href="/ssw/HealthCheck"
     >
       HEALTH CHECK
       <Image

--- a/components/layout/footer/site-info.tsx
+++ b/components/layout/footer/site-info.tsx
@@ -5,14 +5,14 @@ import { Divider } from "./divider";
 export const SiteInfo = () => (
   <div>
     <CustomLink
-      // TODO: Implementation
+      // TODO: Implementation https://github.com/SSWConsulting/SSW.Website/issues/2913
       href="/ssw/MenuMap.aspx"
     >
       SITEMAP
     </CustomLink>
     <Divider />
     <CustomLink
-      // TODO: Implementation
+      // TODO: Implementation https://github.com/SSWConsulting/SSW.Website/issues/2914
       href="/ssw/HealthCheck"
     >
       HEALTH CHECK

--- a/components/layout/footer/site-info.tsx
+++ b/components/layout/footer/site-info.tsx
@@ -6,14 +6,14 @@ export const SiteInfo = () => (
   <div>
     <CustomLink
       // TODO: Implementation https://github.com/SSWConsulting/SSW.Website/issues/2913
-      href="/ssw/MenuMap.aspx"
+      href="/sitemap"
     >
       SITEMAP
     </CustomLink>
     <Divider />
     <CustomLink
       // TODO: Implementation https://github.com/SSWConsulting/SSW.Website/issues/2914
-      href="/ssw/HealthCheck"
+      href="/healthcheck"
     >
       HEALTH CHECK
       <Image

--- a/content/pages/booknow.mdx
+++ b/content/pages/booknow.mdx
@@ -1,7 +1,10 @@
 ---
 seo:
   title: Book Now | SSW Consulting Services
-  description: Book your consultation with SSW, Australia's leading software development company. Secure your spot today for expert tech solutions.
+  description: >-
+    Book your consultation with SSW, Australia's leading software development
+    company. Secure your spot today for expert tech solutions.
+breadcrumbs: false
 subTitle: ''
 beforeBody:
   - title: Event Booking Coming Soon!

--- a/content/pages/healthcheck.mdx
+++ b/content/pages/healthcheck.mdx
@@ -1,0 +1,15 @@
+---
+seo:
+  title: Health Check | SSW Website
+  description: >-
+    A page for monitoring the overall health of our website, in terms of disk
+    usage, memory usage, link health and more!
+subTitle: ''
+beforeBody:
+  - title: HealthCheck Coming Soon!
+    content: "**Watch this space :)**\n\nTODO: [\U0001F496HealthCheck - Add a dedicated page for performing health checks](https://github.com/SSWConsulting/SSW.Website/issues/2914 \"\U0001F496Healthcheck - Add a dedicated page for performing health checks\")\n"
+    align: center
+    _template: Content
+showAzureFooter: true
+---
+

--- a/content/pages/menumap.mdx
+++ b/content/pages/menumap.mdx
@@ -1,0 +1,38 @@
+---
+seo:
+  title: Site Map | SSW Website
+  description: >-
+    A placeholder page for the menu map containing all of the links on our site.
+    Stay tuned for more!
+  showBreadcrumb: true
+breadcrumbs: true
+title: ''
+subTitle: ''
+beforeBody:
+  - title: Sitemap Coming Soon!
+    content: >
+      Watch this space :)\
+
+      \
+
+      TODO: [✨ Sitemap - Add a page compiling all links on the
+      site](https://github.com/SSWConsulting/SSW.Website/issues/2913 "✨ Sitemap
+      - Add a page compiling all links on the site")
+
+
+      For hot tips about our best practices go to [www.ssw.com.au/rules](/rules
+      "SSW Rules")
+
+
+      To learn more about our employees go to[ www.ssw.com.au/people](/people
+      "SSW People")
+
+
+      To get in contact with Us click the button below.
+    align: center
+    _template: Content
+  - buttonText: Book a FREE Initial Meeting
+    _template: BookingButton
+showAzureFooter: true
+---
+

--- a/content/pages/sitemap.mdx
+++ b/content/pages/sitemap.mdx
@@ -5,13 +5,13 @@ seo:
     A placeholder page for the menu map containing all of the links on our site.
     Stay tuned for more!
   showBreadcrumb: true
-breadcrumbs: true
+breadcrumbs: false
 title: ''
 subTitle: ''
 beforeBody:
   - title: Sitemap Coming Soon!
     content: >
-      Watch this space :)\
+      **Watch this space :)**\
 
       \
 
@@ -20,15 +20,10 @@ beforeBody:
       - Add a page compiling all links on the site")
 
 
-      For hot tips about our best practices go to [www.ssw.com.au/rules](/rules
-      "SSW Rules")
+      For hot tips about our best practices go to [SSW Rules]()
 
 
-      To learn more about our employees go to[ www.ssw.com.au/people](/people
-      "SSW People")
-
-
-      To get in contact with Us click the button below.
+      Learn more about our employees on [SSW People](/people "SSW People")
     align: center
     _template: Content
   - buttonText: Book a FREE Initial Meeting

--- a/content/pages/sitemap.mdx
+++ b/content/pages/sitemap.mdx
@@ -20,7 +20,7 @@ beforeBody:
       - Add a page compiling all links on the site")
 
 
-      For hot tips about our best practices go to [SSW Rules]()
+      Check out all our best practices on [SSW Rules](/rules)
 
 
       Learn more about our employees on [SSW People](/people "SSW People")

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@next/eslint-plugin-next": "14.2.5",
-    "@playwright/test": "1.44.1",
+    "@playwright/test": "1.46.0",
     "@svgr/webpack": "^8.1.0",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^15.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "next-sitemap": "^4.2.3",
-    "playwright": "1.45.3",
+    "playwright": "1.46.0",
     "postcss": "^8.4.38",
     "postcss-import": "^16.1.0",
     "postcss-nesting": "^12.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 2.7.0
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1)
+        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1)
       next-plugin-preval:
         specifier: ^1.2.6
         version: 1.2.6(next@14.2.4)
@@ -169,8 +169,8 @@ importers:
         specifier: 14.2.5
         version: 14.2.5
       '@playwright/test':
-        specifier: 1.44.1
-        version: 1.44.1
+        specifier: 1.46.0
+        version: 1.46.0
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.5.2)
@@ -4075,7 +4075,7 @@ packages:
       next: ^13.2.0
       react: ^18.2.0
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
     dev: false
 
@@ -4412,7 +4412,7 @@ packages:
       next: ^13.0.0 || ^14.0.0
       react: ^18.2.0
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       third-party-capital: 1.0.20
     dev: false
@@ -4504,12 +4504,12 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: true
 
-  /@playwright/test@1.44.1:
-    resolution: {integrity: sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==}
-    engines: {node: '>=16'}
+  /@playwright/test@1.46.0:
+    resolution: {integrity: sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.44.1
+      playwright: 1.46.0
 
   /@polka/url@1.0.0-next.25:
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
@@ -13212,7 +13212,7 @@ packages:
       '@babel/register': 7.23.7(@babel/core@7.23.9)
       babel-plugin-module-resolver: 4.1.0
       loader-utils: 2.0.4
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1)
       regenerator-runtime: 0.13.11
       require-from-string: 2.0.2
       tsconfig-paths: 3.14.2
@@ -13232,7 +13232,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
@@ -13248,10 +13248,10 @@ packages:
       '@next/env': 13.5.6
       fast-glob: 3.3.1
       minimist: 1.2.8
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1)
     dev: true
 
-  /next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1):
+  /next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-R8/V7vugY+822rsQGQCjoLhMuC9oFj9SOi4Cl4b2wjDrseD0LRZ10W7R6Czo4w9ZznVSshKjuIomsRjvm9EKJQ==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -13271,7 +13271,7 @@ packages:
     dependencies:
       '@next/env': 14.2.4
       '@opentelemetry/api': 1.8.0
-      '@playwright/test': 1.44.1
+      '@playwright/test': 1.46.0
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001600
@@ -13301,7 +13301,7 @@ packages:
       next: ^13.0.0
       react: ^18.2.0
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.8.0)(@playwright/test@1.46.0)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
     dev: false
 
@@ -13736,25 +13736,10 @@ packages:
       find-up: 3.0.0
     dev: false
 
-  /playwright-core@1.44.1:
-    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   /playwright-core@1.46.0:
     resolution: {integrity: sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==}
     engines: {node: '>=18'}
     hasBin: true
-    dev: true
-
-  /playwright@1.44.1:
-    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dependencies:
-      playwright-core: 1.44.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   /playwright@1.46.0:
     resolution: {integrity: sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==}
@@ -13764,7 +13749,6 @@ packages:
       playwright-core: 1.46.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /popmotion@11.0.3:
     resolution: {integrity: sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: ^4.2.3
         version: 4.2.3(next@14.2.4)
       playwright:
-        specifier: 1.45.3
-        version: 1.45.3
+        specifier: 1.46.0
+        version: 1.46.0
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -13741,8 +13741,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  /playwright-core@1.45.3:
-    resolution: {integrity: sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==}
+  /playwright-core@1.46.0:
+    resolution: {integrity: sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==}
     engines: {node: '>=18'}
     hasBin: true
     dev: true
@@ -13756,12 +13756,12 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /playwright@1.45.3:
-    resolution: {integrity: sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==}
+  /playwright@1.46.0:
+    resolution: {integrity: sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.45.3
+      playwright-core: 1.46.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/ui-tests/images.spec.ts
+++ b/ui-tests/images.spec.ts
@@ -1,4 +1,4 @@
-import test, { expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test("Images load successfully on index", async ({ page }) => {
   await page.on("response", (response) => {

--- a/ui-tests/seo-index.spec.ts
+++ b/ui-tests/seo-index.spec.ts
@@ -1,4 +1,4 @@
-import test, { expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test("🔎 Page can be indexed, no 'noindex' found", async ({
   page,

--- a/ui-tests/seo-noindex.spec.ts
+++ b/ui-tests/seo-noindex.spec.ts
@@ -1,4 +1,4 @@
-import test, { expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test("🔎 Page cannot be indexed, 'noindex' header found!", async ({
   page,


### PR DESCRIPTION
### Description

The footer links for the Health Check and Sitemap pages are currently 404ing. I've added a couple of placeholder pages and am planning to add redirects to the new pages.

- 🧪 fixed playwright test failing
- 🚧 Added placeholder page for the sitemap
- 🚧 Added placeholder page for the Menumap

- Affected routes: 
- ssw.com.au/*
- /sitemap
- /healtcheck

- Fixed #2911 

- [ ] Include done video or screenshots

<img width="818" alt="image" src="https://github.com/user-attachments/assets/88a1adfc-6566-4772-932d-9f04d27e0a42">

**Figure**: **Placeholder page for Healthcheck**

<img width="820" alt="image" src="https://github.com/user-attachments/assets/9213dc69-70e3-4f4b-b767-456e53616346">

**Figure**: **Placeholder page for Sitemap**