### PR TITLE
⚠️🔧 HOTFIX - Fix client side exception on home page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -59,8 +59,8 @@ export default async function RootLayout({
   });
 
   const liveStreamData: EventInfoStatic =
-    nextUG.data.eventsCalendarConnection.edges.length > 0
-      ? nextUG.data.eventsCalendarConnection.edges[0].node
+    nextUG?.data?.eventsCalendarConnection?.edges?.length > 0
+      ? nextUG?.data?.eventsCalendarConnection?.edges[0]?.node
       : null;
 
   return (
@@ -76,9 +76,11 @@ export default async function RootLayout({
         >
           <header className="no-print">
             <Suspense>
-              <LiveStream event={liveStreamData}>
-                <MenuWrapper menu={menuData.data.megamenu.menuGroups} />
-              </LiveStream>
+              {liveStreamData && (
+                <LiveStream event={liveStreamData}>
+                  <MenuWrapper menu={menuData.data.megamenu.menuGroups} />
+                </LiveStream>
+              )}
             </Suspense>
           </header>
           <main className="grow bg-white">{children}</main>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -125,7 +125,7 @@ export const Layout = ({
           )}
         >
           <header className="no-print">
-            {(showBanner || router?.query?.liveBanner?.length > 0) && (
+            {event && (showBanner || router?.query?.liveBanner?.length > 0) && (
               <LiveStreamBanner
                 countdownMins={countdownMins}
                 liveStreamData={event}
@@ -133,7 +133,7 @@ export const Layout = ({
               />
             )}
             <div className="mx-auto max-w-9xl px-8">
-              {(isLive || router.query.liveStream) && (
+              {event && (isLive || router?.query?.liveStream) && (
                 <LiveStreamWidget
                   event={event}
                   countdownMins={countdownMins}

--- a/hooks/useLiveStreamProps.ts
+++ b/hooks/useLiveStreamProps.ts
@@ -15,12 +15,12 @@ export function useLiveStreamTimer(event: EventInfo): LiveStreamProps {
 
   useEffect(() => {
     const rightnow = dayjs().utc();
-    const liveDelay = event.liveStreamDelayMinutes ?? 0;
-    if (!liveStreamDelayMinutes && event.delayedLiveStreamStart) {
+    const liveDelay = event?.liveStreamDelayMinutes ?? 0;
+    if (!liveStreamDelayMinutes && event?.delayedLiveStreamStart) {
       setLiveStreamDelayMinutes(liveDelay);
     }
 
-    const start = dayjs(event.startDateTime).add(liveDelay, "minute");
+    const start = dayjs(event?.startDateTime).add(liveDelay, "minute");
     const minsToStart = start.diff(rightnow, "minute");
     setCountdownMins(minsToStart);
 


### PR DESCRIPTION
### Description

Because the event banner does not have fallback behavior for when there is no upcoming event it will attempt to de-structure a null property if there is no upcoming event.

### Changes
🔧 Live stream banner will not display if the event is null

### Fixed Issue

- Fixed #3130

