### PR TITLE
SEMRUSH - Fixing rules.ssw.com.au links

### DIFF
--- a/content/company/culture.mdx
+++ b/content/company/culture.mdx
@@ -64,7 +64,7 @@ subTitle: >
 
 
   We have documented all of the best practices we can possibly think of in our
-  [Rules to Better 'Everything'](https://rules.ssw.com.au/), and are always
+  [Rules to Better 'Everything'](https://www.ssw.com.au/rules), and are always
   trying to make sure we're following and updating them whenever possible. We
   have also made a number of apps that enforce our coding standards in our work,
   such as [SSW Link Auditor](https://linkauditor.com.au/) and [SSW Code

--- a/content/consulting/access-database-upsizing.mdx
+++ b/content/consulting/access-database-upsizing.mdx
@@ -29,7 +29,7 @@ benefits:
         learn how to measure success with analytics.
   rule:
     - name: SSW Rules to Better Access Databases.
-      url: 'https://rules.ssw.com.au/rules-to-better-access-databases'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-access-databases'
 technologies:
   header: Related Technologies
   technologyCards:

--- a/content/consulting/alm-tooling.mdx
+++ b/content/consulting/alm-tooling.mdx
@@ -55,7 +55,7 @@ benefits:
         property without compromising its further innovation.
   rule:
     - name: SSW Rules to Better Scrum using Azure DevOps
-      url: 'https://rules.ssw.com.au/rules-to-better-scrum-using-azure-devops'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-scrum-using-azure-devops'
 technologies:
   header: Related Technologies
   technologyCards:

--- a/content/consulting/azure.mdx
+++ b/content/consulting/azure.mdx
@@ -42,7 +42,7 @@ benefits:
     - name: >-
         how SSW's developers can utilize best practices to build any custom
         cloud based solution for businesses
-      url: 'https://rules.ssw.com.au/rules-to-better-azure'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-azure'
 technologies:
   header: Technologies
   technologyCards:

--- a/content/consulting/backup-recovery.mdx
+++ b/content/consulting/backup-recovery.mdx
@@ -55,7 +55,7 @@ benefits:
         Recovery.
   rule:
     - name: SSW Rules to Better Backups
-      url: 'https://rules.ssw.com.au/rules-to-better-backups'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-backups'
     - name: Do you know why to use Data Protection Manager (DPM)?
       url: 'https://www.ssw.com.au/rules/why-use-data-protection-manager/'
     - name: Do you have a disaster recovery plan?

--- a/content/consulting/chinafy-app.mdx
+++ b/content/consulting/chinafy-app.mdx
@@ -67,7 +67,7 @@ benefits:
         application.
   rule:
     - name: Have a look at SSW Rules to Better Internationalization.
-      url: 'https://rules.ssw.com.au/rules-to-better-internationalization'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-internationalization'
 technologies:
   header: Areas
   technologyCards:

--- a/content/consulting/data-protection-manager.mdx
+++ b/content/consulting/data-protection-manager.mdx
@@ -36,7 +36,7 @@ benefits:
         Completely revision of your current backup and Disaster Recovery Plan.
   rule:
     - name: SSW Rules to Better Data Protection Manager (DPM).
-      url: 'https://rules.ssw.com.au/rules-to-better-data-protection-manager-dpm'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-data-protection-manager-dpm'
 technologies:
   header: Other technologies
   technologyCards:

--- a/content/consulting/devops.mdx
+++ b/content/consulting/devops.mdx
@@ -51,7 +51,7 @@ benefits:
         release cycles.
   rule:
     - name: SSW Rules to Better DevOps.
-      url: 'https://rules.ssw.com.au/rules-to-better-devops'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-devops'
 technologies:
   header: Related Technologies
   technologyCards:

--- a/content/consulting/hyper-v.mdx
+++ b/content/consulting/hyper-v.mdx
@@ -42,7 +42,7 @@ benefits:
         and Failover Cluster Manager servers
   rule:
     - name: SSW Rules to Better Hyper-V.
-      url: 'https://rules.ssw.com.au/rules-to-better-hyper-v'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-hyper-v'
 technologies:
   header: Other technologies
   technologyCards:

--- a/content/consulting/microsoft-365.mdx
+++ b/content/consulting/microsoft-365.mdx
@@ -33,7 +33,7 @@ benefits:
         productivity, saving time and money.
   rule:
     - name: SSW Rules to Better Office 365
-      url: 'https://rules.ssw.com.au/rules-to-better-office-365'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-office-365'
 technologies:
   header: Related Technologies
   technologyCards:

--- a/content/consulting/microsoft-teams.mdx
+++ b/content/consulting/microsoft-teams.mdx
@@ -49,7 +49,7 @@ benefits:
         also with rich chat and voice features.
   rule:
     - name: SSW Rules to Better Microsoft Teams.
-      url: 'https://rules.ssw.com.au/rules-to-better-microsoft-teams'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-microsoft-teams'
 ---
 
 # Get started with Microsoft Teams

--- a/content/consulting/network-architecture.mdx
+++ b/content/consulting/network-architecture.mdx
@@ -16,12 +16,12 @@ benefits:
     - image: /images/benefits/troubleshooting.png
       title: TROUBLESHOOTING
       description: >
-        Troubleshoot exisiting networks and suggest best practices to move 
+        Troubleshoot exisiting networks and suggest best practices to move
         Infrastructure to a better and more secure design.
     - image: /images/benefits/implementation.png
       title: IMPLEMENTATION
       description: >
-        Our Engineers will provide full installation services for all 
+        Our Engineers will provide full installation services for all
         networking equipment.
     - image: /images/benefits/smart-hands-and-feet.png
       title: SMART HANDS AND FEET
@@ -29,7 +29,7 @@ benefits:
         Providing knowledgebale Network Engineers for remote hands and feet.
   rule:
     - name: SSW Rules to Better Networks
-      url: 'https://rules.ssw.com.au/rules-to-better-networks'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-networks'
 technologies:
   header: Related Technologies
   technologyCards:

--- a/content/consulting/power-platform.mdx
+++ b/content/consulting/power-platform.mdx
@@ -63,7 +63,7 @@ benefits:
         Agents with Power BI to track how your bots are performing.
   rule:
     - name: SSW Rules to Better Power Platform.
-      url: 'https://rules.ssw.com.au/rules-to-better-power-platform'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-power-platform'
 ---
 
 # What is Power Platform?

--- a/content/consulting/remote-work.mdx
+++ b/content/consulting/remote-work.mdx
@@ -34,7 +34,7 @@ benefits:
         become trackable and putting accountability onto your team.
   rule:
     - name: SSW Rules to Better Remote Work
-      url: 'https://rules.ssw.com.au/rules-to-better-remote-work'
+      url: 'https://www.ssw.com.au/rulesrules-to-better-remote-work'
 technologies:
   header: Technologies
   technologyCards:
@@ -86,7 +86,7 @@ Here are a few ways we can help your business:
 * Provide training in livestreaming and video production to enable you to move your in-person content online
 * Provide training via a virtual academy to upskill your staff in online technologies
 
-[See our Remote Work rules](https://rules.ssw.com.au/rules-to-better-remote-work) for best practices for working from home.
+[See our Remote Work rules](https://www.ssw.com.au/rules/rules-to-better-remote-work) for best practices for working from home.
 
 At SSW we are fortunate that our experience in online technology makes it easier for us to adapt our work practices to a crisis such as the COVID-19 pandemic, and because of this, SSW stands ready to help your business adapt to this new environment as well. Because we are always sharing and encouraging collaboration on solutions to technological problems, we’ve created some handy Rules to Better Remote Work to help you and your team adapt to an online workspace, and our own Chief Architect and Microsoft Regional Director, Adam Cogan, has also produced a video on how to prepare yourself for remote work.
 

--- a/content/consulting/scrum.mdx
+++ b/content/consulting/scrum.mdx
@@ -38,7 +38,7 @@ benefits:
         both during the project and afterwards.
   rule:
     - name: Rules to Better Scrum using Azure DevOps.
-      url: 'https://rules.ssw.com.au/rules-to-better-scrum-using-azure-devops'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-scrum-using-azure-devops'
 technologies:
   header: Related Technologies
   technologyCards:

--- a/content/consulting/sharepoint.mdx
+++ b/content/consulting/sharepoint.mdx
@@ -68,7 +68,7 @@ benefits:
         to your business.
   rule:
     - name: SSW Rules to Better SharePoint.
-      url: 'https://rules.ssw.com.au/rules-to-better-sharepoint'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-sharepoint'
 ---
 
 # The benefits of **Microsoft SharePoint**

--- a/content/consulting/sitefinity.mdx
+++ b/content/consulting/sitefinity.mdx
@@ -47,7 +47,7 @@ benefits:
         by understanding and optimizing every customer's individual journey.
   rule:
     - name: SSW Rules to Better Sitefinity.
-      url: 'https://rules.ssw.com.au/rules-to-better-sitefinity'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-sitefinity'
 technologies:
   header: Other Technologies
   technologyCards:

--- a/content/consulting/software-audit.mdx
+++ b/content/consulting/software-audit.mdx
@@ -42,7 +42,7 @@ benefits:
         technology? Is the system designed for future needs, not only for
         today's deadlines?
       linkName: More on Rules to Better Clean Architecture
-      linkURL: 'https://rules.ssw.com.au/rules-to-better-clean-architecture'
+      linkURL: 'https://www.ssw.com.au/rules/rules-to-better-clean-architecture'
     - image: /images/benefits/sharing-and-collaboration.png
       title: DEVOPS AND ALM REVIEW
       description: >
@@ -70,7 +70,7 @@ benefits:
         * Ballpark Estimates for the cost of the project and number of sprints
         to complete.
       linkName: More on Rules to Better Specification Reviews
-      linkURL: 'https://rules.ssw.com.au/rules-to-better-specification-reviews'
+      linkURL: 'https://www.ssw.com.au/rules/rules-to-better-specification-reviews'
     - image: /images/benefits/use-case.png
       title: TEAM AND PROCESS REVIEW
       description: >
@@ -91,7 +91,7 @@ benefits:
         approach.
       linkName: More on Rules to Better Interfaces
       linkURL: >-
-        https://rules.ssw.com.au/rules-to-better-interfaces-(general-usability-practices)
+        https://www.ssw.com.au/rules/rules-to-better-interfaces-(general-usability-practices)
     - image: /images/benefits/super_reports.png
       title: GOOGLE SEARCH ENGINE OPTIMIZATION
       description: >
@@ -121,7 +121,7 @@ benefits:
         architecture and code structure to provide you with a set of
         recommendations and specifications.
       linkName: More on Rules to Better Application Performance
-      linkURL: 'https://rules.ssw.com.au/rules-to-better-application-performance'
+      linkURL: 'https://www.ssw.com.au/rules/rules-to-better-application-performance'
     - image: /images/benefits/security-db.png
       title: SECURITY REVIEW
       description: "Whether it's because of industry requirement, or your peace of mind, SSW can provide a third-party review of your application to target specific issues for improvements. We look at:\n\_\_\_\_Running penetration tests with SSL labs to check how exposed your servers are.\n\_\_\_\_Passwords in .config and code\n\_\_\_\_Authentication an Authorization\n\_\_\_\_Cross site scripting and SQL injection\n\_\_\_\_Encryption of passwords and sensitive data.\n\_\_\_\_Audit trails and logging\n"

--- a/content/consulting/video-production.mdx
+++ b/content/consulting/video-production.mdx
@@ -151,7 +151,7 @@ benefits:
         in text.
   rule:
     - name: SSW Rules to Better Video Recording
-      url: 'https://rules.ssw.com.au/rules-to-better-video-recording'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-video-recording'
 technologies:
   header: Technologies
   technologyCards:

--- a/content/consulting/wordpress.mdx
+++ b/content/consulting/wordpress.mdx
@@ -48,7 +48,7 @@ benefits:
         WordPress is a perfect choice to deal with multi-user issue.
   rule:
     - name: SSW Rules to Better WordPress.
-      url: 'https://rules.ssw.com.au/rules-to-better-wordpress'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-wordpress'
 technologies:
   header: Other Technologies
   technologyCards:

--- a/content/consulting/zendesk.mdx
+++ b/content/consulting/zendesk.mdx
@@ -29,7 +29,7 @@ benefits:
         soon as possible.
   rule:
     - name: SSW Rules to Better Zendesk
-      url: 'https://rules.ssw.com.au/rules-to-better-zendesk'
+      url: 'https://www.ssw.com.au/rules/rules-to-better-zendesk'
 technologies:
   header: Zendesk Solutions
   technologyCards:

--- a/content/netug/present.mdx
+++ b/content/netug/present.mdx
@@ -27,5 +27,5 @@ Remember, the Sydney presentation is going to be recorded AND streamed live to o
 
 * Please be at the SSW Sydney Offices at 5:00 so we have enough time to get everything up and running properly. You can find the directions to our office [here](https://www.ssw.com.au/offices/sydney).
 * Make sure that your laptop has a HDMI, Display Port, or a DVI connection. (Basically anything besides VGA)
-* For more tips and tricks on better ways to enhance your presentations, read through our [Rules to Better Powerpoint Presentations](https://rules.ssw.com.au/rules-to-better-powerpoint-presentations)
+* For more tips and tricks on better ways to enhance your presentations, read through our [Rules to Better Powerpoint Presentations](https://www.ssw.com.au/rules/rules-to-better-powerpoint-presentations)
 * You will need to create 3 questions based on your presentation, to go with the video once it goes live. Please have these ready when you arrive to present

--- a/content/opportunities/Dynamics-365-Guru.mdx
+++ b/content/opportunities/Dynamics-365-Guru.mdx
@@ -2,7 +2,7 @@
 title: Dynamics 365 Guru
 employmentType: Permanent
 
-locations: 
+locations:
   - Sydney
   - Melbourne
   - Brisbane
@@ -11,9 +11,9 @@ hideApply: true
 
 **SSW is looking for an Dynamics 365 Guru to start ASAP.**
 
-You will be working with expert Microsoft stack developers and designers in a wide variety of exciting corporate projects.  
+You will be working with expert Microsoft stack developers and designers in a wide variety of exciting corporate projects.
 
-The main reasons people choose to work at SSW are the [great culture](https://www.ssw.com.au/company/culture), the [cool client projects](https://www.ssw.com.au/company/clients), and the cutting edge [tech stack](https://www.ssw.com.au/consulting).   
+The main reasons people choose to work at SSW are the [great culture](https://www.ssw.com.au/company/culture), the [cool client projects](https://www.ssw.com.au/company/clients), and the cutting edge [tech stack](https://www.ssw.com.au/consulting).
 
 SSW is unlike any place you've ever worked at.
 
@@ -36,7 +36,7 @@ Now the boring stuff:
 * Strong skills designing and implementing solutions using Dynamics 365
 * An IT degree or equivalent experience
 * A working knowledge of agile software development methodologies (preferably Scrum) and good task management skills
-* A passion for finding and using best practices, and updating them when necessary? [https://rules.ssw.com.au](https://rules.ssw.com.au/)
+* A passion for finding and using best practices, and updating them when necessary? [https://www.ssw.com.au/rules](https://www.ssw.com.au/rules)
 * A keen interest in the development community including technological trends, news, people, and innovations
 
 **Skills:**

--- a/content/opportunities/Microsoft-DevOps-Engineer.mdx
+++ b/content/opportunities/Microsoft-DevOps-Engineer.mdx
@@ -2,7 +2,7 @@
 title: Microsoft DevOps Engineer
 employmentType: Permanent
 
-locations: 
+locations:
   - Sydney
   - Melbourne
   - Brisbane
@@ -10,8 +10,8 @@ locations:
 
 hideApply: true
 ---
-        
-[Where is the Cloud Architect?](https://rules.ssw.com.au/cloud-architect)
+
+[Where is the Cloud Architect?](https://www.ssw.com.au/rules/cloud-architect)
 
 **SSW is looking for an enthusiastic Microsoft DevOps Architect for an immediate start**
 

--- a/content/opportunities/Microsoft-Dynamics-365-Developer.mdx
+++ b/content/opportunities/Microsoft-Dynamics-365-Developer.mdx
@@ -2,7 +2,7 @@
 title: Microsoft Dynamics 365 Developer
 employmentType: Permanent
 
-locations: 
+locations:
   - Sydney
   - Melbourne
   - Brisbane
@@ -10,7 +10,7 @@ locations:
 
 hideApply: true
 ---
-        
+
 **SSW is looking for a Dynamics 365 Guru to start ASAP.**
 
 
@@ -53,7 +53,7 @@ Now the boring stuff:
 * Strong skills designing and implementing solutions using Dynamics 365
 * An IT degree or equivalent experience
 * A working knowledge of agile software development methodologies (preferably Scrum) and good task management skills
-* A passion for finding and using best practices, and updating them when necessary. See [SSW Rules](https://rules.ssw.com.au)
+* A passion for finding and using best practices, and updating them when necessary. See [SSW Rules](https://www.ssw.com.au/rules)
 * A keen interest in the development community including technological trends, news, people, and innovations
 
 

--- a/content/opportunities/Senior-Angular-React-NET-MVC-and-Web-API-developer.mdx
+++ b/content/opportunities/Senior-Angular-React-NET-MVC-and-Web-API-developer.mdx
@@ -2,19 +2,19 @@
 title: Senior Angular/React, .NET MVC and Web API developer
 employmentType: Permanent
 
-locations: 
+locations:
   - Sydney
   - Melbourne
   - Brisbane
 
 hideApply: true
 ---
-        
+
 **SSW is looking for an enthusiastic Senior Full Stack .NET developers to start ASAP.**
 
-You will be working with expert Microsoft stack developers and designers in a wide variety of exciting corporate projects.  
+You will be working with expert Microsoft stack developers and designers in a wide variety of exciting corporate projects.
 
-The main reasons people choose to work at SSW are the [great culture](https://www.ssw.com.au/company/culture), the [cool client projects](https://www.ssw.com.au/company/clients), and the cutting edge [tech stack](https://www.ssw.com.au/consulting).  
+The main reasons people choose to work at SSW are the [great culture](https://www.ssw.com.au/company/culture), the [cool client projects](https://www.ssw.com.au/company/clients), and the cutting edge [tech stack](https://www.ssw.com.au/consulting).
 
 SSW is unlike any place you've ever worked at.
 
@@ -37,7 +37,7 @@ Now the boring stuff:
 * Strong skills designing and implementing ASP.NET MVC applications using C#
 * A working knowledge of agile software development methodologies (preferably Scrum) and good task management skills
 * keen interest in the development community including technological trends, news, people,, and innovations
-* A passion for finding and using best practices, and updating them when necessary? [https://rules.ssw.com.au](https://rules.ssw.com.au/)
+* A passion for finding and using best practices, and updating them when necessary? [https://www.ssw.com.au/rules](https://www.ssw.com.au/rules)
 
 **Skills:**
 

--- a/content/pages/terms-and-conditions.mdx
+++ b/content/pages/terms-and-conditions.mdx
@@ -269,162 +269,162 @@ The Client authorizes SSW to provide the resources suitable for the project. SSW
 <FixedColumns
   firstColBody={<>
     ### 01 - Terms & Conditions
-    
+
     This contract is governed by the laws of NSW, Australia. The operation of the postal acceptance rule is expressly excluded. The terms and conditions contained on this document supersede any previous terms and conditions.
-    
+
     ### 02 - Limited Liability
-    
+
     In no event shall SSW or its suppliers be liable for any accidental, consequential, incidental or indirect damages of any kind (including without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out of the use or of the inability to use the software. In no event shall SSW's liability for any claims whether in contract, tort or other theory of liability exceed the purchase price of the subject products or services, unless such limitation of liability is otherwise prohibited by law.
-    
+
     ### 03 - Copyright
-    
+
     The intellectual property rights, copyright and company trade secrets of SSW vested in all software products, upgrades, dual-media software, hard-copy or electronic manuals and documentation are vested in SSW, which reserves the right to use the software or material, or any part of it in other applications and for its own use.
-    
+
     ### 04 - Development Work Credit
-    
+
     In the event SSW performs web development services, the Client acknowledges and will ensure that: (a) SSW receives a permanent credit on the Site (including, without limitation, any alteration, modification or subsequent use of the Site) which acknowledges SSW as the developer of the Site; Unless otherwise agreed in writing credit shall be "[Proudly developed by SSW](https://www.ssw.com.au/)" in a suitable position of each page of the Site. This text will provide a permanent link to [www.ssw.com.au](https://www.ssw.com.au); (b) SSW may claim credit in its own promotional material for the development of the Site; and (c) the Client will remove the credit within 24 hours of receiving a notice from SSW to do so. In the event SSW performs web or other software development services, SSW reserves the right to develop and publish a case study on the work performed. For video productions, credit shall be "Proudly produced by SSW TV".
-    
+
     ### 05 - Microsoft Digital Partner of Record (DPOR)
-    
+
     The Client agrees that SSW will be its nominated Microsoft Digital Partner of Record (MDPR) and authorises SSW to update any of the Client's relevant Microsoft services (including for the avoidance of doubt the Client’s Azure portal) to nominate the SSW Partner ID as the Client's MDPR and for that update to remain during the term and for a period of twelve (12) months following termination of this agreement. SSW’s rights under this clause continue after termination.
-    
+
     ### 06 - Hourly Rate Work
-    
+
     Unless specified otherwise in writing, the Client authorizes SSW to undertake work on an hourly-rate basis. SSW may provide an estimated time to complete this work. Such estimates are not binding and all hours performed will be charged at the rates set out or otherwise agreed. SSW reserves the right to not provide estimates for work regarded by SSW to be less than 24 billing hours. The minimum time chargeable for on-site work is 4 (four) hours per resource. The minimum time chargeable for off-site work is 1 hour per person per request during business hours and/or 2 (two) hours per person per request outside of business hours. SSW reserves the right to rotate resources on projects at least every 6 months to promote knowledge transfer and avoid burnout. Any whole day booking cancelled within 4 business hours will incur a minimum 8 hour charge per resource booked.
-    
+
     ### 07 - Pre-Paid Work
-    
+
     SSW may offer a pre-paid rate where time is pre-paid in blocks of 40 hours per resource. Pre-paid rates become effective upon the day of payment. Rates revert to standard if pre-payment is not made prior to work commencing, or not so made for second or subsequent prepaid invoices in respect of work past the previously prepaid work. We recommend that you process payment within 24 hours of receiving a new invoice to ensure that the prepaid discount is maintained. Unused prepaid credit expires 12 months from the date of issue of the invoice. No refund will be made for unused prepaid credit.
-    
+
     ### 08 - Fixed Price Work
-    
-    SSW may agree to perform certain work for a fixed price in accordance with an agreed specification and/or release plan/s. In this event, the specification and/or release plan/s are fixed. Any additional or unspecified work will be to the Client's account. A fifty percent payment of any fixed-price component is required prior to commencement of work and twenty-five percent payment is required upon delivery of the software for User Acceptance Testing (i.e. when a "[test please](https://rules.ssw.com.au/conduct-a-test-please-internally-and-then-with-the-client)" email is sent). The final twenty-five percent payment is required prior to the Release entering Production OR work commencing on any other release OR the elapse of 30 days after sending the "test please" email (whichever is sooner).
-    
+
+    SSW may agree to perform certain work for a fixed price in accordance with an agreed specification and/or release plan/s. In this event, the specification and/or release plan/s are fixed. Any additional or unspecified work will be to the Client's account. A fifty percent payment of any fixed-price component is required prior to commencement of work and twenty-five percent payment is required upon delivery of the software for User Acceptance Testing (i.e. when a "[test please](https://www.ssw.com.au/rules/conduct-a-test-please-internally-and-then-with-the-client)" email is sent). The final twenty-five percent payment is required prior to the Release entering Production OR work commencing on any other release OR the elapse of 30 days after sending the "test please" email (whichever is sooner).
+
     SSW will only conduct fixed-price work in a Development and/or Staging environment. The Client forfeits any incomplete or unfinished work the moment the Release enters Production. No warranty applies after the Release enters Production.
-    
+
     The following are excluded from any fixed price agreement: on-site work (including on-site meetings), specification development/scoping (including the generation of further estimates), production deployment, 3rd party component integration or configuration, data migration, network infrastructure or hardware services, graphic design including mockups. SSW conducts all development and testing in an environment with a default configuration.
-    
+
     ### 09 - Requests for Work
-    
+
     Work requested by the Client (including employees or representatives of the Client), in written, electronic, or verbal form, is authorized by the Client. The Client may choose to work through a "Product Owner". If so, the Client must inform SSW of this decision in writing. Subsequent to this advice the Product Owner has sole authority to request billable work. All requests that the Product Owner is CC'd on are considered authorized.
-    For more information, see [What is a Product Owner?](https://rules.ssw.com.au/rules-to-better-product-owners)
-    
+    For more information, see [What is a Product Owner?](https://www.ssw.com.au/rules/rules-to-better-product-owners)
+
     ### 10 - Uninvited Solicitation
-    
+
     The parties agree that the Client, its associated entities, sub-contractors, employees or entities with whom it has directed SSW to deal, will not employ or approach for employment any SSW employee or ex-employee during the term and for a minimum period of six (6) months following termination of this agreement. Should the Client, its associated entities, sub-contractors, employees, or an entity with whom it has directed SSW to deal, employs an SSW employee or ex-employee in breach of the above provision, the Client will pay SSW 29% of the total annual remuneration package paid to the solicited employee by the new employer with such amount payable within 14 days of the date SSW reasonably ascertains the employment, and the Client agrees that such amount is a genuine pre-estimate of damages flowing to SSW consequent upon the breach taken into account factors including the costs of recruitment and training of an employee in replacement of the solicited employee or ex-employee. If evidence is not adduced as to the solicited employees total annual remuneration package the parties agree that it shall be deemed to be 125% of the employees total annual remuneration package as at the date of termination.
-    
+
     ### 11 - Warranty
-    
+
     No warranty applies to work done on an hourly basis, this includes bug fixing. SSW and its suppliers disclaim all other warranties, either express or implied, including, but not limited to implied warranties or merchantability and fitness for a particular purpose, with regard to the software, the accompanying written materials, and any accompanying hardware.
     A limited 7 day warranty begins upon delivery of any fixed price component or Release not in Production. If the component or Release enters Production prior to the expiry of 7 days, the warranty ceases. A software issue within the fixed price component or Release is covered by the warranty where:
-    
+
     * The application crashes to code (excluding bugs resulting from third party products e.g. "blue screen of death" or crashing in a third party data grid that we cannot control); or
     * The application displays data inconsistent with the specified business rules; or
     * The application is missing functionality specified in the specification; or
     * The page design/layout is substantially inconsistent with the agreed mock-ups
     * And the developers can reproduce the above on the test server and the application is not yet "live" and the issue has been reported in time.
-    
+
     All software issues shall be presumed to fall outside the warranty unless proven by the client otherwise. More examples of [what is/is not a "bug"?.](https://www.ssw.com.au/rules/definition-of-a-bug/) The doing of work by SSW within any warranty period cannot be construed as an admission by SSW that the work is work performed pursuant to a warranty.
-    
+
     ### 12 - Support
-    
+
     Reproducing issues can be difficult. The client warrants that, before reporting an issue, the client will run Windows Update.
-    
+
     SSW will perform these tasks to the clients account before investigating any issues if the tasks not completed successfully by the client. Software will be supported either under an hourly rate, Service Level Agreement or on a Per Issue basis. SSW will only support web applications accessed using the most recent version (at the time support is provided) of Internet Explorer and/or Chrome. No other browsers are supported.
-    
+
     ### 13 - Negotiation of rates in foreign currency
-    
+
     SSW may in its sole discretion agree to fixed price or hourly rates in a foreign currency amount, however all invoices will be rendered in AUD based on the relevant exchange rate published on [http://www.xe.com/](http://www.xe.com/) at the time the invoice is generated. The Client bears all costs or fees arising from or relating to any foreign currency exchange or international transfer.
   </>}
   secondColBody={<>
     ### 14 - Source Code Ownership
-    
+
     The copyright in the software developed by SSW pursuant to this Agreement, other than in the Retained Software, shall vest in the Client on acceptance. "Retained Software" includes any software of a generic nature used or developed by SSW during the course of this Agreement including the SSW Framework or the SSW Toolkit. The copyright and all other intellectual property rights in the Retained Software vest in SSW. SSW grants a non-exclusive, transferable, perpetual Australian right and license to use, deploy and modify the software comprising the Retained Software within the Client's group of companies for the Client's own internal purposes. SSW reserves the right to use in any way it thinks fit, including in the development of software for third parties, any programming tools, skills or techniques acquired by SSW in the course of this Agreement.
-    
+
     ### 15 - Services of all Notices
-    
+
     Services of all notices shall be sufficient if delivered or sent by any form of email (preferred), or post (standard, certified or registered) to either party's business address.
-    
+
     ### 16 - Testing
-    
+
     The Client is responsible to ensure the software has been tested. The Client agrees that prior to a version being submitted to the client, the SSW developers may:
-    
+
     1. Perform automated testing with SSW Link Auditor (for Web Apps)
     2. Perform automated testing via Unit Tests
     3. Perform an internal "Test Please" (aka "Alpha Testing" e.g. only that pages or forms load, not checking the business rules)
-    
+
     After SSW sends the Client a "test please" email the Client will promptly conduct User Acceptance Testing, checking the specified component/release for bugs, sending all feedback within five business days. SSW is not required to commence development on a future release if any current release is not approved by the Client. For more information, see [Do you know the 4 steps to do a "Test Please"?](https://www.ssw.com.au/rules/conduct-a-test-please-internally-and-then-with-the-client/)
-    
+
     For mobile development, SSW will generally supply 1 recent model Android and 1 recent model iOS device per team. Any additional supported devices required for testing purposes beyond these provided devices would need to be supplied by the Client. It is the Client's responsibility to ensure the availability and compatibility of additional devices required for testing and deployment of the mobile applications.
-    
+
     ### 17 - Use of AI Technologies
-    
+
     The Client authorizes SSW to use such third party Artificial Intelligence technologies (Github Copilot, Azure AI etc) as SSW considers appropriate in the conduct of the work. The Client must notify SSW if there are any specific AI technologies that they would prefer are not used.
-    
+
     ### 18 - De-identification of Data
-    
+
     The Client must de-identify any data provided or supplied to SSW prior to the provision or supply of that data to SSW. For the purpose of this clause 'de-identify' means removing any information which identifies or could potentially be used to identify an individual. The Client warrants that any data it provides or supplies to SSW has been so de-identified.
-    
+
     ### 19 - Training & Documentation
-    
+
     Training is charged in half day or full day sessions. Documentation, if required, is at additional cost. If documentation has not been specifically estimated or quoted, it will not be supplied. All custom documentation, including additions, deletions, and amendments is to the Client's account.
-    
+
     ### 20 - Cancellations by the Client
-    
+
     If any hourly job is cancelled by the Client after commencement, SSW will charge for all hours up to that point in time. Any whole day booking cancelled within 4 business hours will incur a minimum 8 hour charge per resource booked. Any whole day booking that involves travel and accommodation cancelled within 16 business hours (aka 48 hours) will incur a minimum 8 hour charge per resource booked. If an hourly job is cancelled by the Client, any pre-paid work not fully completed will not be refunded; however the remaining balance will be credited to the Client's account for future utilisation. If any fixed price job is cancelled by the Client, SSW will retain the initial fifty percent of pre-paid value. Any further hours completed will be charged to the Client as a proportion of the quoted price based on hours completed to that point in time.
-    
+
     ### 21 - Cancellations by SSW
-    
+
     SSW reserves the right to terminate any previously agreed project specification for fixed price work without prior notice. SSW will charge on a pro-rata basis for any work completed. SSW reserves the right to terminate any previously purchased pre-paid work blocks without prior notice. In this case, the Client will be refunded for hours not completed as a proportion of the pre-paid blocks purchase value. SSW reserves the right to terminate any ongoing service contract including, but not limited to hosting and database updates, with fourteen days notice. In this case, any paid unexecuted services will be refunded as proportion of the charged price based on percentage of specified project completed.
-    
+
     ### 22 - Payment Terms
-    
+
     SSW may at its sole discretion conduct work only on a prepaid basis. Otherwise payment terms are 7 days or AUD$20,000(+GST) per full time resource booked, whichever limit is reached sooner. The Client agrees that SSW can stop work if either of these are exceeded. SSW reserves the right to take legal action to recover debt and/or withhold source code until invoices are paid in full. Client has 7 (seven) days from date of receipt of an invoice to query invoice or timesheet. The Client abrogates any right of reply after this time. SSW will only conduct work for Clients not domiciled within Australia on a prepaid basis.
-    
+
     ### 23 - Interest
-    
+
     SSW reserves the right to charge interest on all overdue accounts (including fees and disbursements) at a rate of 8% per annum compounded daily. Overdue accounts are deemed to be those accounts that remain unpaid after 7 days from the date of invoice for services or products provided by SSW.
-    
+
     ### 24 - Credit Card Details
-    
+
     All payments made by credit card incur a 3.5% surcharge (this is the exact same charge that Stripe charge SSW). This is to reflect the cost of fees charged for credit card transactions. When using a credit card, the invoices cannot be split for payment.
-    
+
     ### 26 - Deadlines
-    
+
     SSW may choose to estimate the completion date of a project. While we will endeavour to meet all deadlines, we do not offer any guarantees, and SSW is not liable for losses suffered due to a project being completed after the estimated completion date.
-    
+
     ### 26 - Equipment
-    
+
     SSW is not liable for any equipment failures be it SSW's equipment or equipment on the Client site to the maximum extent permissible by law.
-    
+
     ### 27 - Viruses
-    
+
     While SSW endeavours to have all its hardware virus-free, the Client is expected to have current virus protection, and SSW is not liable for any accidental infection of the Client's hardware.
-    
+
     ### 28 - Expenses
-    
+
     When requested by the client, or where the work so requires, SSW employees or agents may travel to locations which it considers safe and within a reasonable travel time.
     Within the Sydney, Brisbane and Melbourne metropolitan areas:
-    
+
     * Full Day bookings - Travel is not billable (except for interstate travel of SSW employees or agents)
     * Part Day bookings (less than 8 hours on site) - Travel time is billable at the standard rate.
-    
+
     Outside the [Sydney](https://www.google.com.au/maps/place/Sydney+NSW/@-33.8463455,150.3584243,10z/data=!3m1!4b1!4m6!3m5!1s0x6b129838f39a743f:0x3017d681632a850!8m2!3d-33.8688197!4d151.2092955!16zL20vMDZ5NTc "Map of Sydney metropolitan area"), [Brisbane](https://www.google.com.au/maps/place/Brisbane+QLD/@-27.381252,152.7123339,10z/data=!3m1!4b1!4m6!3m5!1s0x6b91579aac93d233:0x402a35af3deaf40!8m2!3d-27.4704528!4d153.0260341!16zL20vMDFiOGpq "Map of Brisbane metropolitan area") and [Melbourne](https://www.google.com.au/maps/place/Melbourne+VIC/@-37.9716913,144.7722767,10z/data=!3m1!4b1!4m6!3m5!1s0x6ad646b5d2ba4df7:0x4045675218ccd90!8m2!3d-37.8136276!4d144.9630576!16zL20vMGNoZ3pt "Map of Melbourne metropolitan area") metropolitan areas:
-    
+
     * For partial day bookings all travel time within business hours is billable. Travel time is calculated as the time it takes to make a return trip between SSW office and the respective location. SSW reserves the right to refuse travel to any location for any reason.
     * If travel is applicable, the Client shall pay for ordinary expenses including accommodation, airfare, and other transport. We rather arrive on time so please book airfares with a decent airline that won't restrict baggage or flexibility options. Accommodation shall be charged at market rates but at no less than AUD$200 + GST per person per night if not booked and paid for by the client. A per diem of AUD$60 + GST per person per day is chargeable for meals if reasonable provision is not made by the Client. If flights or other expenses are purchased by SSW, a 20% admin fee will be charged.
     * Note: The Sydney Metropolitan area is defined by the council areas in the Sydney Inner (SI) and Sydney Outer (SO) regions listed by the [Department of Local Government](http://www.cityofsydney.nsw.gov.au/learn/research-and-statistics/the-city-at-a-glance/metropolitan-sydney).
-    
+
     ### 29 - Goods and Services Tax ("GST")
-    
+
     Unless otherwise provided in this Agreement, any moneys payable under this Agreement have been calculated without regard to GST. Any amount which is payable on account of GST as a consequence of any supply made under this Agreement is to be paid to the party making the supply at the same time as payment is made for the relevant supply.
-    
+
     ### 30 - Severability
-    
+
     Each of the above clauses is severable and is enforceable separately. If one or more clauses are deemed unenforceable, this does not affect the validity of the rest of the contract.
-    
+
     ### 31 - Business hours
-    
+
     SSW Business Hours are Monday through Friday, 0900 - 1800 AEST not including Federal/NSW/VIC/QLD public holidays.
   </>}
 />


### PR DESCRIPTION
✅ Fixing broken links reported by SEMrush and CodeAuditor for v3 site

