### PR TITLE
🧪 Tests - update events to account for current year

### DIFF
--- a/__tests__/helpers/dates.ts
+++ b/__tests__/helpers/dates.ts
@@ -1,40 +1,41 @@
 import { describe, expect, it } from "@jest/globals";
-import {
-  formatEventDate,
-  formatEventLongDate,
-  formatRelativeEventDate,
-} from "../../helpers/dates";
-
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import isBetween from "dayjs/plugin/isBetween";
 import relativeTime from "dayjs/plugin/relativeTime";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
+import {
+  formatEventDate,
+  formatEventLongDate,
+  formatRelativeEventDate,
+} from "../../helpers/dates";
 dayjs.extend(relativeTime);
 dayjs.extend(timezone);
 dayjs.extend(utc);
 dayjs.extend(advancedFormat);
 dayjs.extend(isBetween);
 
+const currentYear = dayjs().year();
+
 describe("formatEventDate", () => {
-  it("Single Day Event - Date format", () => {
-    const startDate = new Date(2024, 1, 1); // February 1, 2024
-    const endDate = new Date(2024, 1, 1); // February 1, 2024
+  it("Single Day Event - Current year - Date format", () => {
+    const startDate = new Date(currentYear, 1, 1); // February 1, <current year>
+    const endDate = new Date(currentYear, 1, 1); // February 1, <current year>
     const result = formatEventDate(startDate, endDate);
     expect(result).toBe("Feb 1");
   });
 
   it("Single Day Event - Different year - Date format", () => {
-    const startDate = new Date(2025, 1, 1); // February 1, 2024
-    const endDate = new Date(2025, 1, 1); // February 1, 2024
+    const startDate = new Date(2999, 1, 1); // February 1, 2999
+    const endDate = new Date(2999, 1, 1); // February 1, 2999
     const result = formatEventDate(startDate, endDate);
-    expect(result).toBe("Feb 1 2025");
+    expect(result).toBe("Feb 1 2999");
   });
 
-  it("Mutiple Days Event - Date format", () => {
-    const startDate = new Date(2024, 1, 1); // February 1, 2024
-    const endDate = new Date(2024, 1, 2); // February 2, 2024
+  it("Mutiple Days Event - Current year - Date format", () => {
+    const startDate = new Date(currentYear, 1, 1); // February 1, <current year>
+    const endDate = new Date(currentYear, 1, 2); // February 2, <current year>
     const result = formatEventDate(startDate, endDate);
     expect(result).toBe("Feb 1 - Feb 2");
   });


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

### Description

The unit tests for the date conversion method are broken. I suspect this is because the tests were written assuming the year was 2024 but it's now 2025. 

- Fixed: #3438

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [ ] Include done video or screenshots


