### PR TITLE
SEMrush - Fixing non-canonical links in sitemap

### DIFF
--- a/app/products/[filename]/page.tsx
+++ b/app/products/[filename]/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata({
 
   const seo = tinaProps.data.products.seo;
   if (seo && !seo.canonical) {
-    seo.canonical = `${tinaProps.data.global.header.url}/products/${params.filename}`;
+    seo.canonical = `${tinaProps.data.global.header.url}products/${params.filename}`;
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/pages/industry/index.tsx
+++ b/pages/industry/index.tsx
@@ -44,7 +44,7 @@ export const getStaticProps = async () => {
 
   const seo = tinaProps.data.industryIndex.seo;
   if (seo && !seo.canonical) {
-    seo.canonical = `${tinaProps.data.global.header.url}/products`;
+    seo.canonical = `${tinaProps.data.global.header.url}/industry`;
   }
 
   return {

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -1,6 +1,7 @@
 import client from "@/tina/client";
 import classNames from "classnames";
 import { InferGetStaticPropsType } from "next";
+import ReactDomServer from "react-dom/server";
 import { tinaField, useTina } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 import {
@@ -26,7 +27,6 @@ import { getRandomTestimonialsByCategory } from "../../helpers/getTestimonials";
 import { sanitiseXSS, spanWhitelist } from "../../helpers/validator";
 import { removeExtension } from "../../services/client/utils.service";
 import { EventInfo } from "../../services/server/events";
-import ReactDomServer from "react-dom/server";
 
 const ISR_TIME = 60 * 60; // 1 hour;
 
@@ -390,7 +390,7 @@ export const getStaticProps = async ({ params }) => {
     tinaProps.data.userGroupPage.seo &&
     !tinaProps.data.userGroupPage.seo.canonical
   ) {
-    tinaProps.data.userGroupPage.seo.canonical = `${tinaProps.data.global.header.url}netug/${params.filename ?? ""}`;
+    tinaProps.data.userGroupPage.seo.canonical = `${tinaProps.data.global.header.url}netug${params.filename ? `/${params.filename}` : ""}`;
   }
 
   return {


### PR DESCRIPTION
Affected Routes:
- /netug*
- /industry
- /products/rewards




