### PR TITLE
SEMrsuh - fixing duplicate titles & meta description 

### DIFF
--- a/content/industry/index/index.json
+++ b/content/industry/index/index.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "Explore SSW's expertise across various industries",
+    "title": "Explore SSW's expertise across various industries.",
     "canonical": "/industry"
   },
   "title": "Industries we work with",

--- a/content/industry/index/index.json
+++ b/content/industry/index/index.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "SSW Consulting Services | Over 25 years of experience developing awesome solutions on top of Angular, React, Blazor, .NET, Azure, GitHub, DevOps (was VSTS/TFS), Power Apps, Power Automate, Power BI, SharePoint, Dynamics and SQL Server",
+    "title": "Explore SSW's expertise across various industries",
     "canonical": "/industry"
   },
   "title": "Industries we work with",

--- a/content/industry/index/index.json
+++ b/content/industry/index/index.json
@@ -1,6 +1,7 @@
 {
   "seo": {
-    "title": "Explore SSW's expertise across various industries.",
+    "title": "SSW Industry",
+    "description": "Explore SSW's expertise across various industries",
     "canonical": "/industry"
   },
   "title": "Industries we work with",

--- a/content/industry/index/index.json
+++ b/content/industry/index/index.json
@@ -1,7 +1,7 @@
 {
   "seo": {
     "title": "SSW Industry",
-    "description": "Explore SSW's expertise across various industries",
+    "description": "Explore SSW's expertise across various industries.",
     "canonical": "/industry"
   },
   "title": "Industries we work with",

--- a/content/products/index/index.json
+++ b/content/products/index/index.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "SSW Consulting Services | Over 25 years of experience developing awesome solutions on top of Angular, React, Blazor, .NET, Azure, GitHub, DevOps (was VSTS/TFS), Power Apps, Power Automate, Power BI, SharePoint, Dynamics and SQL Server",
+    "title": " Explore SSW's products built with the latest tech stack.",
     "canonical": "/products"
   },
   "title": "SSW Products",

--- a/content/products/index/index.json
+++ b/content/products/index/index.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": " Explore SSW's products built with the latest tech stack.",
+    "title": "Explore SSW's products built with the latest tech stack.",
     "canonical": "/products"
   },
   "title": "SSW Products",

--- a/content/products/index/index.json
+++ b/content/products/index/index.json
@@ -1,6 +1,7 @@
 {
   "seo": {
-    "title": "Explore SSW's products built with the latest tech stack.",
+    "title": "SSW Products",
+    "description": "Explore SSW's products built with the latest tech stack.",
     "canonical": "/products"
   },
   "title": "SSW Products",


### PR DESCRIPTION
Suggested by SEMrush

Affected Routes:
- `/products`
- `/industry`

