### PR TITLE
Upgrading app service plan to P1V3

### DIFF
--- a/infra/appService.bicep
+++ b/infra/appService.bicep
@@ -5,30 +5,11 @@ param tags object
 param dockerRegistryServerURL string
 param appInsightConnectionString string
 param keyVaultName string
+param skuName string
+param skuCapacity int
 
 param healthCheckPath string = '/'
 
-@allowed([
-  'B1'
-  'B2'
-  'B3'
-  'S1'
-  'S2'
-  'S3'
-  'P1'
-  'P2'
-  'P3'
-  'P1V2'
-  'P2V2'
-  'P3V2'
-  'P1V3'
-  'P2V3'
-  'P3V3'
-])
-param skuName string = 'P1V2'
-
-@minValue(1)
-param skuCapacity int = 1
 
 param acrName string
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,7 +19,7 @@ param servicePrincipalObjectId string
   'P2V3'
   'P3V3'
 ])
-param skuName string = 'P1V2'
+param skuName string = 'P1V3'
 
 
 @minValue(1)


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

Upgrading the app service plan to P1V3 - giving us more CPU & RAM.
SKU details here: https://azure.microsoft.com/en-us/pricing/details/app-service/linux/

- Fixed: #3243 
i.e. the website was crashing when there were too many PR slots running.

We also found that the SKU was being set twice - we removed this from appService.bicep and kept it in main.bicep.