### PR TITLE
💄Footer - Add Azure/TinaCMS banner to all page templates

### DIFF
--- a/app/articles/[filename]/index.tsx
+++ b/app/articles/[filename]/index.tsx
@@ -138,7 +138,7 @@ const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
             ? data.articles
             : {
                 azureBanner: {
-                  azureFooterColor: "default",
+                  azureFooterColor: "white",
                 },
               }
         }

--- a/app/articles/[filename]/index.tsx
+++ b/app/articles/[filename]/index.tsx
@@ -79,7 +79,7 @@ const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
       {data.articles.subTitle && (
         <section
           className={classNames(
-            "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 lg:flex"
+            "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8 lg:flex"
           )}
         >
           <div data-tina-field={tinaField(data.articles, "subTitle")}>

--- a/app/articles/[filename]/index.tsx
+++ b/app/articles/[filename]/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ArticleAuthor from "@/components/articles/articleAuthor";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
 import { CallToAction } from "@/components/callToAction/callToAction";
 import { PreFooter } from "@/components/layout/footer/pre-footer";
@@ -26,9 +27,9 @@ export type ArticlePageProps = {
 const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
   const { data } = tinaProps;
   const showCallToAction = data.articles.callToAction.showCallToAction;
-  const azureBannerColor = showCallToAction
-    ? SectionColor.Default
-    : SectionColor.LightGray;
+  const azureBannerColor: SectionColor = showCallToAction
+    ? "default"
+    : "lightgray";
   const { author } = data.articles;
   return (
     <>
@@ -85,7 +86,7 @@ const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
       {data.articles.subTitle && (
         <section
           className={classNames(
-            "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8 lg:flex"
+            "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 lg:flex"
           )}
         >
           <div data-tina-field={tinaField(data.articles, "subTitle")}>
@@ -138,9 +139,7 @@ const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
           )}
         </CallToAction>
       )}
-      {data.articles.showAzureFooter && (
-        <PreFooter backgroundColor={azureBannerColor} />
-      )}
+      <PreFooter data={data.articles} />
     </>
   );
 };

--- a/app/articles/[filename]/index.tsx
+++ b/app/articles/[filename]/index.tsx
@@ -79,7 +79,7 @@ const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
       {data.articles.subTitle && (
         <section
           className={classNames(
-            "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8 lg:flex"
+            "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 lg:flex"
           )}
         >
           <div data-tina-field={tinaField(data.articles, "subTitle")}>
@@ -135,11 +135,9 @@ const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
       <PreFooter
         data={
           data.articles?.azureBanner?.azureFooterColor
-            ? data.articles
+            ? data.articles.azureBanner
             : {
-                azureBanner: {
-                  azureFooterColor: "white",
-                },
+                azureFooterColor: "white",
               }
         }
       />

--- a/app/articles/[filename]/index.tsx
+++ b/app/articles/[filename]/index.tsx
@@ -1,12 +1,9 @@
 "use client";
-
 import ArticleAuthor from "@/components/articles/articleAuthor";
-import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
 import { CallToAction } from "@/components/callToAction/callToAction";
 import { PreFooter } from "@/components/layout/footer/pre-footer";
 import SidebarPanel from "@/components/sidebar/sidebarPanel";
-import { SectionColor } from "@/components/util/constants/styles";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import client from "@/tina/client";
@@ -26,10 +23,6 @@ export type ArticlePageProps = {
 
 const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
   const { data } = tinaProps;
-  const showCallToAction = data.articles.callToAction.showCallToAction;
-  const azureBannerColor: SectionColor = showCallToAction
-    ? "default"
-    : "lightgray";
   const { author } = data.articles;
   return (
     <>
@@ -139,7 +132,17 @@ const ArticlePage = ({ props, tinaProps }: ArticlePageProps) => {
           )}
         </CallToAction>
       )}
-      <PreFooter data={data.articles} />
+      <PreFooter
+        data={
+          data.articles?.azureBanner?.azureFooterColor
+            ? data.articles
+            : {
+                azureBanner: {
+                  azureFooterColor: "default",
+                },
+              }
+        }
+      />
     </>
   );
 };

--- a/app/articles/index.tsx
+++ b/app/articles/index.tsx
@@ -61,7 +61,7 @@ function ArticlesIndexPage({ props, tinaProps }: ArticlesIndexPageProps) {
         </Section>
         <section
           className={classNames(
-            "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 md:flex"
+            "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8 md:flex"
           )}
         >
           {data.articlesIndex._body.children.length > 0 && (

--- a/app/articles/index.tsx
+++ b/app/articles/index.tsx
@@ -2,7 +2,6 @@
 
 import ArticlesHeader from "@/components/articles/articlesHeader";
 import ArticlesList from "@/components/articles/articlesList";
-import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
 import { PreFooter } from "@/components/layout/footer/pre-footer";
 import SidebarPanel from "@/components/sidebar/sidebarPanel";
@@ -62,7 +61,7 @@ function ArticlesIndexPage({ props, tinaProps }: ArticlesIndexPageProps) {
         </Section>
         <section
           className={classNames(
-            "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8 md:flex"
+            "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 md:flex"
           )}
         >
           {data.articlesIndex._body.children.length > 0 && (

--- a/app/articles/index.tsx
+++ b/app/articles/index.tsx
@@ -2,6 +2,7 @@
 
 import ArticlesHeader from "@/components/articles/articlesHeader";
 import ArticlesList from "@/components/articles/articlesList";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
 import { PreFooter } from "@/components/layout/footer/pre-footer";
 import SidebarPanel from "@/components/sidebar/sidebarPanel";
@@ -96,7 +97,7 @@ function ArticlesIndexPage({ props, tinaProps }: ArticlesIndexPageProps) {
             </div>
           )}
         </section>
-        {data.articlesIndex.showAzureFooter && <PreFooter />}
+        <PreFooter data={data.articlesIndex} />
       </HydrationBoundary>
     </>
   );

--- a/app/articles/index.tsx
+++ b/app/articles/index.tsx
@@ -61,7 +61,7 @@ function ArticlesIndexPage({ props, tinaProps }: ArticlesIndexPageProps) {
         </Section>
         <section
           className={classNames(
-            "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8 md:flex"
+            "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 md:flex"
           )}
         >
           {data.articlesIndex._body.children.length > 0 && (
@@ -96,7 +96,7 @@ function ArticlesIndexPage({ props, tinaProps }: ArticlesIndexPageProps) {
             </div>
           )}
         </section>
-        <PreFooter data={data.articlesIndex} />
+        <PreFooter data={data.articlesIndex.azureBanner} />
       </HydrationBoundary>
     </>
   );

--- a/app/company/[filename]/index.tsx
+++ b/app/company/[filename]/index.tsx
@@ -44,7 +44,7 @@ export default function CompanyPage({ tinaProps, props }) {
         {data.company.subTitle && (
           <section
             className={classNames(
-              "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8",
+              "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0",
               data.company.fullWidthBody ? "" : "md:flex"
             )}
           >
@@ -95,7 +95,7 @@ export default function CompanyPage({ tinaProps, props }) {
           </Section>
         )}
         <Section>
-          <BuiltOnAzure data={{ backgroundColor: "lightgray" }} />
+          <BuiltOnAzure data={data.company} />
         </Section>
       </div>
     </>

--- a/app/company/[filename]/index.tsx
+++ b/app/company/[filename]/index.tsx
@@ -44,7 +44,7 @@ export default function CompanyPage({ tinaProps, props }) {
         {data.company.subTitle && (
           <section
             className={classNames(
-              "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8",
+              "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0",
               data.company.fullWidthBody ? "" : "md:flex"
             )}
           >
@@ -95,7 +95,7 @@ export default function CompanyPage({ tinaProps, props }) {
           </Section>
         )}
         <Section>
-          <BuiltOnAzure data={data.company} />
+          <BuiltOnAzure data={data.company.azureBanner} />
         </Section>
       </div>
     </>

--- a/app/company/[filename]/index.tsx
+++ b/app/company/[filename]/index.tsx
@@ -44,7 +44,7 @@ export default function CompanyPage({ tinaProps, props }) {
         {data.company.subTitle && (
           <section
             className={classNames(
-              "prose mx-auto w-full max-w-9xl flex-row px-8 pb-8 prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0",
+              "prose prose-h1:my-0 prose-h1:pt-8 prose-h2:mt-8 prose-img:my-0 mx-auto w-full max-w-9xl flex-row px-8 pb-8",
               data.company.fullWidthBody ? "" : "md:flex"
             )}
           >

--- a/app/company/clients/[filename]/index.tsx
+++ b/app/company/clients/[filename]/index.tsx
@@ -56,11 +56,9 @@ export default function CompanyPage({ tinaProps, props }) {
         <BuiltOnAzure
           data={
             data.caseStudy?.azureBanner?.azureFooterColor
-              ? data.caseStudy
+              ? data.caseStudy.azureBanner
               : {
-                  azureBanner: {
-                    azureFooterColor: "white",
-                  },
+                  azureFooterColor: "white",
                 }
           }
         />

--- a/app/company/clients/[filename]/index.tsx
+++ b/app/company/clients/[filename]/index.tsx
@@ -53,7 +53,17 @@ export default function CompanyPage({ tinaProps, props }) {
         <TechUpgrade />
       </Section>
       <Section>
-        <BuiltOnAzure data={{ backgroundColor: "transparent" }} />
+        <BuiltOnAzure
+          data={
+            data.caseStudy?.azureBanner?.azureFooterColor
+              ? data.caseStudy
+              : {
+                  azureBanner: {
+                    azureFooterColor: "white",
+                  },
+                }
+          }
+        />
       </Section>
     </>
   );

--- a/app/company/index.tsx
+++ b/app/company/index.tsx
@@ -63,7 +63,7 @@ export default function CompanyIndexPage({ props, tinaProps }) {
         <></>
       )}
       <Section>
-        <BuiltOnAzure data={data.companyIndex} />
+        <BuiltOnAzure data={data.companyIndex.azureBanner} />
       </Section>
     </>
   );

--- a/app/company/index.tsx
+++ b/app/company/index.tsx
@@ -63,7 +63,7 @@ export default function CompanyIndexPage({ props, tinaProps }) {
         <></>
       )}
       <Section>
-        <BuiltOnAzure data={{ backgroundColor: "default" }} />
+        <BuiltOnAzure data={data.companyIndex} />
       </Section>
     </>
   );

--- a/app/company/partners/index.tsx
+++ b/app/company/partners/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { PageCard } from "@/components/blocks/pageCards";
 import { Container } from "@/components/util/container";
 import { Breadcrumbs } from "app/components/breadcrumb";
@@ -21,6 +22,7 @@ export default function PartnersIndex({ tinaProps }) {
           </div>
         </div>
       </Container>
+      <BuiltOnAzure data={data} />
     </>
   );
 }

--- a/app/company/partners/index.tsx
+++ b/app/company/partners/index.tsx
@@ -22,7 +22,7 @@ export default function PartnersIndex({ tinaProps }) {
           </div>
         </div>
       </Container>
-      <BuiltOnAzure data={data.partnerIndex} />
+      <BuiltOnAzure data={data.partnerIndex.azureBanner} />
     </>
   );
 }

--- a/app/company/partners/index.tsx
+++ b/app/company/partners/index.tsx
@@ -22,7 +22,7 @@ export default function PartnersIndex({ tinaProps }) {
           </div>
         </div>
       </Container>
-      <BuiltOnAzure data={data} />
+      <BuiltOnAzure data={data.partnerIndex} />
     </>
   );
 }

--- a/app/consulting/[filename]/consulting.tsx
+++ b/app/consulting/[filename]/consulting.tsx
@@ -133,11 +133,17 @@ export default function Consulting({ tinaProps, props }) {
         </CallToAction>
       )}
       <Section>
-        <BuiltOnAzure data={data.consulting?.azureBanner?.azureBannerColor ? data.consulting : {
-          azureBanner: { 
-            azureFooterColor: "default",
+        <BuiltOnAzure
+          data={
+            data.consulting?.azureBanner?.azureFooterColor
+              ? data.consulting
+              : {
+                  azureBanner: {
+                    azureFooterColor: "default",
+                  },
+                }
           }
-        }} />
+        />
       </Section>
     </>
   );

--- a/app/consulting/[filename]/consulting.tsx
+++ b/app/consulting/[filename]/consulting.tsx
@@ -138,9 +138,7 @@ export default function Consulting({ tinaProps, props }) {
             data.consulting?.azureBanner?.azureFooterColor
               ? data.consulting
               : {
-                  azureBanner: {
-                    azureFooterColor: "white",
-                  },
+                  azureFooterColor: "white",
                 }
           }
         />

--- a/app/consulting/[filename]/consulting.tsx
+++ b/app/consulting/[filename]/consulting.tsx
@@ -139,7 +139,7 @@ export default function Consulting({ tinaProps, props }) {
               ? data.consulting
               : {
                   azureBanner: {
-                    azureFooterColor: "default",
+                    azureFooterColor: "white",
                   },
                 }
           }

--- a/app/consulting/[filename]/consulting.tsx
+++ b/app/consulting/[filename]/consulting.tsx
@@ -133,7 +133,11 @@ export default function Consulting({ tinaProps, props }) {
         </CallToAction>
       )}
       <Section>
-        <BuiltOnAzure data={{ backgroundColor: "default" }} />
+        <BuiltOnAzure data={data.consulting?.azureBanner?.azureBannerColor ? data.consulting : {
+          azureBanner: { 
+            azureFooterColor: "default",
+          }
+        }} />
       </Section>
     </>
   );

--- a/app/consulting/[filename]/consulting2.tsx
+++ b/app/consulting/[filename]/consulting2.tsx
@@ -1,8 +1,6 @@
 "use client";
 import { Blocks } from "@/components/blocks-renderer";
-import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { PreFooter } from "@/components/layout/footer/pre-footer";
-import { SectionColor } from "@/components/util/constants/styles";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import { Consultingv2Query } from "@/tina/types";

--- a/app/consulting/[filename]/consulting2.tsx
+++ b/app/consulting/[filename]/consulting2.tsx
@@ -42,7 +42,7 @@ const Consulting2 = memo(
               </div>
             </Container>
           </Section>
-          <PreFooter data={data.consultingv2} />
+          <PreFooter data={data.consultingv2.azureBanner} />
         </div>
       </>
     );

--- a/app/consulting/[filename]/consulting2.tsx
+++ b/app/consulting/[filename]/consulting2.tsx
@@ -23,7 +23,7 @@ const Consulting2 = memo(
     return (
       <>
         <div className="dark flex h-full flex-col">
-          <Section color={"toggleLightmode"}>
+          <Section color={"toggleLightMode"}>
             <Container
               size="custom"
               width="custom"

--- a/app/consulting/[filename]/consulting2.tsx
+++ b/app/consulting/[filename]/consulting2.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Blocks } from "@/components/blocks-renderer";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { SectionColor } from "@/components/util/constants/styles";
 import { Container } from "@/components/util/container";
@@ -24,7 +25,7 @@ const Consulting2 = memo(
     return (
       <>
         <div className="dark flex h-full flex-col">
-          <Section color={SectionColor.ToggleLightMode}>
+          <Section color={"toggleLightmode"}>
             <Container
               size="custom"
               width="custom"
@@ -43,7 +44,7 @@ const Consulting2 = memo(
               </div>
             </Container>
           </Section>
-          <PreFooter />
+          <PreFooter data={data.consultingv2} />
         </div>
       </>
     );

--- a/app/consulting/index.tsx
+++ b/app/consulting/index.tsx
@@ -117,7 +117,7 @@ export default function ConsultingIndex({ tinaProps }) {
           </div>
         </div>
       </Container>
-      <BuiltOnAzure data={tinaProps} />
+      <BuiltOnAzure data={tinaProps.azureBanner} />
     </>
   );
 }

--- a/app/consulting/index.tsx
+++ b/app/consulting/index.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-
-import { useEffect, useMemo, useRef, useState } from "react";
-import { MdLiveHelp } from "react-icons/md";
-
-import { wrapGrid } from "animate-css-grid";
-
-import { tinaField } from "tinacms/dist/react";
-
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { Category } from "@/components/consulting/index/category";
 import { Tag } from "@/components/consulting/index/tag";
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
+import { wrapGrid } from "animate-css-grid";
 import { Breadcrumbs } from "app/components/breadcrumb";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { MdLiveHelp } from "react-icons/md";
+import { tinaField } from "tinacms/dist/react";
 
 const allServices = "All SSW Services";
 
@@ -120,6 +118,7 @@ export default function ConsultingIndex({ tinaProps }) {
           </div>
         </div>
       </Container>
+      <BuiltOnAzure data={tinaProps} />
     </>
   );
 }

--- a/app/consulting/index.tsx
+++ b/app/consulting/index.tsx
@@ -3,7 +3,6 @@
 import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { Category } from "@/components/consulting/index/category";
 import { Tag } from "@/components/consulting/index/tag";
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { wrapGrid } from "animate-css-grid";
 import { Breadcrumbs } from "app/components/breadcrumb";

--- a/app/consulting/video-production/[filename]/video-production.tsx
+++ b/app/consulting/video-production/[filename]/video-production.tsx
@@ -4,19 +4,15 @@ import { TinaMarkdown } from "tinacms/dist/rich-text";
 
 import { Blocks } from "@/components/blocks-renderer";
 import { Booking } from "@/components/blocks/booking";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
 import { BookingButton } from "@/components/bookingButton/bookingButton";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
-import { Breadcrumbs } from "app/components/breadcrumb";
-import { ReactElement } from "react";
-
-import {
-  azureFooterColors,
-  BuiltOnAzure,
-} from "@/components/blocks/builtOnAzure";
 import { sanitiseXSS, spanWhitelist } from "@/helpers/validator";
 import { removeExtension } from "@/services/client/utils.service";
+import { Breadcrumbs } from "app/components/breadcrumb";
+import { ReactElement } from "react";
 import ReactDOMServer from "react-dom/server";
 
 export default function VideoProductionPage({ props, tinaProps }) {

--- a/app/consulting/video-production/[filename]/video-production.tsx
+++ b/app/consulting/video-production/[filename]/video-production.tsx
@@ -92,11 +92,9 @@ export default function VideoProductionPage({ props, tinaProps }) {
         <BuiltOnAzure
           data={
             data.videoProduction?.azureBanner?.azureFooterColor
-              ? data.videoProduction
+              ? data.videoProduction.azureBanner
               : {
-                  azureBanner: {
-                    azureFooterColors: "white",
-                  },
+                  azureFooterColors: "white",
                 }
           }
         />

--- a/app/consulting/video-production/[filename]/video-production.tsx
+++ b/app/consulting/video-production/[filename]/video-production.tsx
@@ -11,7 +11,10 @@ import { Section } from "@/components/util/section";
 import { Breadcrumbs } from "app/components/breadcrumb";
 import { ReactElement } from "react";
 
-import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
+import {
+  azureFooterColors,
+  BuiltOnAzure,
+} from "@/components/blocks/builtOnAzure";
 import { sanitiseXSS, spanWhitelist } from "@/helpers/validator";
 import { removeExtension } from "@/services/client/utils.service";
 import ReactDOMServer from "react-dom/server";
@@ -90,7 +93,17 @@ export default function VideoProductionPage({ props, tinaProps }) {
       )}
 
       <Section>
-        <BuiltOnAzure data={{ backgroundColor: "default" }} />
+        <BuiltOnAzure
+          data={
+            data.videoProduction?.azureBanner?.azureFooterColor
+              ? data.videoProduction
+              : {
+                  azureBanner: {
+                    azureFooterColors: "white",
+                  },
+                }
+          }
+        />
       </Section>
     </>
   );

--- a/app/employment/index.tsx
+++ b/app/employment/index.tsx
@@ -163,11 +163,9 @@ export default function EmploymentPage({ tinaProps, props }) {
         <BuiltOnAzure
           data={
             data.azureBanner?.azureFooterColor
-              ? data
+              ? data.azureBanner
               : {
-                  azureBanner: {
-                    azureFooterColor: "white",
-                  },
+                  azureFooterColor: "white",
                 }
           }
         />

--- a/app/employment/index.tsx
+++ b/app/employment/index.tsx
@@ -160,7 +160,17 @@ export default function EmploymentPage({ tinaProps, props }) {
         </Container>
       </Section>
       <Section>
-        <BuiltOnAzure data={{ backgroundColor: "default" }} />
+        <BuiltOnAzure
+          data={
+            data.azureBanner?.azureFooterColor
+              ? data
+              : {
+                  azureBanner: {
+                    azureFooterColor: "white",
+                  },
+                }
+          }
+        />
       </Section>
     </>
   );

--- a/app/events/[filename]/index.tsx
+++ b/app/events/[filename]/index.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { Blocks } from "@/components/blocks-renderer";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
 import EventsHeader from "@/components/events/eventsHeader";
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import { removeExtension } from "@/services/client/utils.service";
@@ -10,7 +12,6 @@ import { Breadcrumbs } from "app/components/breadcrumb";
 import dynamic from "next/dynamic";
 import { tinaField } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
-
 const ClientLogos = dynamic(() =>
   import("@/components/blocks/clientLogos").then((mod) => mod.ClientLogos)
 );
@@ -115,6 +116,7 @@ export default function EventsPage({ props, tinaProps }) {
           components={componentRenderer}
         />
       </div>
+      <BuiltOnAzure data={data} />
     </>
   );
 }

--- a/app/events/[filename]/index.tsx
+++ b/app/events/[filename]/index.tsx
@@ -93,7 +93,7 @@ export default function EventsPage({ props, tinaProps }) {
           </Section>
         )}
 
-        <Section color="white">
+        <Section color="default">
           <Container padding={"md:px-8 px-4"} className={"flex-1 pt-0"}>
             <div className="flex flex-col items-center pb-15 text-center">
               <h2>

--- a/app/events/[filename]/index.tsx
+++ b/app/events/[filename]/index.tsx
@@ -4,7 +4,6 @@ import { Blocks } from "@/components/blocks-renderer";
 import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
 import EventsHeader from "@/components/events/eventsHeader";
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import { removeExtension } from "@/services/client/utils.service";
@@ -78,7 +77,7 @@ export default function EventsPage({ props, tinaProps }) {
         </div>
 
         {data.events.showTestimonials && (
-          <Section color="white" className="">
+          <Section color="default" className="">
             <Container padding={"md:px-8 px-2"} className={"flex-1 pt-0"}>
               <div
                 data-tina-field={tinaField(data.events.testimonials, "tagline")}

--- a/app/events/[filename]/index.tsx
+++ b/app/events/[filename]/index.tsx
@@ -115,7 +115,7 @@ export default function EventsPage({ props, tinaProps }) {
           components={componentRenderer}
         />
       </div>
-      <BuiltOnAzure data={data} />
+      <BuiltOnAzure data={data.events.azureBanner} />
     </>
   );
 }

--- a/app/industry/[filename]/index.tsx
+++ b/app/industry/[filename]/index.tsx
@@ -5,9 +5,6 @@ import {
   DownloadWhitepaperLink,
   industryRenderer,
 } from "@/components/blocks/industryRenderer";
-
-
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { removeExtension } from "@/services/client/utils.service";
 import { Breadcrumbs } from "app/components/breadcrumb";

--- a/app/industry/[filename]/index.tsx
+++ b/app/industry/[filename]/index.tsx
@@ -5,6 +5,9 @@ import {
   DownloadWhitepaperLink,
   industryRenderer,
 } from "@/components/blocks/industryRenderer";
+
+
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { removeExtension } from "@/services/client/utils.service";
 import { Breadcrumbs } from "app/components/breadcrumb";
@@ -61,7 +64,7 @@ export default function IndustryPage({ props, tinaProps }) {
           />
         </div>
       </Container>
-      <BuiltOnAzure data={{ backgroundColor: "lightgray" }} />
+      <BuiltOnAzure data={industry} />
     </>
   );
 }

--- a/app/industry/[filename]/index.tsx
+++ b/app/industry/[filename]/index.tsx
@@ -61,7 +61,7 @@ export default function IndustryPage({ props, tinaProps }) {
           />
         </div>
       </Container>
-      <BuiltOnAzure data={industry} />
+      <BuiltOnAzure data={industry.azureBanner} />
     </>
   );
 }

--- a/app/industry/index.tsx
+++ b/app/industry/index.tsx
@@ -25,7 +25,7 @@ export default function IndustriesPage({ tinaProps }) {
           </div>
         </div>
       </Container>
-      <BuiltOnAzure data={data.industryIndex} />
+      <BuiltOnAzure data={data.industryIndex.azureBanner} />
     </>
   );
 }

--- a/app/industry/index.tsx
+++ b/app/industry/index.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { PageCard } from "@/components/blocks/pageCards";
 import { Container } from "@/components/util/container";
 import { Breadcrumbs } from "../components/breadcrumb";
 
 export default function IndustriesPage({ tinaProps }) {
   const { data } = tinaProps;
-
   return (
     <>
       <Container className="mb-10 flex-1 pt-2">
@@ -25,6 +25,7 @@ export default function IndustriesPage({ tinaProps }) {
           </div>
         </div>
       </Container>
+      <BuiltOnAzure data={data.industryIndex} />
     </>
   );
 }

--- a/app/offices/[filename]/index.tsx
+++ b/app/offices/[filename]/index.tsx
@@ -51,7 +51,7 @@ export default function OfficePage({ props, tinaProps }) {
         </div>
       </Container>
       <Section>
-        <BuiltOnAzure data={{ backgroundColor: "lightgray" }} />
+        <BuiltOnAzure data={data.offices} />
       </Section>
     </>
   );

--- a/app/offices/[filename]/index.tsx
+++ b/app/offices/[filename]/index.tsx
@@ -51,7 +51,7 @@ export default function OfficePage({ props, tinaProps }) {
         </div>
       </Container>
       <Section>
-        <BuiltOnAzure data={data.offices} />
+        <BuiltOnAzure data={data.offices.azureBanner} />
       </Section>
     </>
   );

--- a/app/offices/index.tsx
+++ b/app/offices/index.tsx
@@ -2,7 +2,6 @@
 import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { Flag } from "@/components/blocks/flag";
 import { CustomLink } from "@/components/customLink";
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import MicrosoftPanel from "@/components/offices/microsoftPanel";
 import TestimonialPanel from "@/components/offices/testimonialPanel";
 import { Countries } from "@/components/util/constants/country";

--- a/app/offices/index.tsx
+++ b/app/offices/index.tsx
@@ -110,7 +110,7 @@ export default function OfficesPage({ tinaProps }) {
               </div>
             </div>
           </Container>
-          <BuiltOnAzure data={tinaProps} />
+          <BuiltOnAzure data={tinaProps.azureBanner} />
           {/* <PreFooter /> */}
         </>
       )}

--- a/app/offices/index.tsx
+++ b/app/offices/index.tsx
@@ -1,7 +1,8 @@
 "use client";
-
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { Flag } from "@/components/blocks/flag";
 import { CustomLink } from "@/components/customLink";
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import MicrosoftPanel from "@/components/offices/microsoftPanel";
 import TestimonialPanel from "@/components/offices/testimonialPanel";
 import { Countries } from "@/components/util/constants/country";
@@ -14,97 +15,106 @@ export default function OfficesPage({ tinaProps }) {
   const offices = data.officeIndex.officesIndex?.map((office) => office.office);
 
   return (
-    offices && (
-      <Container className="flex-1 pt-2">
-        <Breadcrumbs path={"/offices"} title={"Offices"} />
+    <>
+      {offices && (
+        <>
+          <Container className="flex-1 pt-2">
+            <Breadcrumbs path={"/offices"} title={"Offices"} />
 
-        <div className="md:flex">
-          <div className="grow">
-            <h1 className="pt-0">Our Offices</h1>
-            {offices.map((office) => (
-              <div key={office.addressLocality} className="mb-10 block">
-                <span>
-                  <h2 className="mt-0 text-sswRed">
-                    {`${office.addressLocality} | ${office.addressCountry}`}{" "}
-                    <Flag country={office.addressCountry as Countries} />
-                  </h2>
-                </span>
-                {office.thumbnail ? (
-                  <Image
-                    className="float-left mr-4 pb-3"
-                    src={office.thumbnail}
-                    width={115}
-                    height={115}
-                    alt="Office Thumbnail"
-                  />
-                ) : (
-                  <></>
-                )}
-                <p className="block max-sm:clear-left">
-                  {office.streetAddress}
-                  <br />
-                  {office.suburb}, {office.addressRegion} {office.postalCode}
-                </p>
-                <p className="block max-sm:clear-left">
-                  <strong>Phone: {office.phone}</strong>
-                </p>
-                <p className="block max-sm:clear-left">
-                  <CustomLink
-                    href={
-                      office.localWebsiteLink?.url ||
-                      `/offices/${office.addressLocality.toLowerCase()}`
-                    }
-                  >
-                    Learn more about our {office.addressLocality} office
-                  </CustomLink>
-                </p>
-                <p className="block max-sm:clear-left">
-                  <CustomLink
-                    href={`${`/offices/${office.addressLocality.toLowerCase()}`}#Directions`}
-                  >
-                    Directions to SSW {office.addressLocality}
-                  </CustomLink>
-                </p>
-              </div>
-            ))}
-            <hr className="my-3" />
-            <div className="border-2 bg-gray-100 px-4 py-2">
-              <p>
-                Our staff are ready to work remotely for any country globally.
-                We have worked for clients from the
-                <strong> USA, Canada, the UK</strong>, New Zealand, and even
-                European countries, such as <strong>France, Germany</strong>,
-                and as far north as <strong>Sweden</strong>.
-              </p>
-            </div>
-            <br />
-            <p>
-              {"If you require any further information, don't hesitate to "}
-              <CustomLink href="mailto:info@ssw.com.au">contact us.</CustomLink>
-            </p>
-          </div>
-          <div className="md:max-w-sm md:pl-6">
-            <div className="prose max-w-full">
-              <h3>SSW Offices</h3>
-              <ul>
+            <div className="md:flex">
+              <div className="grow">
+                <h1 className="pt-0">Our Offices</h1>
                 {offices.map((office) => (
-                  <li key={office.addressLocality}>
-                    <CustomLink
-                      href={`${`/offices/${office.addressLocality.toLowerCase()}`}#Directions`}
-                    >
-                      {office.addressLocality}
-                    </CustomLink>
-                  </li>
+                  <div key={office.addressLocality} className="mb-10 block">
+                    <span>
+                      <h2 className="mt-0 text-sswRed">
+                        {`${office.addressLocality} | ${office.addressCountry}`}{" "}
+                        <Flag country={office.addressCountry as Countries} />
+                      </h2>
+                    </span>
+                    {office.thumbnail ? (
+                      <Image
+                        className="float-left mr-4 pb-3"
+                        src={office.thumbnail}
+                        width={115}
+                        height={115}
+                        alt="Office Thumbnail"
+                      />
+                    ) : (
+                      <></>
+                    )}
+                    <p className="block max-sm:clear-left">
+                      {office.streetAddress}
+                      <br />
+                      {office.suburb}, {office.addressRegion}{" "}
+                      {office.postalCode}
+                    </p>
+                    <p className="block max-sm:clear-left">
+                      <strong>Phone: {office.phone}</strong>
+                    </p>
+                    <p className="block max-sm:clear-left">
+                      <CustomLink
+                        href={
+                          office.localWebsiteLink?.url ||
+                          `/offices/${office.addressLocality.toLowerCase()}`
+                        }
+                      >
+                        Learn more about our {office.addressLocality} office
+                      </CustomLink>
+                    </p>
+                    <p className="block max-sm:clear-left">
+                      <CustomLink
+                        href={`${`/offices/${office.addressLocality.toLowerCase()}`}#Directions`}
+                      >
+                        Directions to SSW {office.addressLocality}
+                      </CustomLink>
+                    </p>
+                  </div>
                 ))}
-              </ul>
-              <div className="hidden sm:block">
-                <MicrosoftPanel />
-                <TestimonialPanel />
+                <hr className="my-3" />
+                <div className="border-2 bg-gray-100 px-4 py-2">
+                  <p>
+                    Our staff are ready to work remotely for any country
+                    globally. We have worked for clients from the
+                    <strong> USA, Canada, the UK</strong>, New Zealand, and even
+                    European countries, such as <strong>France, Germany</strong>
+                    , and as far north as <strong>Sweden</strong>.
+                  </p>
+                </div>
+                <br />
+                <p>
+                  {"If you require any further information, don't hesitate to "}
+                  <CustomLink href="mailto:info@ssw.com.au">
+                    contact us.
+                  </CustomLink>
+                </p>
+              </div>
+              <div className="md:max-w-sm md:pl-6">
+                <div className="prose max-w-full">
+                  <h3>SSW Offices</h3>
+                  <ul>
+                    {offices.map((office) => (
+                      <li key={office.addressLocality}>
+                        <CustomLink
+                          href={`${`/offices/${office.addressLocality.toLowerCase()}`}#Directions`}
+                        >
+                          {office.addressLocality}
+                        </CustomLink>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="hidden sm:block">
+                    <MicrosoftPanel />
+                    <TestimonialPanel />
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-      </Container>
-    )
+          </Container>
+          <BuiltOnAzure data={tinaProps} />
+          {/* <PreFooter /> */}
+        </>
+      )}
+    </>
   );
 }

--- a/app/page-content.tsx
+++ b/app/page-content.tsx
@@ -1,7 +1,6 @@
 import { Blocks } from "@/components/blocks-renderer";
 import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import classNames from "classnames";

--- a/app/page-content.tsx
+++ b/app/page-content.tsx
@@ -1,5 +1,7 @@
 import { Blocks } from "@/components/blocks-renderer";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import classNames from "classnames";
@@ -91,6 +93,7 @@ export default function PageContent({ props }) {
       <div className="no-print">
         <Blocks prefix="PageAfterBody" blocks={data.page.afterBody} />
       </div>
+      <BuiltOnAzure data={data.page} />
     </>
   );
 }

--- a/app/page-content.tsx
+++ b/app/page-content.tsx
@@ -92,7 +92,7 @@ export default function PageContent({ props }) {
       <div className="no-print">
         <Blocks prefix="PageAfterBody" blocks={data.page.afterBody} />
       </div>
-      <BuiltOnAzure data={data.page} />
+      <BuiltOnAzure data={data.page.azureBanner} />
     </>
   );
 }

--- a/app/products/[filename]/products-content.tsx
+++ b/app/products/[filename]/products-content.tsx
@@ -1,6 +1,5 @@
 import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import { removeExtension } from "@/services/client/utils.service";
@@ -26,8 +25,7 @@ export default function ProductsContent({ props }) {
           components={componentRenderer}
         />
       </Container>
-      <BuiltOnAzure data={data} />
-      {/* <PreFooter data={data} /> */}
+      <BuiltOnAzure data={data.products} />
     </>
   );
 }

--- a/app/products/[filename]/products-content.tsx
+++ b/app/products/[filename]/products-content.tsx
@@ -17,7 +17,7 @@ export default function ProductsContent({ props }) {
       </Section>
       <Container
         className={
-          "prose flex-1 pt-4 prose-h1:!my-0 prose-h1:!pt-4 prose-h3:!mt-0 prose-img:!my-0"
+          "prose prose-h1:!my-0 prose-h1:!pt-4 prose-h3:!mt-0 prose-img:!my-0 flex-1 pt-4"
         }
       >
         <TinaMarkdown

--- a/app/products/[filename]/products-content.tsx
+++ b/app/products/[filename]/products-content.tsx
@@ -1,10 +1,11 @@
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
 import { removeExtension } from "@/services/client/utils.service";
 import { Breadcrumbs } from "app/components/breadcrumb";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
-
 export default function ProductsContent({ props }) {
   const { data, variables } = props;
   return (
@@ -17,7 +18,7 @@ export default function ProductsContent({ props }) {
       </Section>
       <Container
         className={
-          "prose prose-h1:!my-0 prose-h1:!pt-4 prose-h3:!mt-0 prose-img:!my-0 flex-1 pt-4"
+          "prose flex-1 pt-4 prose-h1:!my-0 prose-h1:!pt-4 prose-h3:!mt-0 prose-img:!my-0"
         }
       >
         <TinaMarkdown
@@ -25,6 +26,8 @@ export default function ProductsContent({ props }) {
           components={componentRenderer}
         />
       </Container>
+      <BuiltOnAzure data={data} />
+      {/* <PreFooter data={data} /> */}
     </>
   );
 }

--- a/app/products/products-index.tsx
+++ b/app/products/products-index.tsx
@@ -1,4 +1,6 @@
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { PageCard } from "@/components/blocks/pageCards";
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Breadcrumbs } from "app/components/breadcrumb";
 import { tinaField } from "tinacms/dist/react";
@@ -32,6 +34,7 @@ export default function ProductsIndexContent({ props }) {
           </div>
         </div>
       </Container>
+      <BuiltOnAzure data={props} />
     </>
   );
 }

--- a/app/products/products-index.tsx
+++ b/app/products/products-index.tsx
@@ -1,6 +1,5 @@
 import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { PageCard } from "@/components/blocks/pageCards";
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { Container } from "@/components/util/container";
 import { Breadcrumbs } from "app/components/breadcrumb";
 import { tinaField } from "tinacms/dist/react";

--- a/app/products/products-index.tsx
+++ b/app/products/products-index.tsx
@@ -33,7 +33,7 @@ export default function ProductsIndexContent({ props }) {
           </div>
         </div>
       </Container>
-      <BuiltOnAzure data={props} />
+      <BuiltOnAzure data={props.productsIndex.azureBanner} />
     </>
   );
 }

--- a/app/training/[filename]/index.tsx
+++ b/app/training/[filename]/index.tsx
@@ -79,7 +79,7 @@ export default function TrainingPage({ props, tinaProps }) {
           </Section>
         )}
 
-        <Section color="white">
+        <Section color="default">
           <Container padding={"md:px-8 px-4"} className={"flex-1 pt-0"}>
             <div className="flex flex-col items-center pb-15 text-center">
               <h2>

--- a/app/training/[filename]/index.tsx
+++ b/app/training/[filename]/index.tsx
@@ -5,7 +5,6 @@ import { Blocks } from "@/components/blocks-renderer";
 import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { ClientLogos } from "@/components/blocks/clientLogos";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
-import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { TestimonialRow } from "@/components/testimonials/TestimonialRow";
 import TrainingCarousel from "@/components/training/trainingHeader";
 import { Container } from "@/components/util/container";
@@ -61,7 +60,7 @@ export default function TrainingPage({ props, tinaProps }) {
         </div>
 
         {data.training.showTestimonials && (
-          <Section color="white" className="">
+          <Section color="default" className="">
             <Container padding={"md:px-8 px-2"} className={"flex-1 pt-0"}>
               <div
                 data-tina-field={tinaField(

--- a/app/training/[filename]/index.tsx
+++ b/app/training/[filename]/index.tsx
@@ -101,7 +101,7 @@ export default function TrainingPage({ props, tinaProps }) {
           components={componentRenderer}
         />
       </div>
-      <BuiltOnAzure data={data} />
+      <BuiltOnAzure data={data.training.azureBanner} />
     </>
   );
 }

--- a/app/training/[filename]/index.tsx
+++ b/app/training/[filename]/index.tsx
@@ -2,8 +2,10 @@
 
 import { Breadcrumbs } from "@/app/components/breadcrumb";
 import { Blocks } from "@/components/blocks-renderer";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { ClientLogos } from "@/components/blocks/clientLogos";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
+import { PreFooter } from "@/components/layout/footer/pre-footer";
 import { TestimonialRow } from "@/components/testimonials/TestimonialRow";
 import TrainingCarousel from "@/components/training/trainingHeader";
 import { Container } from "@/components/util/container";
@@ -100,6 +102,7 @@ export default function TrainingPage({ props, tinaProps }) {
           components={componentRenderer}
         />
       </div>
+      <BuiltOnAzure data={data} />
     </>
   );
 }

--- a/components/blocks/agenda.tsx
+++ b/components/blocks/agenda.tsx
@@ -32,7 +32,7 @@ const AgendaItem: FC<AgendaItemProps> = ({ body }) => {
 
 export const Agenda = ({ data }) => {
   return (
-    <Section color="white">
+    <Section color="default">
       <Container
         padding={"md:px-8 px-2"}
         size={"xsmall"}

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -17,10 +17,11 @@ export type BuiltOnAzureProps = {
 export const BuiltOnAzure = ({
   data,
 }: BuiltOnAzureProps) => {
+  console.log("data", data);
   if(data?.azureBanner?.showAzureFooter === false) return <></>
   //show the azure banner by default unless it's disabled
   return (
-    <Section color={data?.azureBanner?.azureFooterColor || "lightgray"}>
+    <Section color={data?.azureBanner?.azureFooterColor || "default"}>
       <Container className="grid grid-cols-1 text-lg lg:grid-cols-2">
         <Link
           data={data}

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -3,7 +3,6 @@ import dynamic from "next/dynamic";
 import type { Template } from "tinacms";
 import { tinaField } from "tinacms/dist/react";
 import { CustomLink } from "../customLink";
-import { SectionColor } from "../util/constants/styles";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 
@@ -13,12 +12,9 @@ export type BuiltOnAzureProps = {
   data: {
     azureBanner?: { showAzureFooter?: boolean; azureFooterColor?: string };
   };
-}
-export const BuiltOnAzure = ({
-  data,
-}: BuiltOnAzureProps) => {
-  console.log("data", data);
-  if(data?.azureBanner?.showAzureFooter === false) return <></>
+};
+export const BuiltOnAzure = ({ data }: BuiltOnAzureProps) => {
+  if (data?.azureBanner?.showAzureFooter === false) return <></>;
   //show the azure banner by default unless it's disabled
   return (
     <Section color={data?.azureBanner?.azureFooterColor || "lightgray"}>

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -78,7 +78,7 @@ const Link = ({ data, href, className, text, image }) => {
   return (
     <CustomLink
       href={href}
-      data-tina-field={tinaField(data, "azureBanner")}
+      data-tina-field={tinaField(data)}
       className={classNames(
         "unstyled flex items-center justify-center",
         className

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -1,11 +1,11 @@
 import classNames from "classnames";
 import dynamic from "next/dynamic";
+import { Template } from "tinacms";
 import { tinaField } from "tinacms/dist/react";
 import { CustomLink } from "../customLink";
 import { SectionColor } from "../util/constants/styles";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
-import { Template } from "tinacms";
 
 const Image = dynamic(() => import("next/image"));
 
@@ -18,23 +18,20 @@ export const azureFooterColors: Array<string> = [
 type AzureFooterColors = (typeof azureFooterColors)[number];
 
 export type BuiltOnAzureProps = {
-  data: {
-    azureBanner?: {
-      showAzureFooter?: boolean;
-      azureFooterColor?: AzureFooterColors;
-    };
+  data?: {
+    showAzureFooter?: boolean;
+    azureFooterColor?: AzureFooterColors;
   };
 };
 export const BuiltOnAzure = ({ data }: BuiltOnAzureProps) => {
-  let footerColor: AzureFooterColors =
-    data?.azureBanner?.azureFooterColor || "lightgray";
+  let footerColor: AzureFooterColors = data?.azureFooterColor || "lightgray";
 
   if (footerColor === "white") {
     footerColor = "default";
   }
   //show the azure banner by default unless it's disabled
 
-  if (data?.azureBanner?.showAzureFooter === false) {
+  if (data?.showAzureFooter === false) {
     return <></>;
   }
 

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -3,14 +3,25 @@ import dynamic from "next/dynamic";
 import type { Template } from "tinacms";
 import { tinaField } from "tinacms/dist/react";
 import { CustomLink } from "../customLink";
+import { SectionColor } from "../util/constants/styles";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 
 const Image = dynamic(() => import("next/image"));
 
-export const BuiltOnAzure = ({ data }) => {
+export type BuiltOnAzureProps = {
+  data: {
+    azureBanner?: { showAzureFooter?: boolean; azureFooterColor?: string };
+  };
+}
+export const BuiltOnAzure = ({
+  data,
+}: BuiltOnAzureProps) => {
+  console.log("data", data);
+  if(data?.azureBanner?.showAzureFooter === false) return <></>
+  //show the azure banner by default unless it's disabled
   return (
-    <Section color={data.backgroundColor}>
+    <Section color={data?.azureBanner?.azureFooterColor || "default"}>
       <Container className="grid grid-cols-1 text-lg lg:grid-cols-2">
         <Link
           data={data}
@@ -52,7 +63,7 @@ const Link = ({ data, href, className, text, image }) => {
   return (
     <CustomLink
       href={href}
-      data-tina-field={tinaField(data, builtOnAzureBlock.backgroundColor)}
+      data-tina-field={tinaField(data, "azureBanner")}
       className={classNames(
         "unstyled flex items-center justify-center",
         className

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -5,6 +5,7 @@ import { CustomLink } from "../customLink";
 import { SectionColor } from "../util/constants/styles";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
+import { Template } from "tinacms";
 
 const Image = dynamic(() => import("next/image"));
 

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -21,7 +21,7 @@ export const BuiltOnAzure = ({
   if(data?.azureBanner?.showAzureFooter === false) return <></>
   //show the azure banner by default unless it's disabled
   return (
-    <Section color={data?.azureBanner?.azureFooterColor || "default"}>
+    <Section color={data?.azureBanner?.azureFooterColor || "lightgray"}>
       <Container className="grid grid-cols-1 text-lg lg:grid-cols-2">
         <Link
           data={data}

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -70,29 +70,3 @@ const Link = ({ data, href, className, text, image }) => {
     </CustomLink>
   );
 };
-
-export const builtOnAzureBlock = {
-  backgroundColor: "backgroundColor",
-};
-
-export const builtOnAzureBlockSchema: Template = {
-  name: "BuiltOnAzure",
-  label: "Built on Azure",
-  ui: {
-    previewSrc: "/images/thumbs/tina/built-on-azure.jpg",
-  },
-  // Todo: Turn into util field
-  fields: [
-    {
-      type: "string",
-      label: "Background Color",
-      name: "backgroundColor",
-      options: [
-        { label: "Default", value: "default" },
-        { label: "Light Gray", value: "lightgray" },
-        { label: "Red", value: "red" },
-        { label: "Black", value: "black" },
-      ],
-    },
-  ],
-};

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -91,3 +91,29 @@ const Link = ({ data, href, className, text, image }) => {
     </CustomLink>
   );
 };
+
+export const builtOnAzureBlock = {
+  backgroundColor: "backgroundColor",
+};
+
+export const builtOnAzureBlockSchema: Template = {
+  name: "BuiltOnAzure",
+  label: "Built on Azure",
+  ui: {
+    previewSrc: "/images/thumbs/tina/built-on-azure.jpg",
+  },
+  // Todo: Turn into util field
+  fields: [
+    {
+      type: "string",
+      label: "Background Color",
+      name: "backgroundColor",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Light Gray", value: "lightgray" },
+        { label: "Red", value: "red" },
+        { label: "Black", value: "black" },
+      ],
+    },
+  ],
+};

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -1,23 +1,44 @@
 import classNames from "classnames";
 import dynamic from "next/dynamic";
-import type { Template } from "tinacms";
 import { tinaField } from "tinacms/dist/react";
 import { CustomLink } from "../customLink";
+import { SectionColor } from "../util/constants/styles";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 
 const Image = dynamic(() => import("next/image"));
 
+export const azureFooterColors: Array<string> = [
+  "white",
+  "lightgray",
+  "darkgray",
+];
+
+type AzureFooterColors = (typeof azureFooterColors)[number];
+
 export type BuiltOnAzureProps = {
   data: {
-    azureBanner?: { showAzureFooter?: boolean; azureFooterColor?: string };
+    azureBanner?: {
+      showAzureFooter?: boolean;
+      azureFooterColor?: AzureFooterColors;
+    };
   };
 };
 export const BuiltOnAzure = ({ data }: BuiltOnAzureProps) => {
-  if (data?.azureBanner?.showAzureFooter === false) return <></>;
+  let footerColor: AzureFooterColors =
+    data?.azureBanner?.azureFooterColor || "lightgray";
+
+  if (footerColor === "white") {
+    footerColor = "default";
+  }
   //show the azure banner by default unless it's disabled
+
+  if (data?.azureBanner?.showAzureFooter === false) {
+    return <></>;
+  }
+
   return (
-    <Section color={data?.azureBanner?.azureFooterColor || "lightgray"}>
+    <Section color={footerColor as SectionColor} className="py-2">
       <Container className="grid grid-cols-1 text-lg lg:grid-cols-2">
         <Link
           data={data}

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -17,11 +17,10 @@ export type BuiltOnAzureProps = {
 export const BuiltOnAzure = ({
   data,
 }: BuiltOnAzureProps) => {
-  console.log("data", data);
   if(data?.azureBanner?.showAzureFooter === false) return <></>
   //show the azure banner by default unless it's disabled
   return (
-    <Section color={data?.azureBanner?.azureFooterColor || "default"}>
+    <Section color={data?.azureBanner?.azureFooterColor || "lightgray"}>
       <Container className="grid grid-cols-1 text-lg lg:grid-cols-2">
         <Link
           data={data}

--- a/components/blocks/content.tsx
+++ b/components/blocks/content.tsx
@@ -3,6 +3,7 @@ import type { Template } from "tinacms";
 import { tinaField } from "tinacms/dist/react";
 import { TinaMarkdown, TinaMarkdownContent } from "tinacms/dist/rich-text";
 import { clientLogosBlockSchema } from "../../components/blocks/clientLogos";
+import { SectionColor } from "../util/constants/styles";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 import { colorBlockSchema } from "./colorBlock";
@@ -48,7 +49,7 @@ export const Content = ({ data }: ContentProps) => {
   const size = sizeClasses[data?.size] ?? sizeClasses.base;
   return (
     <Section
-      color={data.backgroundColor}
+      color={data.backgroundColor as SectionColor}
       data-tina-field={tinaField(data, contentBlock.title)}
       className="px-8 md:px-0"
     >

--- a/components/layout/footer/pre-footer.tsx
+++ b/components/layout/footer/pre-footer.tsx
@@ -1,15 +1,13 @@
-import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
+import { BuiltOnAzure, BuiltOnAzureProps } from "@/components/blocks/builtOnAzure";
 import { SectionColor } from "@/components/util/constants/styles";
 import { Section } from "@/components/util/section";
-
+import { headers } from "next/headers";
 export const PreFooter = ({
-  backgroundColor = SectionColor.LightGray,
-}: {
-  backgroundColor?: SectionColor;
-}) => {
+  data
+}: BuiltOnAzureProps) => {
   return (
     <Section className="w-full flex-none">
-      <BuiltOnAzure data={{ backgroundColor }} />
+      <BuiltOnAzure data={data} />
     </Section>
   );
 };

--- a/components/layout/footer/pre-footer.tsx
+++ b/components/layout/footer/pre-footer.tsx
@@ -1,10 +1,9 @@
-import { BuiltOnAzure, BuiltOnAzureProps } from "@/components/blocks/builtOnAzure";
-import { SectionColor } from "@/components/util/constants/styles";
+import {
+  BuiltOnAzure,
+  BuiltOnAzureProps,
+} from "@/components/blocks/builtOnAzure";
 import { Section } from "@/components/util/section";
-import { headers } from "next/headers";
-export const PreFooter = ({
-  data
-}: BuiltOnAzureProps) => {
+export const PreFooter = ({ data }: BuiltOnAzureProps) => {
   return (
     <Section className="w-full flex-none">
       <BuiltOnAzure data={data} />

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -2,7 +2,6 @@ import classNames from "classnames";
 import { useRouter } from "next/router";
 import { useLiveStreamTimer } from "../../hooks/useLiveStreamProps";
 import { Footer } from "./footer/footer";
-import { PreFooter } from "./footer/pre-footer";
 import { Theme } from "./theme";
 
 import {
@@ -16,7 +15,6 @@ import dynamic from "next/dynamic";
 import { Inter } from "next/font/google";
 import { useReportWebVitals } from "next/web-vitals";
 import { MegaMenuLayout, NavMenuGroup } from "ssw.megamenu";
-import { BuiltOnAzure } from "../blocks/builtOnAzure";
 import { CustomLink } from "../customLink";
 import { ErrorBoundary } from "../util/error/error-boundary";
 

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -62,7 +62,6 @@ export const Layout = ({
   children,
   menu,
   className = "",
-  showAzureBanner,
 }: LayoutProps) => {
   const eventJson: EventInfoStatic = liveStreamData?.edges[0]?.node;
 

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -53,7 +53,6 @@ interface LayoutProps {
     menuGroups: NavMenuGroup[];
   };
   children: React.ReactNode;
-  showAzureBanner?: boolean;
   liveStreamData: LiveStreamData;
 }
 

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -156,8 +156,6 @@ export const Layout = ({
           </header>
           <ErrorBoundary key={router.asPath}>
             <main className={classNames("grow bg-white")}>{children}</main>
-
-            {showAzureBanner && <BuiltOnAzure />}
             <Footer />
           </ErrorBoundary>
         </div>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -16,6 +16,7 @@ import dynamic from "next/dynamic";
 import { Inter } from "next/font/google";
 import { useReportWebVitals } from "next/web-vitals";
 import { MegaMenuLayout, NavMenuGroup } from "ssw.megamenu";
+import { BuiltOnAzure } from "../blocks/builtOnAzure";
 import { CustomLink } from "../customLink";
 import { ErrorBoundary } from "../util/error/error-boundary";
 
@@ -156,7 +157,7 @@ export const Layout = ({
           <ErrorBoundary key={router.asPath}>
             <main className={classNames("grow bg-white")}>{children}</main>
 
-            {showAzureBanner && <PreFooter />}
+            {showAzureBanner && <BuiltOnAzure />}
             <Footer />
           </ErrorBoundary>
         </div>

--- a/components/training/trainingInformation.tsx
+++ b/components/training/trainingInformation.tsx
@@ -32,7 +32,7 @@ const TrainingInformationItem: FC<TrainingInformationItemProps> = ({
 
 export const TrainingInformation = ({ data }) => {
   return (
-    <Section color="white">
+    <Section color="default">
       <Container
         padding={"md:px-8 px-2"}
         size={"xsmall"}

--- a/components/util/constants/styles.tsx
+++ b/components/util/constants/styles.tsx
@@ -7,13 +7,10 @@ export const sectionColors = {
   toggleLightMode: "dark:bg-gray-950 dark:text-gray-300",
 };
 
-export enum SectionColor {
-  Default = "default",
-  LightGray = "lightgray",
-  DarkGray = "darkgray",
-  Red = "red",
-  Black = "black",
-  ToggleLightMode = "toggleLightMode",
-}
-
-export enum SectionColorConsulting {}
+export type SectionColor =
+  | "default"
+  | "lightgray"
+  | "darkgray"
+  | "red"
+  | "black"
+  | "toggleLightMode";

--- a/components/util/section.tsx
+++ b/components/util/section.tsx
@@ -1,14 +1,22 @@
 import classNames from "classnames";
 import React from "react";
-import { sectionColors } from "./constants/styles";
+import { SectionColor, sectionColors } from "./constants/styles";
+
+type SectionProps = {
+  children: React.ReactNode;
+  color?: SectionColor;
+  className?: string;
+  style?: React.CSSProperties;
+  id?: string;
+};
 
 export const Section = ({
   children,
-  color = "",
+  color = "default",
   className = "",
   style = {},
   id = "",
-}) => {
+}: SectionProps) => {
   const sectionColorCss = sectionColors[color] || sectionColors.default;
 
   return (

--- a/components/util/showAzureBanner.tsx
+++ b/components/util/showAzureBanner.tsx
@@ -4,19 +4,19 @@ import { sectionColors } from "./constants/styles";
 const azureBannerSchema: TinaField = {
   type: "object",
   name: "azureBanner",
-  label: "Azure Footer",
+  label: "Azure/Tina Footer",
   required: false,
   fields: [
     {
       type: "boolean",
       name: "showAzureFooter",
-      label: "Show Azure Footer",
+      label: "Show Azure/Tina Footer",
       required: false,
     },
     {
       type: "string",
       name: "azureFooterColor",
-      label: "Azure Footer Color",
+      label: "Azure/Tina Footer Background Color",
       required: false,
       options: Object.keys(sectionColors),
     },

--- a/components/util/showAzureBanner.tsx
+++ b/components/util/showAzureBanner.tsx
@@ -1,5 +1,5 @@
 import { TinaField } from "tinacms";
-import { sectionColors } from "./constants/styles";
+import { azureFooterColors } from "../blocks/builtOnAzure";
 
 const azureBannerSchema: TinaField = {
   type: "object",
@@ -18,7 +18,7 @@ const azureBannerSchema: TinaField = {
       name: "azureFooterColor",
       label: "Azure/Tina Footer Background Color",
       required: false,
-      options: Object.keys(sectionColors),
+      options: azureFooterColors,
     },
   ],
 };

--- a/components/util/showAzureBanner.tsx
+++ b/components/util/showAzureBanner.tsx
@@ -1,8 +1,26 @@
 import { TinaField } from "tinacms";
+import { sectionColors } from "./constants/styles";
 
 const azureBannerSchema: TinaField = {
-  type: "boolean",
-  name: "showAzureFooter",
-  label: "Show Azure Footer",
+  type: "object",
+  name: "azureBanner",
+  label: "Azure Footer",
+  required: false,
+  fields: [
+    {
+      type: "boolean",
+      name: "showAzureFooter",
+      label: "Show Azure Footer",
+      required: false,
+    },
+    {
+      type: "string",
+      name: "azureFooterColor",
+      label: "Azure Footer Color",
+      required: false,
+      options: Object.keys(sectionColors),
+    },
+  ],
 };
+
 export default azureBannerSchema;

--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -1,4 +1,5 @@
 ---
+showAzureFooter: true
 seo:
   description: >-
     30 years of Microsoft software and web development experience in Australia.
@@ -115,7 +116,9 @@ afterBody:
     align: center
     backgroundColor: default
     _template: Content
-showAzureFooter: true
+azureBanner:
+  showAzureFooter: true
+  azureFooterColor: lightgray
 ---
 
 # Australia's Leading AI, .NET and Azure Consultants

--- a/pages/[...filename].tsx
+++ b/pages/[...filename].tsx
@@ -1,14 +1,14 @@
 import { Blocks } from "@/components/blocks-renderer";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { componentRenderer } from "@/components/blocks/mdxComponentRenderer";
+import { client } from "@/tina/client";
 import classNames from "classnames";
+import { TODAY } from "hooks/useFetchEvents";
 import { InferGetStaticPropsType } from "next";
 import Head from "next/head";
 import { WebSite, WithContext } from "schema-dts";
 import { tinaField, useTina } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
-
-import { client } from "@/tina/client";
-import { TODAY } from "hooks/useFetchEvents";
 import { pageBlocks } from "../components/blocks";
 import { Breadcrumbs } from "../components/blocks/breadcrumbs";
 import { Layout } from "../components/layout";
@@ -120,6 +120,7 @@ export default function HomePage(
         <div className="no-print">
           <Blocks prefix="PageAfterBody" blocks={data.page.afterBody} />
         </div>
+        <BuiltOnAzure data={data.page.azureBanner} />
       </Layout>
     </>
   );

--- a/pages/[...filename].tsx
+++ b/pages/[...filename].tsx
@@ -59,11 +59,7 @@ export default function HomePage(
       )}
 
       <SEO seo={data.page.seo} />
-      <Layout
-        menu={data.megamenu}
-        liveStreamData={props.data.userGroup}
-        showAzureBanner={data.page.showAzureFooter}
-      >
+      <Layout menu={data.megamenu} liveStreamData={props.data.userGroup}>
         {data.page.breadcrumbs && (
           <Section className="mx-auto w-full max-w-9xl px-8 py-5">
             <Breadcrumbs

--- a/pages/live.tsx
+++ b/pages/live.tsx
@@ -116,7 +116,7 @@ export default function LivePage(
       <Container size="xsmall">
         <YoutubePlaylistBlock {...data.live.youtubePlaylist} />
       </Container>
-      <BuiltOnAzure data={data.live} />
+      <BuiltOnAzure data={data.live.azureBanner} />
     </Layout>
   );
 }

--- a/pages/live.tsx
+++ b/pages/live.tsx
@@ -116,7 +116,7 @@ export default function LivePage(
       <Container size="xsmall">
         <YoutubePlaylistBlock {...data.live.youtubePlaylist} />
       </Container>
-      <BuiltOnAzure data={{ backgroundColor: "lightgray" }} />
+      <BuiltOnAzure data={data.live} />
     </Layout>
   );
 }

--- a/pages/logo/[[...filename]].tsx
+++ b/pages/logo/[[...filename]].tsx
@@ -57,7 +57,7 @@ export default function LogosPage(
           </Section>
         )}
       </Container>
-      <BuiltOnAzure data={data.logos} />
+      <BuiltOnAzure data={data.logos.azureBanner} />
     </Layout>
   );
 }

--- a/pages/logo/[[...filename]].tsx
+++ b/pages/logo/[[...filename]].tsx
@@ -4,6 +4,7 @@ import { TinaMarkdown } from "tinacms/dist/rich-text";
 import { Breadcrumbs } from "@/blocks/breadcrumbs";
 import { componentRenderer } from "@/blocks/mdxComponentRenderer";
 import { Blocks } from "@/components/blocks-renderer";
+import { BuiltOnAzure } from "@/components/blocks/builtOnAzure";
 import { Layout } from "@/components/layout";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
@@ -60,6 +61,7 @@ export default function LogosPage(
           </Section>
         )}
       </Container>
+      <BuiltOnAzure data={data.logos} />
     </Layout>
   );
 }

--- a/pages/logo/[[...filename]].tsx
+++ b/pages/logo/[[...filename]].tsx
@@ -24,11 +24,7 @@ export default function LogosPage(
   });
 
   return (
-    <Layout
-      liveStreamData={props.data.userGroup}
-      menu={data?.megamenu}
-      showAzureBanner
-    >
+    <Layout liveStreamData={props.data.userGroup} menu={data?.megamenu}>
       <SEO seo={props.seo} />
       <Container className="flex-1 pt-2">
         {props?.seo?.showBreadcrumb && (

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -304,7 +304,7 @@ export default function NETUGPage(
           </Container>
 
           <Section>
-            <BuiltOnAzure data={data.userGroupPage} />
+            <BuiltOnAzure data={data.userGroupPage.azureBanner} />
           </Section>
         </Layout>
       </>
@@ -328,14 +328,14 @@ export default function NETUGPage(
               />
             </Section>
           )}
-          <Container className="prose prose-h1:pt-2 py-4" size="custom">
+          <Container className="prose py-4 prose-h1:pt-2" size="custom">
             <TinaMarkdown
               content={data.userGroupPage._body}
               components={componentRenderer}
               data-tina-field={tinaField(data.userGroupPage, "_body")}
             />
           </Container>
-          <BuiltOnAzure data={data.userGroupPage} />
+          <BuiltOnAzure data={data.userGroupPage.azureBanner} />
         </Layout>
       </>
     );

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -10,7 +10,7 @@ import ReactDomServer from "react-dom/server";
 import { tinaField, useTina } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 import { Breadcrumbs } from "../../components/blocks/breadcrumbs";
-import { BuiltOnAzure, BuiltOnAzure } from "../../components/blocks/builtOnAzure";
+import { BuiltOnAzure } from "../../components/blocks/builtOnAzure";
 import { componentRenderer } from "../../components/blocks/mdxComponentRenderer";
 import { Layout } from "../../components/layout";
 import { TestimonialRow } from "../../components/testimonials/TestimonialRow";
@@ -304,7 +304,7 @@ export default function NETUGPage(
           </Container>
 
           <Section>
-            <BuiltOnAzure data={{ azureBanner: {azureFooterColor: "lightgray" }}} />
+            <BuiltOnAzure data={data.userGroupPage} />
           </Section>
         </Layout>
       </>
@@ -328,18 +328,14 @@ export default function NETUGPage(
               />
             </Section>
           )}
-          <Container className="prose prose-h1:pt-2 py-4" size="custom">
+          <Container className="prose py-4 prose-h1:pt-2" size="custom">
             <TinaMarkdown
               content={data.userGroupPage._body}
               components={componentRenderer}
               data-tina-field={tinaField(data.userGroupPage, "_body")}
             />
           </Container>
-          <BuiltOnAzure data={{
-            azureBanner: {
-              azureFooterColor: "lightgray"
-            }
-          }} />
+          <BuiltOnAzure data={data.userGroupPage} />
         </Layout>
       </>
     );

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -1,17 +1,16 @@
+import { GoogleMapsWrapper } from "@/components/blocks/googleMapsWrapper";
+import { JoinAsPresenter } from "@/components/usergroup/joinAsPresenter";
+import { JoinGithub } from "@/components/usergroup/joinGithub";
+import { LatestTech } from "@/components/usergroup/latestTech";
+import { Organizer } from "@/components/usergroup/organizer";
 import client from "@/tina/client";
 import classNames from "classnames";
 import { InferGetStaticPropsType } from "next";
 import ReactDomServer from "react-dom/server";
 import { tinaField, useTina } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
-
-import { GoogleMapsWrapper } from "@/components/blocks/googleMapsWrapper";
-import { JoinAsPresenter } from "@/components/usergroup/joinAsPresenter";
-import { JoinGithub } from "@/components/usergroup/joinGithub";
-import { LatestTech } from "@/components/usergroup/latestTech";
-import { Organizer } from "@/components/usergroup/organizer";
 import { Breadcrumbs } from "../../components/blocks/breadcrumbs";
-import { BuiltOnAzure } from "../../components/blocks/builtOnAzure";
+import { BuiltOnAzure, BuiltOnAzure } from "../../components/blocks/builtOnAzure";
 import { componentRenderer } from "../../components/blocks/mdxComponentRenderer";
 import { Layout } from "../../components/layout";
 import { TestimonialRow } from "../../components/testimonials/TestimonialRow";
@@ -305,7 +304,7 @@ export default function NETUGPage(
           </Container>
 
           <Section>
-            <BuiltOnAzure data={{ backgroundColor: "lightgray" }} />
+            <BuiltOnAzure data={{ azureBanner: {azureFooterColor: "lightgray" }}} />
           </Section>
         </Layout>
       </>
@@ -336,6 +335,11 @@ export default function NETUGPage(
               data-tina-field={tinaField(data.userGroupPage, "_body")}
             />
           </Container>
+          <BuiltOnAzure data={{
+            azureBanner: {
+              azureFooterColor: "lightgray"
+            }
+          }} />
         </Layout>
       </>
     );

--- a/pages/netug/[[...filename]].tsx
+++ b/pages/netug/[[...filename]].tsx
@@ -328,7 +328,7 @@ export default function NETUGPage(
               />
             </Section>
           )}
-          <Container className="prose py-4 prose-h1:pt-2" size="custom">
+          <Container className="prose prose-h1:pt-2 py-4" size="custom">
             <TinaMarkdown
               content={data.userGroupPage._body}
               components={componentRenderer}

--- a/tina/collections/articles.tsx
+++ b/tina/collections/articles.tsx
@@ -18,7 +18,6 @@ import {
   callToActionSchema,
 } from "../../components/callToAction/callToAction";
 import { seoSchema } from "../../components/util/seo";
-import AzureBannerFields from "../../components/util/showAzureBanner";
 import { sidebarPanelSchema } from "../../components/util/sidebarPanel";
 import { tipField } from "./shared-fields";
 
@@ -137,7 +136,6 @@ export const articlesSchema: Collection = {
         ...callToActionSchema.fields,
       ],
     },
-    // azureBannerSchema,
   ],
 };
 

--- a/tina/collections/articles.tsx
+++ b/tina/collections/articles.tsx
@@ -206,7 +206,6 @@ export const articlesIndexSchema: Collection = {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     sidebarPanelSchema,
-    // azureBannerSchema,
   ],
 };
 export const clientsCategorySchema: Collection = {

--- a/tina/collections/articles.tsx
+++ b/tina/collections/articles.tsx
@@ -18,7 +18,7 @@ import {
   callToActionSchema,
 } from "../../components/callToAction/callToAction";
 import { seoSchema } from "../../components/util/seo";
-import azureBannerSchema from "../../components/util/showAzureBanner";
+import AzureBannerFields from "../../components/util/showAzureBanner";
 import { sidebarPanelSchema } from "../../components/util/sidebarPanel";
 import { tipField } from "./shared-fields";
 
@@ -137,7 +137,7 @@ export const articlesSchema: Collection = {
         ...callToActionSchema.fields,
       ],
     },
-    azureBannerSchema,
+    // azureBannerSchema,
   ],
 };
 
@@ -208,7 +208,7 @@ export const articlesIndexSchema: Collection = {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     sidebarPanelSchema,
-    azureBannerSchema,
+    // azureBannerSchema,
   ],
 };
 export const clientsCategorySchema: Collection = {

--- a/tina/collections/case-study.tsx
+++ b/tina/collections/case-study.tsx
@@ -5,7 +5,7 @@ import { tipField } from "./shared-fields";
 
 export const caseStudySchema: Collection = {
   name: "caseStudy",
-  label: "Company - Case Studies",
+  label: "Company - Case Study - Pages",
   format: "mdx",
   path: "content/company/case-study",
   ui: {

--- a/tina/collections/pages.tsx
+++ b/tina/collections/pages.tsx
@@ -84,6 +84,5 @@ export const pagesSchema: Collection = {
       },
       templates: [...Schemas.pageBlocks],
     },
-    // azureBannerSchema,
   ],
 };

--- a/tina/collections/pages.tsx
+++ b/tina/collections/pages.tsx
@@ -2,7 +2,6 @@ import type { Collection } from "tinacms";
 
 import * as Schemas from "../../components/blocks";
 import { seoSchema } from "../../components/util/seo";
-import azureBannerSchema from "../../components/util/showAzureBanner";
 import { tipField } from "./shared-fields";
 
 export const pagesSchema: Collection = {
@@ -85,6 +84,6 @@ export const pagesSchema: Collection = {
       },
       templates: [...Schemas.pageBlocks],
     },
-    azureBannerSchema,
+    // azureBannerSchema,
   ],
 };

--- a/tina/collections/usergroup.tsx
+++ b/tina/collections/usergroup.tsx
@@ -7,6 +7,7 @@ import type { Collection } from "tinacms";
 import { youtubePlaylistSchema } from "../../components/blocks/youtubePlaylist";
 import { joinAsPresenterSchema } from "../../components/usergroup/joinAsPresenter";
 import { latestTechSchema } from "../../components/usergroup/latestTech";
+import azureBannerSchema from "../../components/util/showAzureBanner";
 import { tipField } from "./shared-fields";
 
 export const userGroupPageSchema: Collection = {
@@ -154,6 +155,7 @@ export const userGroupPageSchema: Collection = {
           name: "testimonialCategories",
           collections: ["testimonialCategories"],
         },
+        azureBannerSchema,
       ],
     },
     {
@@ -171,6 +173,7 @@ export const userGroupPageSchema: Collection = {
           isBody: true,
           templates: [...Schemas.pageBlocks],
         },
+        azureBannerSchema,
       ],
     },
   ],

--- a/tina/config.tsx
+++ b/tina/config.tsx
@@ -1,4 +1,5 @@
 import { defineStaticConfig, TinaCMS } from "tinacms";
+import azureBannerSchema from "../components/util/showAzureBanner";
 import { articlesIndexSchema, articlesSchema } from "./collections/articles";
 import { caseStudySchema } from "./collections/case-study";
 import {
@@ -35,6 +36,7 @@ import { partnerIndexSchema } from "./collections/partner";
 import { paymentDetailsSchema } from "./collections/payment-details";
 import { presenterSchema } from "./collections/presenter";
 import { productsIndexSchema, productsSchema } from "./collections/products";
+import { tipField } from "./collections/shared-fields";
 import { technologiesSchema } from "./collections/technologies";
 import { testimonialCategoriesSchema } from "./collections/testimonialCategories";
 import { testimonialSchema } from "./collections/testimonials";
@@ -45,6 +47,74 @@ import {
 } from "./collections/usergroup";
 import { videoProductionSchema } from "./collections/videoProduction";
 
+const appendSharedSchemas = (
+  schemas,
+  leadingFields = [],
+  trailingFields = []
+) => {
+  for (const schema of schemas) {
+    if (!schema.fields) {
+      continue;
+    }
+    schema.fields = [...leadingFields, ...schema.fields, ...trailingFields];
+  }
+  return schemas;
+};
+
+const formattedSchemas = () => {
+  return [
+    ...schemas,
+    ...appendSharedSchemas(pageSchemas, [], [azureBannerSchema]),
+  ].sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const pageSchemas = [
+  caseStudySchema,
+  pagesSchema,
+  articlesIndexSchema,
+  articlesSchema,
+  companyIndexSchema,
+  companySchema,
+  consultingv2Schema,
+  consultingIndexSchema,
+  consultingSchema,
+  videoProductionSchema,
+  employmentSchema,
+  eventsIndexSchema,
+  eventsSchema,
+  industrySchema,
+  liveSchema,
+  marketingSchema,
+  officeIndexSchema,
+  officeSchema,
+  partnerIndexSchema,
+  productsIndexSchema,
+  industryIndexSchema,
+  productsSchema,
+  userGroupPageSchema,
+  trainingSchema,
+];
+
+const schemas = [
+  consultingv2TechnologySchema,
+  consultingv2TechnologyGroupsSchema,
+  paymentDetailsSchema,
+  clientsCategorySchema,
+  eventsCalendarSchema,
+  consultingCategorySchema,
+  consultingTagSchema,
+  technologiesSchema,
+  locationSchema,
+  presenterSchema,
+  newsletterSchema,
+  testimonialSchema,
+  testimonialCategoriesSchema,
+  opportunitiesSchema,
+  globalSchema,
+  megaMenuSchema,
+  logosSchema,
+  userGroupGlobalSchema,
+];
 const config = defineStaticConfig({
   clientId: process.env.NEXT_PUBLIC_TINA_CLIENT_ID!,
   branch:
@@ -86,50 +156,7 @@ const config = defineStaticConfig({
     return cms;
   },
   schema: {
-    collections: [
-      pagesSchema,
-      globalSchema,
-      megaMenuSchema,
-      articlesIndexSchema,
-      articlesSchema,
-      companyIndexSchema,
-      companySchema,
-      clientsCategorySchema,
-      paymentDetailsSchema,
-      caseStudySchema,
-      consultingv2Schema,
-      consultingv2TechnologyGroupsSchema,
-      consultingv2TechnologySchema,
-      consultingIndexSchema,
-      consultingSchema,
-      videoProductionSchema,
-      consultingCategorySchema,
-      consultingTagSchema,
-      technologiesSchema,
-      employmentSchema,
-      opportunitiesSchema,
-      eventsIndexSchema,
-      eventsSchema,
-      eventsCalendarSchema,
-      locationSchema,
-      presenterSchema,
-      logosSchema,
-      industrySchema,
-      liveSchema,
-      marketingSchema,
-      newsletterSchema,
-      officeIndexSchema,
-      officeSchema,
-      partnerIndexSchema,
-      productsIndexSchema,
-      industryIndexSchema,
-      productsSchema,
-      testimonialSchema,
-      testimonialCategoriesSchema,
-      trainingSchema,
-      userGroupPageSchema,
-      userGroupGlobalSchema,
-    ],
+    collections: formattedSchemas(),
   },
   search: {
     tina: {

--- a/tina/config.tsx
+++ b/tina/config.tsx
@@ -60,7 +60,6 @@ const appendSharedSchemas = (
   }
   return schemas;
 };
-
 const formattedSchemas = () => {
   return [
     ...schemas,
@@ -92,6 +91,7 @@ const pageSchemas = [
   industryIndexSchema,
   productsSchema,
   userGroupPageSchema,
+  logosSchema,
   trainingSchema,
 ];
 
@@ -112,7 +112,6 @@ const schemas = [
   opportunitiesSchema,
   globalSchema,
   megaMenuSchema,
-  logosSchema,
   userGroupGlobalSchema,
 ];
 const config = defineStaticConfig({

--- a/tina/config.tsx
+++ b/tina/config.tsx
@@ -36,7 +36,6 @@ import { partnerIndexSchema } from "./collections/partner";
 import { paymentDetailsSchema } from "./collections/payment-details";
 import { presenterSchema } from "./collections/presenter";
 import { productsIndexSchema, productsSchema } from "./collections/products";
-import { tipField } from "./collections/shared-fields";
 import { technologiesSchema } from "./collections/technologies";
 import { testimonialCategoriesSchema } from "./collections/testimonialCategories";
 import { testimonialSchema } from "./collections/testimonials";


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: /*


### Description 
This PR adds the azure banner to every page. There are page templates where the default color of the banner doesn't fit the style of the page so I've updated the banner to default to a color that suits the content. I've also added an option in Tina to disable the banner where it might not suit the content of the page. 

**Note**: **"white" has never been a valid property value for the section color property. I just added typescript to this prop so the errors are appearing now.**

### Changes
-  Added a the Azure banner to every page without one
- ♻️ Created a more efficient way to add fields to every page template
- ✨ Added an option to change the background of the Azure banner on every page
- ✨ Added an option to disable the azure banner on every page

- Fixed #3498

- [x] Include done video or screenshots

![azure banner customizeability](https://github.com/user-attachments/assets/6e211d77-0b11-45cb-9efb-bd3077064102)

**Figure**: **Customizing the Azure banner**


