### PR TITLE
💄 Consultingv2 – Setting Card Index to Center on Tab Change / Initial Render

### DIFF
--- a/components/blocks/cardCarousel/layout/cardCarouseSlideshow.tsx
+++ b/components/blocks/cardCarousel/layout/cardCarouseSlideshow.tsx
@@ -23,6 +23,8 @@ type CardSlideshowProps = {
 
 const CardList = ({ activeCategory, data, hasImages }: CardSlideshowProps) => {
   const [cardData, setCardData] = useState(data.cards);
+  const [indexLength, setIndexLength] = useState(0);
+
   useEffect(() => {
     if (
       activeCategory &&
@@ -40,14 +42,20 @@ const CardList = ({ activeCategory, data, hasImages }: CardSlideshowProps) => {
   }, [activeCategory, data.cards]);
   useEffect(() => {
     setCardData(data.cards);
+    setIndexLength(data.cards?.length ?? 0);
   }, [data]);
 
   return (
     <div>
       <div className="mask-horizontal-fade">
         <Carousel
-          opts={{ align: "center", loop: true, containScroll: false }}
+          opts={{
+            align: "center",
+            loop: true,
+            containScroll: false,
+          }}
           className="w-full max-w-9xl"
+          itemLength={indexLength}
         >
           <CarouselContent>
             {cardData?.map((cardData, index) => {

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -18,6 +18,7 @@ type CarouselProps = {
   plugins?: CarouselPlugin;
   orientation?: "horizontal" | "vertical";
   setApi?: (api: CarouselApi) => void;
+  itemLength?: number;
 };
 
 type CarouselContextProps = {
@@ -54,6 +55,7 @@ const Carousel = React.forwardRef<
       plugins,
       className,
       children,
+      itemLength,
       ...props
     },
     ref
@@ -69,7 +71,7 @@ const Carousel = React.forwardRef<
         AutoPlay({
           delay: 5000,
           playOnInit: true,
-          stopOnInteraction: false,
+          stopOnInteraction: true,
           stopOnMouseEnter: true,
         }),
         ...(plugins || []),
@@ -135,6 +137,11 @@ const Carousel = React.forwardRef<
         api?.off("select", onSelect);
       };
     }, [api, onSelect]);
+
+    React.useEffect(() => {
+      api?.scrollTo(Math.floor((itemLength - 1) / 2));
+      setSelectedIndex(Math.floor((itemLength - 1) / 2));
+    }, [itemLength, api]);
 
     return (
       <CarouselContext.Provider

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -139,6 +139,9 @@ const Carousel = React.forwardRef<
     }, [api, onSelect]);
 
     React.useEffect(() => {
+      if (!api || !itemLength) {
+        return;
+      }
       api?.scrollTo(Math.floor((itemLength - 1) / 2));
       setSelectedIndex(Math.floor((itemLength - 1) / 2));
     }, [itemLength, api]);

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -139,11 +139,11 @@ const Carousel = React.forwardRef<
     }, [api, onSelect]);
 
     React.useEffect(() => {
-      if (!api || !itemLength) {
-        return;
+      const lengthOrApiMissing = !api || !itemLength
+      if (!lengthOrApiMissing ) {
+           api?.scrollTo(Math.floor((itemLength - 1) / 2));
+           setSelectedIndex(Math.floor((itemLength - 1) / 2));
       }
-      api?.scrollTo(Math.floor((itemLength - 1) / 2));
-      setSelectedIndex(Math.floor((itemLength - 1) / 2));
     }, [itemLength, api]);
 
     return (

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -139,10 +139,10 @@ const Carousel = React.forwardRef<
     }, [api, onSelect]);
 
     React.useEffect(() => {
-      const lengthOrApiMissing = !api || !itemLength
-      if (!lengthOrApiMissing ) {
-           api?.scrollTo(Math.floor((itemLength - 1) / 2));
-           setSelectedIndex(Math.floor((itemLength - 1) / 2));
+      const lengthOrApiMissing = !api || !itemLength;
+      if (!lengthOrApiMissing) {
+        api?.scrollTo(Math.floor((itemLength - 1) / 2));
+        setSelectedIndex(Math.floor((itemLength - 1) / 2));
       }
     }, [itemLength, api]);
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: consulting v2 components.
- For card-based components, in the carousel, sets the index on initial render and tab change to the centre index (or lower of centre indices for even length card lists).

- Fixed #3442.

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [ ] Include done video or screenshots


