### PR TITLE
💄V2 Card component - added option to embed Youtube videos inside the card carousel

### DIFF
--- a/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
+++ b/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
@@ -307,6 +307,13 @@ export const CardCarouselSchema: Template = {
           },
         },
         {
+          type: "string",
+          label: "Embed",
+          name: "embed",
+          description:
+            "The YouTube video ID to embed (https://www.youtube.com/watch?v=[embed]).",
+        },
+        {
           type: "image",
           label: "Image",
           name: "image",

--- a/components/blocks/cardCarousel/layout/card.tsx
+++ b/components/blocks/cardCarousel/layout/card.tsx
@@ -85,4 +85,3 @@ const Card = ({ data, placeholder }: CardProps) => {
 };
 
 export { Card };
-

--- a/components/blocks/cardCarousel/layout/card.tsx
+++ b/components/blocks/cardCarousel/layout/card.tsx
@@ -1,5 +1,6 @@
 import { ListItem } from "@/components/blocksSubtemplates/listItem";
 import { PillGroup } from "@/components/blocksSubtemplates/pillGroup";
+import { YouTubeEmbed } from "@/components/embeds/youtubeEmbed";
 import Image from "next/image";
 import { useState } from "react";
 import { tinaField } from "tinacms/dist/react";
@@ -24,23 +25,27 @@ const Card = ({ data, placeholder }: CardProps) => {
         })?.classes
       }`}
     >
-      {(data.image || placeholder) && (
-        <div
-          className="relative mb-2 min-h-36 w-full overflow-hidden rounded-md"
-          data-tina-field={tinaField(data, "image")}
-        >
-          <Image
-            src={
-              usePlaceholder
-                ? placeholderImage
-                : (data.image ?? placeholderImage)
-            }
-            onError={() => setUsePlaceholder(true)}
-            alt={data.altText ?? "Card Image"}
-            fill={true}
-            className={data.contain ? "object-contain" : "object-cover"}
-          />
-        </div>
+      {data.embed ? (
+        <YouTubeEmbed className="mb-2 min-h-36 w-full" id={data.embed} />
+      ) : (
+        (data.image || placeholder) && (
+          <div
+            className="relative mb-2 min-h-36 w-full overflow-hidden rounded-md"
+            data-tina-field={tinaField(data, "image")}
+          >
+            <Image
+              src={
+                usePlaceholder
+                  ? placeholderImage
+                  : (data.image ?? placeholderImage)
+              }
+              onError={() => setUsePlaceholder(true)}
+              alt={data.altText ?? "Card Image"}
+              fill={true}
+              className={data.contain ? "object-contain" : "object-cover"}
+            />
+          </div>
+        )
       )}
       <Icon data={{ name: data.icon }} className="size-6 text-sswRed" />
       {data.chips && <PillGroup data={data.chips} />}
@@ -80,3 +85,4 @@ const Card = ({ data, placeholder }: CardProps) => {
 };
 
 export { Card };
+

--- a/components/embeds/youtubeEmbed.tsx
+++ b/components/embeds/youtubeEmbed.tsx
@@ -1,7 +1,7 @@
 type YouTubeEmbedProps = {
   className?: string;
-  width: string;
-  height: string;
+  width?: string;
+  height?: string;
   id: string;
   autoplay?: boolean;
 };


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: /consulting/*

- Fixed #3474 

- [x] Include done video or screenshots

![image](https://github.com/user-attachments/assets/c965d6bd-71e1-4137-86e8-c023c16d54c9)

**Figure**: **Video embed in stacked layout**

![image](https://github.com/user-attachments/assets/bc20bbbf-7bf7-4536-b2b3-01525bb57740)

**Figure**: **Video embed in carousel layout**


![image](https://github.com/user-attachments/assets/3ea8d37e-b65c-4c33-80ab-2ab58c864717)

**Figure**: **Youtube embed field on card component**