### PR TITLE
♻️ Change font family to Inter

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { Metadata, Viewport } from "next";
-import { Open_Sans } from "next/font/google";
+import { Inter } from "next/font/google";
 import client from "../tina/__generated__/client";
 import { MenuWrapper } from "./components/MenuWrapper";
 import { WebVitals } from "./components/web-vitals";
@@ -27,8 +27,8 @@ dayjs.extend(utc);
 dayjs.extend(advancedFormat);
 dayjs.extend(isBetween);
 
-const openSans = Open_Sans({
-  variable: "--open-sans-font",
+const inter = Inter({
+  variable: "--inter-font",
   subsets: ["latin"],
   display: "swap",
   weight: ["400", "600", "700"],
@@ -67,7 +67,7 @@ export default async function RootLayout({
       ? nextUG?.data?.eventsCalendarConnection?.edges[0]?.node
       : null;
   return (
-    <html lang="en" className={openSans.className}>
+    <html lang="en" className={inter.className}>
       <body>
         {/* <Theme> */}
         {/* Ensures next/font CSS variable is accessible for all components */}

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -13,14 +13,14 @@ import {
 import { useAppInsightsContext } from "@microsoft/applicationinsights-react-js";
 import dayjs from "dayjs";
 import dynamic from "next/dynamic";
-import { Open_Sans } from "next/font/google";
+import { Inter } from "next/font/google";
 import { useReportWebVitals } from "next/web-vitals";
 import { MegaMenuLayout, NavMenuGroup } from "ssw.megamenu";
 import { CustomLink } from "../customLink";
 import { ErrorBoundary } from "../util/error/error-boundary";
 
-const openSans = Open_Sans({
-  variable: "--open-sans-font",
+const inter = Inter({
+  variable: "--inter-font",
   subsets: ["latin"],
 });
 
@@ -114,13 +114,13 @@ export const Layout = ({
         {/* Ensures next/font CSS variable is accessible for all components */}
         <style jsx global>{`
           :root {
-            --open-sans-font: ${openSans.style.fontFamily};
+            --inter-font: ${inter.style.fontFamily};
           }
         `}</style>
         <div
           className={classNames(
             "flex min-h-screen flex-col font-sans",
-            openSans.className,
+            inter.className,
             className
           )}
         >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -198,15 +198,10 @@ export default {
         "tooltip",
       ], // ordered by z-index ascendant
       fontFamily: {
-        sans: [
-          "var(--open-sans-font)",
-          "Helvetica Neue",
-          "Helvetica",
-          "sans-serif",
-        ],
+        sans: ["var(--inter-font)"],
         helvetica: ["Helvetica Neue", "Helvetica", "sans-serif"],
         body: [
-          "var(--open-sans-font)",
+          "var(--inter-font)",
           "Helvetica Neue",
           "Helvetica",
           "sans-serif",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -198,7 +198,12 @@ export default {
         "tooltip",
       ], // ordered by z-index ascendant
       fontFamily: {
-        sans: ["var(--inter-font)"],
+        sans: [
+          "var(--inter-font)",
+          "Helvetica Neue",
+          "Helvetica",
+          "sans-serif",
+        ],
         helvetica: ["Helvetica Neue", "Helvetica", "sans-serif"],
         body: [
           "var(--inter-font)",


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: All pages font family

- Fixed #3269 

This pull request focuses on replacing the Google font `Open_Sans` with `Inter` across the project.

Font replacement:

* `app/layout.tsx`: Replaced `Open_Sans` with `Inter` in the font import, initialization, and usage in the HTML element.
* `components/layout/layout.tsx`: Updated the font import, initialization, and usage in the global CSS and component class names from `Open_Sans` to `Inter`.
* `tailwind.config.js`: Replaced `--open-sans-font` variable with `--inter-font` variable

![image](https://github.com/user-attachments/assets/5db97b59-855a-478d-9640-915578ce9e70)
**Figure: html and body tag's font family is changed to Inter**


