### PR TITLE
Fixed title not appearing in related technology cards

### DIFF
--- a/components/blocks/cardCarousel/technologyCards/technologyCardCarousel.tsx
+++ b/components/blocks/cardCarousel/technologyCards/technologyCardCarousel.tsx
@@ -24,7 +24,7 @@ export const TechnologyCardCarousel = ({ data }) => {
         return {
           guid: card.node.associatedGroup?.name,
           image: card.node.thumbnail,
-          title: card.node.name,
+          heading: card.node.name,
           altText: card.node.name,
           description: card.node.body,
           embeddedButton: {


### PR DESCRIPTION
CC: @louisroa8189 

### Description:

The related technology card was passing in the wrong prop name for titles so the title wasn't appearing

- Affected routes: <!-- E.g. `/offices/brisbane`  -->

- Fixed #3320


- [x] Include done video or screenshots


![image](https://github.com/user-attachments/assets/ff9a23c8-ecfb-4244-a8b0-1e5eb245afd7)
**Figure**: **Title added to related technology cards**