### PR TITLE
Fixed sidebar going over the limits of the page

### DIFF
--- a/pages/company/[filename].tsx
+++ b/pages/company/[filename].tsx
@@ -83,7 +83,7 @@ export default function CompanyPage(
                 <div className="max-w-sm shrink pl-16">
                   {data.company.sidebar && (
                     <div
-                      className={classNames("md:block lg:min-w-96", {
+                      className={classNames("md:block", {
                         hidden: data.company.hideSidebarOnMobile,
                         "min-w-fit": data.company.fixedWidthSidebar,
                       })}


### PR DESCRIPTION
To fix the right spacing, I removed that extra class `md:block lg:min-w-96` from this DIV

<img width="1717" alt="Screenshot 2024-10-18 at 1 37 19 PM" src="https://github.com/user-attachments/assets/a4362a75-ce94-46c1-bdaf-65999102e8b6">

@andrewwaltosssw 

I think this was caused by this change: https://github.com/SSWConsulting/SSW.Website/commit/87c3b2d7bc16ffc7e0feca0c7701789e1c43fd2b

1. Please double check my PR won't affect other pages you might have added that class for.

---

- Affected routes: https://www.ssw.com.au/company/about-us 

- Fixed https://github.com/SSWConsulting/SSW.Website/issues/3231




