### PR TITLE
UI - Fixing link styling on consulting pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,10 +4,7 @@
 
 @layer base {
   a:not(.unstyled) {
-    @apply transition duration-300 hover:border-sswRed hover:text-sswRed;
-  }
-  a:not(.no-underline)a:not(.unstyled) {
-    @apply underline;
+    @apply transition duration-300 hover:border-sswRed hover:text-sswRed underline decoration-ssw-gray-light decoration-1;
   }
   html,
   body {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -329,8 +329,7 @@ export default {
               marginBottom: "1.5em",
             },
             a: {
-              textDecorationColor: "#aaa",
-              textDecorationStyle: "solid",
+              textDecorationColor: theme("color.ssw.gray.light"),
               textDecorationThickness: "1px",
             },
             ul: {


### PR DESCRIPTION
Affected Route: `/`

Fixed #3093

Screenshot:
![image](https://github.com/user-attachments/assets/4d72381b-11b2-4b03-8f97-46174c95c820)

**Figure: Link on the consulting page** 



