### PR TITLE
Fixing layout shifting issue on Homepage

### DIFF
--- a/components/blocks/bigCardContent.tsx
+++ b/components/blocks/bigCardContent.tsx
@@ -1,0 +1,77 @@
+import dynamic from "next/dynamic";
+import React, { memo } from "react";
+import { tinaField } from "tinacms/dist/react";
+import { CustomLink } from "../customLink";
+import { serviceCards } from "./serviceCards";
+
+const Image = dynamic(() => import("next/image"), { ssr: false });
+
+interface BigCardContentProps {
+  card: {
+    title: string;
+    link?: string;
+    imgSrc?: string;
+    description: string;
+    color: string;
+  };
+  index: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  schema: any;
+  bgColor: { [key: string]: string };
+}
+
+const BigCardContent = memo(
+  ({ card, index, schema, bgColor }: BigCardContentProps) => {
+    return (
+      <li
+        key={card.title}
+        className={`col-span-1 flex flex-col divide-y divide-gray-200 text-center shadow ${bgColor[card.color]} hover:opacity-80`}
+      >
+        <CustomLink
+          href={card.link ?? ""}
+          className="unstyled flex grow text-left text-white"
+        >
+          <div className="flex grow flex-col">
+            {card?.imgSrc && (
+              <div className="absolute flex-1 self-end">
+                <Image
+                  className="opacity-50"
+                  src={card.imgSrc ?? ""}
+                  width={100}
+                  height={100}
+                  sizes="20vw"
+                  alt={`Icon for ${card.title}`}
+                  loading="lazy"
+                />
+              </div>
+            )}
+            <div className="relative flex grow flex-col p-8">
+              <h3
+                className="flex pb-3 text-2xl font-thin lg:pt-8"
+                data-tina-field={tinaField(
+                  schema.bigCards[index],
+                  serviceCards.bigCards.title
+                )}
+              >
+                {card.title}
+              </h3>
+              <div className="grow"></div>
+              <p
+                data-tina-field={tinaField(
+                  schema.bigCards[index],
+                  serviceCards.bigCards.description
+                )}
+              >
+                {card.description}
+              </p>
+            </div>
+          </div>
+        </CustomLink>
+      </li>
+    );
+  }
+);
+
+BigCardContent.displayName = "BigCardContent";
+
+export default BigCardContent;

--- a/components/blocks/carousel.tsx
+++ b/components/blocks/carousel.tsx
@@ -1,4 +1,3 @@
-"use client";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import * as React from "react";
@@ -6,16 +5,13 @@ import { tinaField } from "tinacms/dist/react";
 
 import type { Template } from "tinacms";
 
-import dynamic from "next/dynamic";
 import useIsMobile from "../../hooks/useIsMobile";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 
-const CarouselImplementation = dynamic(() =>
-  import("react-responsive-carousel").then((module) => module.Carousel)
-);
+import { Carousel as CarouselImplementation } from "react-responsive-carousel";
 
 export const Carousel = ({ data }) => {
   const router = useRouter();
@@ -51,7 +47,6 @@ export const Carousel = ({ data }) => {
         className={/* eslint-disable-line */ "aspect-carousel w-full"}
         data-tina-field={tinaField(data, carouselBlock.delay)}
       >
-        {/* @ts-expect-error next/dynamic */}
         <CarouselImplementation
           autoPlay={true}
           infiniteLoop={true}

--- a/components/blocks/carousel.tsx
+++ b/components/blocks/carousel.tsx
@@ -100,7 +100,7 @@ const CarouselItemImage = (props: CarouselItemImageProps) => {
         alt={label}
         height={388}
         width={1080}
-        sizes="100vw"
+        sizes="(max-width: 640px) 50vw, 100vw"
         priority={index === 0}
       />
       {/* `legend` required so that the carousel works properly */}

--- a/components/blocks/serviceCards.tsx
+++ b/components/blocks/serviceCards.tsx
@@ -5,7 +5,7 @@ const Image = dynamic(() => import("next/image"), { ssr: false });
 import type { Template } from "tinacms";
 
 import dynamic from "next/dynamic";
-import React, { Profiler, useMemo } from "react";
+import React, { useMemo } from "react";
 import { CustomLink } from "../customLink";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
@@ -26,18 +26,11 @@ export const ServiceCards = ({ data }) => {
         data-tina-field={tinaField(data, serviceCards.bigCardsLabel)}
       >
         <div className="py-4">
-          <Profiler
-            id="bigCards"
-            onRender={(id, phase, actualDuration) => {
-              console.log("Profiler", { id, phase, actualDuration });
-            }}
-          >
-            <BigCards
-              title={data.bigCardsLabel}
-              cards={data.bigCards}
-              schema={data}
-            />
-          </Profiler>
+          <BigCards
+            title={data.bigCardsLabel}
+            cards={data.bigCards}
+            schema={data}
+          />
         </div>
 
         <div className="py-4">

--- a/components/blocks/serviceCards.tsx
+++ b/components/blocks/serviceCards.tsx
@@ -5,9 +5,11 @@ const Image = dynamic(() => import("next/image"), { ssr: false });
 import type { Template } from "tinacms";
 
 import dynamic from "next/dynamic";
+import React, { Profiler, useMemo } from "react";
 import { CustomLink } from "../customLink";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
+import BigCardContent from "./bigCardContent";
 
 const bgColor = {
   red: "bg-sswRed",
@@ -24,11 +26,18 @@ export const ServiceCards = ({ data }) => {
         data-tina-field={tinaField(data, serviceCards.bigCardsLabel)}
       >
         <div className="py-4">
-          <BigCards
-            title={data.bigCardsLabel}
-            cards={data.bigCards}
-            schema={data}
-          />
+          <Profiler
+            id="bigCards"
+            onRender={(id, phase, actualDuration) => {
+              console.log("Profiler", { id, phase, actualDuration });
+            }}
+          >
+            <BigCards
+              title={data.bigCardsLabel}
+              cards={data.bigCards}
+              schema={data}
+            />
+          </Profiler>
         </div>
 
         <div className="py-4">
@@ -57,6 +66,8 @@ const Label = ({ text, schema, cardLabel }) => {
 };
 
 const BigCards = ({ title, cards, schema }) => {
+  const memoizedCards = useMemo(() => cards, [cards]);
+
   return (
     <>
       <Label
@@ -68,54 +79,14 @@ const BigCards = ({ title, cards, schema }) => {
         role="list"
         className="mt-5 grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-4"
       >
-        {cards.map((card, index) => (
-          <li
+        {memoizedCards.map((card, index) => (
+          <BigCardContent
             key={card.title}
-            className={`col-span-1 flex flex-col divide-y divide-gray-200 text-center shadow ${
-              bgColor[card.color]
-            } hover:opacity-80`}
-          >
-            <CustomLink
-              href={card.link ?? ""}
-              className="unstyled flex grow text-left text-white"
-            >
-              <div className="flex grow flex-col">
-                {card?.imgSrc && (
-                  <div className="absolute flex-1 self-end">
-                    <Image
-                      className="opacity-50"
-                      src={card.imgSrc ?? ""}
-                      width="100"
-                      height="100"
-                      sizes="20vw"
-                      alt={`Icon for ${card.title}`}
-                      loading="lazy"
-                    />
-                  </div>
-                )}
-                <div className="relative flex grow flex-col p-8">
-                  <h3
-                    className="flex pb-3 text-2xl font-thin lg:pt-8"
-                    data-tina-field={tinaField(
-                      schema.bigCards[index],
-                      serviceCards.bigCards.title
-                    )}
-                  >
-                    {card.title}
-                  </h3>
-                  <div className="grow"></div>
-                  <p
-                    data-tina-field={tinaField(
-                      schema.bigCards[index],
-                      serviceCards.bigCards.description
-                    )}
-                  >
-                    {card.description}
-                  </p>
-                </div>
-              </div>
-            </CustomLink>
-          </li>
+            card={card}
+            index={index}
+            schema={schema}
+            bgColor={bgColor}
+          />
         ))}
       </ul>
     </>


### PR DESCRIPTION
Issue: #3156
![image](https://github.com/user-attachments/assets/71f4b0a5-8286-47e5-8e6b-8da2b8a54b54)
**Figure: Error: duplicate images being loaded on the homage page**

✅ Removing the code splitting logic for carousel to avoid any delays and cumulative layout shifts 
✅ Tested it local with nginx server with throttling (3G), seems to have no cumulative shift anymore 

