### PR TITLE
Remove "Other SSW Services" from menu

### DIFF
--- a/content/megamenu/menu.json
+++ b/content/megamenu/menu.json
@@ -64,12 +64,6 @@
                   "url": "/consulting?tag=Cloud-and+Infrastructure",
                   "description": "Designing scalable, secure, and resilient cloud computing environments",
                   "iconImg": "/images/megamenu-icons/CloudAndInfrastructure.svg"
-                },
-                {
-                  "name": "Other SSW Services",
-                  "url": "/consulting?tag=Other-SSW+Services",
-                  "description": "SSW's other enterprise software development services",
-                  "iconImg": "/images/megamenu-icons/OtherSSWService.svg"
                 }
               ]
             }


### PR DESCRIPTION
cc @adamcogan 

As per @uly1 request on "Re: Consulting - we clicked the link and it gave Brainstorming as #1 - WTF"

> ![image](https://github.com/user-attachments/assets/f48f6431-8544-4abb-9a84-4f33184d2e0c)



