### PR TITLE
3444 add lead capture image text

### DIFF
--- a/components/blocks/cardCarousel/cardCarousel/cardCarousel.tsx
+++ b/components/blocks/cardCarousel/cardCarousel/cardCarousel.tsx
@@ -72,7 +72,7 @@ export const CardCarousel = ({ data }) => {
                   />
                 );
 
-                return button.buttonLink ? (
+                return button.buttonLink && !button.showLeadCaptureForm ? (
                   <Link href={button.buttonLink} key={`link-wrapper-${index}`}>
                     {buttonElement}
                   </Link>

--- a/components/blocks/imageComponents/accordionBlock/accordionBlock.tsx
+++ b/components/blocks/imageComponents/accordionBlock/accordionBlock.tsx
@@ -60,7 +60,7 @@ export const AccordionBlock = ({ data }) => {
               />
             );
 
-            return button.buttonLink ? (
+            return button.buttonLink && !button.showLeadCaptureForm ? (
               <Link href={button.buttonLink} key={`link-wrapper-${index}`}>
                 {buttonElement}
               </Link>

--- a/components/blocks/imageComponents/imageTextBlock/imageTextBlock.tsx
+++ b/components/blocks/imageComponents/imageTextBlock/imageTextBlock.tsx
@@ -80,7 +80,7 @@ export const ImageTextBlock = ({ data }) => {
               />
             );
 
-            return button.buttonLink ? (
+            return button.buttonLink && !button.showLeadCaptureForm ? (
               <Link href={button.buttonLink} key={`link-wrapper-${index}`}>
                 {buttonElement}
               </Link>

--- a/components/button/rippleButtonV2.tsx
+++ b/components/button/rippleButtonV2.tsx
@@ -18,6 +18,7 @@ interface RippleButtonProps
   fontClassName?: string;
   duration?: string;
   variant: ColorVariant;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
 const RippleButton = React.forwardRef<HTMLButtonElement, RippleButtonProps>(
@@ -30,6 +31,7 @@ const RippleButton = React.forwardRef<HTMLButtonElement, RippleButtonProps>(
       rippleColor = "rgba(0, 0, 0, 0.25)",
       duration = "600ms",
       textTinaField,
+      onClick = () => {},
       ...props
     },
     ref
@@ -64,6 +66,7 @@ const RippleButton = React.forwardRef<HTMLButtonElement, RippleButtonProps>(
 
     return (
       <button
+        onClick={(e) => onClick(e)}
         className={cn(
           "text-primary relative cursor-pointer items-center justify-center overflow-hidden rounded-md px-6 py-3 text-center",
           "",

--- a/components/button/templateButton.schema.tsx
+++ b/components/button/templateButton.schema.tsx
@@ -9,6 +9,11 @@ export const buttonSchema = [
     name: "buttonText",
   },
   {
+    type: "boolean",
+    label: "Show lead capture form",
+    name: "showLeadCaptureForm",
+  },
+  {
     type: "string",
     label: "Button Link",
     name: "buttonLink",

--- a/components/button/templateButton.tsx
+++ b/components/button/templateButton.tsx
@@ -1,7 +1,12 @@
 import { Icon } from "@/components/blocksSubtemplates/tinaFormElements/icon";
 import classNames from "classnames";
+import { useState } from "react";
+import Jotform from "react-jotform";
 import { tinaField } from "tinacms/dist/react";
+import Popup from "../popup/popup";
 import RippleButton, { ButtonTinaFields, ColorVariant } from "./rippleButtonV2";
+
+import globals from "../../content/global/index.json";
 
 enum ButtonColors {
   Red = 0,
@@ -13,6 +18,8 @@ export interface TemplateButtonOptions extends ButtonTinaFields {
   colour?: ButtonColors;
   iconFirst?: boolean;
   icon?: string;
+  showLeadCaptureForm?: boolean;
+  onClick?: () => void;
 }
 
 export const Button = ({
@@ -22,27 +29,44 @@ export const Button = ({
   className: string;
   data: TemplateButtonOptions;
 }) => {
+  const [open, setOpen] = useState(false);
   const variants: ColorVariant[] = ["primary", "secondary"];
   const { iconFirst, buttonText, colour } = data;
   return (
-    <RippleButton
-      textTinaField={tinaField(data, "buttonText")}
-      className={className}
-      fontClassName={classNames(
-        "gap-0.5",
-        iconFirst ? "flex-row" : "flex-row-reverse"
-      )}
-      variant={variants[colour]}
-    >
-      <Icon
-        tinaField={tinaField(data, "icon")}
-        className="size-6"
-        data={{
-          name: data.icon,
+    <>
+      <RippleButton
+        onClick={() => {
+          if (data.showLeadCaptureForm) setOpen(true);
         }}
-      />
+        textTinaField={tinaField(data, "buttonText")}
+        className={className}
+        fontClassName={classNames(
+          "gap-0.5",
+          iconFirst ? "flex-row" : "flex-row-reverse"
+        )}
+        variant={variants[colour]}
+      >
+        <Icon
+          tinaField={tinaField(data, "icon")}
+          className="size-6"
+          data={{
+            name: data.icon,
+          }}
+        />
 
-      {buttonText}
-    </RippleButton>
+        {buttonText}
+      </RippleButton>
+      {data.showLeadCaptureForm && (
+        <Popup
+          isVisible={open}
+          showCloseIcon={true}
+          onClose={() => setOpen(false)}
+        >
+          <Jotform
+            src={`https://form.jotform.com/${globals.bookingJotFormId}`}
+          ></Jotform>
+        </Popup>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->


This PR adds a toggle to all consulting page components with buttons. When the toggle is enabled, the button on the consulting page component will make the lead capture form appear.
- Affected routes: /consulting/*

- Fixed #3444 

- [x] Include done video or screenshots

![lead_capture_form_image_text_block](https://github.com/user-attachments/assets/6f39c422-bd63-474c-a2ab-c0204b4adf00)
**Figure**: **Lead capture form displaying on button click**

<br>

![image](https://github.com/user-attachments/assets/35912bd2-4b02-4539-a9b2-bfd789e57436)
**Figure**: **Button to enable lead capture form**