### PR TITLE
🐛 Megamenu - Fix mega menu not appearing on app router pages

### DIFF
--- a/app/components/MenuWrapper.tsx
+++ b/app/components/MenuWrapper.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+type MenuWrapperProps = {
+  children: React.ReactNode;
+};
+export const MenuWrapper = (props: MenuWrapperProps) => {
+  return <div className="mx-auto max-w-9xl px-8">{props.children}</div>;
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,12 +58,10 @@ export default async function RootLayout({
     top: 1,
     calendarType: "User Groups",
   });
-
   const liveStreamData: EventInfoStatic =
     nextUG?.data?.eventsCalendarConnection?.edges?.length > 0
       ? nextUG?.data?.eventsCalendarConnection?.edges[0]?.node
       : null;
-
   return (
     <html lang="en" className={openSans.className}>
       <body>
@@ -76,16 +74,17 @@ export default async function RootLayout({
           )}
         >
           <header className="no-print">
-            <Suspense>
-              {liveStreamData && (
+            {liveStreamData ? (
+              <Suspense>
                 <LiveStream event={liveStreamData}>
                   <MegaMenuWrapper menu={menuData.data.megamenu.menuGroups} />
                 </LiveStream>
-              )}
-            </Suspense>
-            <MenuWrapper>
-              <MegaMenuWrapper menu={menuData.data.megamenu.menuGroups} />
-            </MenuWrapper>
+              </Suspense>
+            ) : (
+              <MenuWrapper>
+                <MegaMenuWrapper menu={menuData.data.megamenu.menuGroups} />
+              </MenuWrapper>
+            )}
           </header>
           <main className="grow bg-white">{children}</main>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import { Open_Sans } from "next/font/google";
 // import Head from "next/head";
 // import { Theme } from "../components/layout/theme";
 import { Footer } from "@/components/layout/footer/footer";
-import { MenuWrapper } from "@/components/server/MenuWrapper";
+import { MegaMenuWrapper } from "@/components/server/MegaMenuWrapper";
 import ChatBaseBot from "@/components/zendeskButton/chatBaseBot";
 import { Metadata, Viewport } from "next";
 
@@ -21,6 +21,7 @@ import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { Suspense } from "react";
 import client from "../tina/__generated__/client";
+import { MenuWrapper } from "./components/MenuWrapper";
 import { LiveStream } from "./live-steam-banner/live-stream";
 import { DEFAULT } from "./meta-data/default";
 import { getMegamenu } from "./utils/get-mega-menu";
@@ -78,10 +79,13 @@ export default async function RootLayout({
             <Suspense>
               {liveStreamData && (
                 <LiveStream event={liveStreamData}>
-                  <MenuWrapper menu={menuData.data.megamenu.menuGroups} />
+                  <MegaMenuWrapper menu={menuData.data.megamenu.menuGroups} />
                 </LiveStream>
               )}
             </Suspense>
+            <MenuWrapper>
+              <MegaMenuWrapper menu={menuData.data.megamenu.menuGroups} />
+            </MenuWrapper>
           </header>
           <main className="grow bg-white">{children}</main>
 

--- a/app/live-steam-banner/live-stream.tsx
+++ b/app/live-steam-banner/live-stream.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MenuWrapper } from "app/components/MenuWrapper";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import isBetween from "dayjs/plugin/isBetween";
@@ -110,7 +111,7 @@ export function LiveStream({ event, children }: LiveStreamProps) {
           isLive={!!isLive}
         />
       )}
-      <div className="mx-auto max-w-9xl px-8">
+      <MenuWrapper>
         {(isLive || params.get("liveStream")) && (
           <LiveStreamWidget
             {...{ eventDynamic, liveStreamDelayMinutes }}
@@ -119,7 +120,7 @@ export function LiveStream({ event, children }: LiveStreamProps) {
           />
         )}
         {children}
-      </div>
+      </MenuWrapper>
     </>
   );
 }

--- a/components/server/MegaMenuWrapper.tsx
+++ b/components/server/MegaMenuWrapper.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import { MegaMenuLayout } from "ssw.megamenu";
 import { CustomLink } from "../customLink";
 
-export function MenuWrapper(props) {
+export function MegaMenuWrapper(props) {
   return (
     <MegaMenuLayout
       menuBarItems={props.menu}


### PR DESCRIPTION
### Description

In a previous [PR](https://github.com/SSWConsulting/SSW.Website/pull/3129) I added some fallback logic to ensure the live stream component wouldn't attempt to load if there was no upcoming event. However I didn't realize that the megamenu was being embedded in that component. Therefore whenever there's no upcoming livestream the megamenu wouldn't display.



- Fixed #3136 


