### PR TITLE
🚑 Hotfix - Fix blank presenter on user group page

### DIFF
--- a/components/usergroup/organizer.tsx
+++ b/components/usergroup/organizer.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useState } from "react";
 import type { Template } from "tinacms";
 import { tinaField } from "tinacms/dist/react";
 import type { TinaMarkdownContent } from "tinacms/dist/rich-text";
@@ -21,6 +22,7 @@ export const Organizer = ({
   data: OrganizerType;
   stringContent?: string;
 }) => {
+  const [image, setFallbackImage] = useState<string>(data.profileImg ?? "");
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-row items-center gap-2">
@@ -28,15 +30,16 @@ export const Organizer = ({
           className="size-17 overflow-hidden rounded-full"
           data-tina-field={tinaField(data, "name")}
         >
-          {data.profileImg && (
-            <Image
-              alt={`Picture of ${data?.name ?? "Organizer"}`}
-              src={data?.profileImg ?? ""}
-              height={68}
-              width={68}
-              className="w-17"
-            />
-          )}
+          <Image
+            alt={`Picture of ${data?.name ?? "Organizer"}`}
+            src={image}
+            height={68}
+            width={68}
+            onError={() =>
+              setFallbackImage("/images/thumbs/avatar-thumbnail.png")
+            }
+            className="w-17"
+          />
         </div>
         <div className="font-sans">
           <CustomLink

--- a/components/usergroup/organizer.tsx
+++ b/components/usergroup/organizer.tsx
@@ -28,13 +28,15 @@ export const Organizer = ({
           className="size-17 overflow-hidden rounded-full"
           data-tina-field={tinaField(data, "name")}
         >
-          <Image
-            alt={`Picture of ${data?.name ?? "Organizer"}`}
-            src={data?.profileImg ?? ""}
-            height={68}
-            width={68}
-            className="w-17"
-          />
+          {data.profileImg && (
+            <Image
+              alt={`Picture of ${data?.name ?? "Organizer"}`}
+              src={data?.profileImg ?? ""}
+              height={68}
+              width={68}
+              className="w-17"
+            />
+          )}
         </div>
         <div className="font-sans">
           <CustomLink

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -43,7 +43,6 @@ export default function NETUGPage(
   const speaker = props.event?.presenterList
     ? props.event.presenterList[0]
     : null;
-
   // Converting element to string to render in presenter block
   const aboutDescription = ReactDomServer.renderToString(
     <TinaMarkdown content={speaker?.presenter?.about} />
@@ -189,7 +188,7 @@ export default function NETUGPage(
                   ))}
                 </div>
               </div>
-              {speaker && (
+              {speaker.presenter && (
                 <div className="col-span-1 py-4 md:py-0">
                   <h2 className="text-4xl font-medium text-sswRed">
                     Presenter

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -188,7 +188,7 @@ export default function NETUGPage(
                   ))}
                 </div>
               </div>
-              {speaker.presenter && (
+              {(speaker || props.event.presenterName) && (
                 <div className="col-span-1 py-4 md:py-0">
                   <h2 className="text-4xl font-medium text-sswRed">
                     Presenter
@@ -197,9 +197,12 @@ export default function NETUGPage(
                     <Organizer
                       data={{
                         profileImg: speaker?.presenter?.profileImg,
-                        name: speaker?.presenter?.presenter?.name,
+                        name:
+                          speaker?.presenter?.presenter?.name ||
+                          props.event.presenterName,
                         profileLink:
-                          speaker?.presenter?.presenter?.peopleProfileURL,
+                          speaker?.presenter?.presenter?.peopleProfileURL ||
+                          props.event.presenterProfileUrl,
                       }}
                       stringContent={aboutDescription}
                     />


### PR DESCRIPTION
### Description
Fixes a bug causing the presenter image to appear blank when not sourcing the presenter from Tina.


### Related Issue
- Fixed https://github.com/SSWConsulting/SSW.Website/issues/2833

### Screenshots

<img width="896" alt="image" src="https://github.com/user-attachments/assets/acf8f0c3-3afc-4d13-be8e-560c78d426b8">

**Figure**: **Bad - presenter breaking with no presenter in list**

<br>

<img width="614" alt="image" src="https://github.com/user-attachments/assets/2533bf57-3fec-4023-b757-efaec08c2bee">

**Figure**: **Good - presenter sourcing name/link from event as a backup**
