### PR TITLE
Updating sitemap for the SEMrush audit

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -61,8 +61,8 @@ module.exports = {
       },
     ],
     additionalSitemaps: [
-      "https://www.ssw.com.au/people/sitemap-index.xml",
-      "https://www.ssw.com.au/rules/sitemap-index.xml",
+      "https://www.ssw.com.au/people/sitemap-0.xml",
+      "https://www.ssw.com.au/rules/sitemap-0.xml",
       "https://www.ssw.com.au/archive/sitemap-index.xml",
       // Removed v1 sitemap as its a duplication of bunch of Next.js pages - coming from
       // "https://www.ssw.com.au/ssw/sitemap.xml",


### PR DESCRIPTION
Fixed #2974 

> Based on the sitemaps for each site, SEMrush should be able to crawl the following number of pages:

> - `ssw.com.au` -> 402 pages
> - `ssw.com.au/people` -> 584 pages
> - `ssw.com.au/rules` -> 3,689 pages
> - `ssw.com.au/archives` -> 1,011 pages

> In total, a minimum of **5,686** pages should be crawled. However, it seems SEMrush is not crawling every single page from the sitemap.

I suspect the issue might be due to the sitemap pointing to a sitemap further down the hierarchy, causing SEMrush to only crawl the pages listed in the first-level sitemap.
