### PR TITLE
🐛 Fixed tina cache folder not being writable in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 
 
 # Create a folder with read/write permissions for tina cache files
-RUN mkdir -p chmod 666 /app/tina
+RUN mkdir -p /app/tina && chmod 666 /app/tina
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,6 @@ FROM base AS builder
 WORKDIR /app
 
 
-# Create a folder with read/write permissions for tina cache files
-RUN mkdir -p /app/tina && chmod 666 /app/tina
-
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
@@ -110,6 +107,10 @@ COPY --from=builder /app/public ./public
 # Set the correct permission for prerender cache
 RUN mkdir .next
 RUN chown nextjs:nodejs .next
+
+# Set the correct permissions for the tina cache folder
+RUN mkdir -p app/tina
+RUN chown -p nextjs:nodejs app/tina
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,8 @@ RUN mkdir .next
 RUN chown nextjs:nodejs .next
 
 # Set the correct permissions for the tina cache folder
-RUN mkdir -p app/tina
-RUN chown -p nextjs:nodejs app/tina
+RUN mkdir -p /app/tina
+RUN chown nextjs:nodejs /app/tina
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN \
 FROM base AS builder
 WORKDIR /app
 
+
+# Create a folder with read/write permissions for tina cache files
+RUN mkdir -p chmod 666 /app/tina
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 


### PR DESCRIPTION
### Description
The events API was failing because Next JS was attempting to cache files from Tina without the appropriate permissions. I've remedied this issue buy giving Next JS write permissions for the appropriate cache folder.

### Relevant Issue
- Fixed #3123

~~- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template~~

~~- [ ] Include done video or screenshots~~


