### PR TITLE
Fixed bleed effect for image being in top right corner

### DIFF
--- a/components/layout/v2ComponentWrapper.tsx
+++ b/components/layout/v2ComponentWrapper.tsx
@@ -43,12 +43,13 @@ const V2ComponentWrapper = ({
         className
       )}
     >
-      {data.background?.bleed ? (
-        <div>
+      {data.background?.bleed && data.background?.backgroundImage ? (
+        <div className="absolute aspect-video w-full">
           <Image
             src={data.background?.backgroundImage}
-            className="absolute inset-0 w-full object-cover"
+            className="absolute inset-0 object-cover"
             alt="background image"
+            layout="fill"
             fill={true}
           />
         </div>
@@ -114,6 +115,20 @@ export const backgroundSchema = {
       type: "boolean",
       label: "Bleed",
       name: "bleed",
+      ui: {
+        validate: (value, data) => {
+          if (!data.background?.backgroundImage && value) {
+            for (const component of data.blocks) {
+              if (
+                !component.background?.backgroundImage &&
+                component.background?.bleed
+              ) {
+                return "Ensure all components images with bleed enabled have an image.";
+              }
+            }
+          }
+        },
+      },
       description: "If true, the background will bleed into lower blocks.",
     },
   ],


### PR DESCRIPTION
### Description
This PR fixes the bleed effect for the background image of the consulting page v2 components.

- Affected routes: /consulting/*

- Fixed #3319

### Screenshot

![image](https://github.com/user-attachments/assets/7979b493-fefd-487d-9a25-664016903d58)

**Figure**: **Fixed bleed effect for consulting page v2 components**
- [ ] Include done video or screenshots


