### PR TITLE
🔥Hotfix - Fix Corepack error in build pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,9 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-
-
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 
-RUN \
-  npm i -g corepack@latest; \
-  fi
+RUN npm i -g corepack@latest
 
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,16 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
+
+
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+
+  
+
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm i --frozen-lockfile; \
   else echo "Lockfile not found." && exit 1; \
   fi
 
@@ -86,7 +91,7 @@ ENV NEXT_PUBLIC_SLOT_URL $NEXT_PUBLIC_SLOT_URL
 RUN \
   if [ -f yarn.lock ]; then yarn run build; \
   elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm run build; \
   else echo "Lockfile not found." && exit 1; \
   fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@ WORKDIR /app
 
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 
-  
+RUN \
+  npm i -g corepack@latest; \
+  fi
 
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm i --frozen-lockfile; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
   else echo "Lockfile not found." && exit 1; \
   fi
 
@@ -88,10 +90,12 @@ ENV TINA_SEARCH_TOKEN $TINA_SEARCH_TOKEN
 ARG NEXT_PUBLIC_SLOT_URL
 ENV NEXT_PUBLIC_SLOT_URL $NEXT_PUBLIC_SLOT_URL
 
+
+
 RUN \
   if [ -f yarn.lock ]; then yarn run build; \
   elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
   else echo "Lockfile not found." && exit 1; \
   fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,10 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 
-RUN npm i -g corepack@latest
-
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm i --frozen-lockfile; \
   else echo "Lockfile not found." && exit 1; \
   fi
 
@@ -91,7 +89,7 @@ ENV NEXT_PUBLIC_SLOT_URL $NEXT_PUBLIC_SLOT_URL
 RUN \
   if [ -f yarn.lock ]; then yarn run build; \
   elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm run build; \
   else echo "Lockfile not found." && exit 1; \
   fi
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->


Older versions of Corepack have the the npm registrey key (which was recently updated) hard coded. The alpine image we use in the Docker container for our deployment pipeline still uses a version of Corepack with the old key, causing our deployments to fail when we try to enable Corepack during the build step.

See issue https://github.com/nodejs/corepack/issues/625#issue-2826464146. 


To fix this I've updated our build pipeline to manually install the latest version of Corepack. The fix was published [here](https://github.com/nodejs/corepack/pull/614).


- Affected routes: N/a

- Fixed #3572 

- [x] Include done video or screenshots

![image](https://github.com/user-attachments/assets/8500a908-76cf-41bb-8827-3b24d2b5327b)

**Figure**: **Build pipeline running successfully**
