### PR TITLE
Chips - Allow adding up to 6 chips

### DIFF
--- a/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
+++ b/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
@@ -333,11 +333,11 @@ export const CardCarouselSchema: Template = {
           name: "chips",
           label: "Chips",
           type: "object",
-          description: "The list of chips that displayed on card",
+          description: "The chips displayed on card. Max 6.",
           list: true,
           ui: {
             itemProps: (item) => {
-              return { label: item?.label ?? "Chip" };
+              return { label: item?.chipText ?? "Chip" };
             },
             defaultItem: {
               chipText: "Lorem",

--- a/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
+++ b/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
@@ -1,7 +1,7 @@
 import { default as React, useEffect, useState } from "react";
 import { Template, TinaField, wrapFieldsWithMeta } from "tinacms";
 import { listItemSchema } from "../../../blocksSubtemplates/listItem.schema";
-import { pillGroupSchema } from "../../../blocksSubtemplates/pillGroup";
+import { pillGroupSchemaV2 } from "../../../blocksSubtemplates/pillGroup";
 import tabletTextAlignmentField from "../../../blocksSubtemplates/tabletTextAlignment.schema";
 import { cardOptions } from "../../../blocksSubtemplates/tinaFormElements/colourOptions/cardOptions";
 import { ColorPickerInput } from "../../../blocksSubtemplates/tinaFormElements/colourSelector";
@@ -27,14 +27,16 @@ const GUIDGeneratorComponent = (props) => {
 const defaultCardItem = {
   guid: null,
   altText: "Lorem Ipsum",
-  chips: {
-    chips: [
-      {
-        filledChipText: "Lorem",
-        clearChipText: "Ipsum",
-      },
-    ],
-  },
+  chips: [
+    {
+      chipText: "Lorem",
+      chipType: "filledChip",
+    },
+    {
+      chipText: "Ipsum",
+      chipType: "clearChip",
+    },
+  ],
   icon: "info",
   heading: "Lorem Ipsum",
   description:
@@ -331,9 +333,20 @@ export const CardCarouselSchema: Template = {
           name: "chips",
           label: "Chips",
           type: "object",
-          description: "Add chips to the bottom of the media text block.",
+          description: "The list of chips that displayed on card",
+          list: true,
+          ui: {
+            itemProps: (item) => {
+              return { label: item?.label ?? "Chip" };
+            },
+            defaultItem: {
+              chipText: "Lorem",
+              chipType: "filledChip",
+            },
+            max: 6,
+          },
           //@ts-expect-error – fields are not being recognized
-          fields: pillGroupSchema,
+          fields: pillGroupSchemaV2,
         },
         {
           type: "string",

--- a/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
+++ b/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
@@ -1,7 +1,7 @@
 import { default as React, useEffect, useState } from "react";
 import { Template, TinaField, wrapFieldsWithMeta } from "tinacms";
 import { listItemSchema } from "../../../blocksSubtemplates/listItem.schema";
-import { pillGroupSchemaV2 } from "../../../blocksSubtemplates/pillGroup";
+import { pillGroupSchema } from "../../../blocksSubtemplates/pillGroup";
 import tabletTextAlignmentField from "../../../blocksSubtemplates/tabletTextAlignment.schema";
 import { cardOptions } from "../../../blocksSubtemplates/tinaFormElements/colourOptions/cardOptions";
 import { ColorPickerInput } from "../../../blocksSubtemplates/tinaFormElements/colourSelector";
@@ -346,7 +346,7 @@ export const CardCarouselSchema: Template = {
             max: 6,
           },
           //@ts-expect-error – fields are not being recognized
-          fields: pillGroupSchemaV2,
+          fields: pillGroupSchema,
         },
         {
           type: "string",

--- a/components/blocks/cardCarousel/layout/card.tsx
+++ b/components/blocks/cardCarousel/layout/card.tsx
@@ -22,6 +22,8 @@ const Card = ({ data, placeholder, className }: CardProps) => {
     : null;
   const [usePlaceholder, setUsePlaceholder] = useState(false);
   const placeholderImage = "/images/videoPlaceholder.png";
+  // eslint-disable-next-line no-console
+  console.log(data.chips);
 
   return (
     <div

--- a/components/blocks/cardCarousel/layout/card.tsx
+++ b/components/blocks/cardCarousel/layout/card.tsx
@@ -22,8 +22,6 @@ const Card = ({ data, placeholder, className }: CardProps) => {
     : null;
   const [usePlaceholder, setUsePlaceholder] = useState(false);
   const placeholderImage = "/images/videoPlaceholder.png";
-  // eslint-disable-next-line no-console
-  console.log(data.chips);
 
   return (
     <div

--- a/components/blocks/imageComponents/imageTextBlock/imageTextBlock.schema.tsx
+++ b/components/blocks/imageComponents/imageTextBlock/imageTextBlock.schema.tsx
@@ -2,7 +2,7 @@ import tabletTextAlignmentField from "@/components/blocksSubtemplates/tabletText
 import { Template, TinaField } from "tinacms";
 import { IconLabelSchema } from "../../../blocksSubtemplates/iconLabel";
 import { listItemSchema } from "../../../blocksSubtemplates/listItem.schema";
-import { pillGroupSchema } from "../../../blocksSubtemplates/pillGroup";
+import { pillGroupSchemaV2 } from "../../../blocksSubtemplates/pillGroup";
 import { buttonSchema } from "../../../button/templateButton.schema";
 import { ImageComponentLayoutSchema } from "../ImageComponentLayoutSchema";
 
@@ -83,7 +83,7 @@ export const ImageTextBlockSchema: Template = {
       type: "object",
       description: "Add chips to the bottom of the media text block.",
       //@ts-expect-error – fields are not being recognized
-      fields: pillGroupSchema,
+      fields: pillGroupSchemaV2,
     },
     {
       name: "featureColumns",

--- a/components/blocks/imageComponents/imageTextBlock/imageTextBlock.schema.tsx
+++ b/components/blocks/imageComponents/imageTextBlock/imageTextBlock.schema.tsx
@@ -81,7 +81,18 @@ export const ImageTextBlockSchema: Template = {
       name: "chips",
       label: "Chips",
       type: "object",
-      description: "Add chips to the bottom of the media text block.",
+      description: "The chips displayed on card. Max 6.",
+      list: true,
+      ui: {
+        itemProps: (item) => {
+          return { label: item?.chipText ?? "Chip" };
+        },
+        defaultItem: {
+          chipText: "Lorem",
+          chipType: "filledChip",
+        },
+        max: 6,
+      },
       //@ts-expect-error – fields are not being recognized
       fields: pillGroupSchemaV2,
     },

--- a/components/blocks/imageComponents/imageTextBlock/imageTextBlock.schema.tsx
+++ b/components/blocks/imageComponents/imageTextBlock/imageTextBlock.schema.tsx
@@ -2,7 +2,7 @@ import tabletTextAlignmentField from "@/components/blocksSubtemplates/tabletText
 import { Template, TinaField } from "tinacms";
 import { IconLabelSchema } from "../../../blocksSubtemplates/iconLabel";
 import { listItemSchema } from "../../../blocksSubtemplates/listItem.schema";
-import { pillGroupSchemaV2 } from "../../../blocksSubtemplates/pillGroup";
+import { pillGroupSchema } from "../../../blocksSubtemplates/pillGroup";
 import { buttonSchema } from "../../../button/templateButton.schema";
 import { ImageComponentLayoutSchema } from "../ImageComponentLayoutSchema";
 
@@ -94,7 +94,7 @@ export const ImageTextBlockSchema: Template = {
         max: 6,
       },
       //@ts-expect-error – fields are not being recognized
-      fields: pillGroupSchemaV2,
+      fields: pillGroupSchema,
     },
     {
       name: "featureColumns",

--- a/components/blocksSubtemplates/pillGroup.tsx
+++ b/components/blocksSubtemplates/pillGroup.tsx
@@ -28,11 +28,12 @@ export const pillGroupSchema = [
     type: "string",
     label: "Chip text",
     name: "chipText",
+    description: "Max 30 characters.",
     ui: {
       validate: (value: string) => {
         const lenghtOfText = value?.length || 0;
         if (lenghtOfText > 30) {
-          return "Chip text should be less than 30 characters";
+          return "Chip text should be less than 30 characters.";
         }
       },
     },

--- a/components/blocksSubtemplates/pillGroup.tsx
+++ b/components/blocksSubtemplates/pillGroup.tsx
@@ -1,59 +1,24 @@
 import { tinaField } from "tinacms/dist/react";
 
-// export const PillGroup = ({ data }) => {
-//   return (
-//     <div className="flex gap-2 py-2">
-//       {data.filledChipText && (
-//         <span
-//           data-tina-field={tinaField(data, "filledChipText")}
-//           className="rounded-md bg-neutral-600 px-2 py-1 text-xs font-light text-white"
-//         >
-//           {data.filledChipText}
-//         </span>
-//       )}
-//       {data.clearChipText && (
-//         <span
-//           data-tina-field={tinaField(data, "clearChipText")}
-//           className="px-2 py-1 text-xs font-light text-white"
-//         >
-//           {data.clearChipText}
-//         </span>
-//       )}
-//     </div>
-//   );
-// };
-
-export const pillGroupSchema = [
-  {
-    type: "string",
-    label: "Filled Chip",
-    name: "filledChipText",
-    description: "Text for the filled chip.",
-  },
-  {
-    type: "string",
-    label: "Clear Chip",
-    name: "clearChipText",
-    description: "Text for the clear chip.",
-  },
-];
-
 export const PillGroup = ({ data }) => {
   return (
-    <div className="flex gap-2 py-2">
-      {data.chips?.map((chip, index) => {
-        <span
-          key={index}
-          data-tina-field={tinaField(data, `chips[${index}].chipText`)}
-          className={
-            chip.chipType === "filledChip"
-              ? "rounded-md bg-neutral-600 px-2 py-1 text-xs font-light text-white"
-              : "px-2 py-1 text-xs font-light text-white"
-          }
-        >
-          {chip.chipText}
-        </span>;
-      })}
+    <div className="flex flex-wrap gap-2 py-2">
+      {data?.map(
+        (chip, index) =>
+          chip?.chipText && (
+            <span
+              key={index}
+              data-tina-field={tinaField(chip, "chipText")}
+              className={
+                chip.chipType === "filledChip"
+                  ? "rounded-md bg-neutral-600 px-2 py-1 text-xs font-light text-white"
+                  : "px-2 py-1 text-xs font-light text-white"
+              }
+            >
+              {chip.chipText}
+            </span>
+          )
+      )}
     </div>
   );
 };
@@ -63,13 +28,19 @@ export const pillGroupSchemaV2 = [
     type: "string",
     label: "Chip text",
     name: "chipText",
-    description: "Text for the chip",
+    ui: {
+      validate: (value: string) => {
+        const lenghtOfText = value?.length || 0;
+        if (lenghtOfText > 30) {
+          return "Chip text should be less than 30 characters";
+        }
+      },
+    },
   },
   {
     type: "string",
     label: "Select chip type",
     name: "chipType",
-    description: "Type of the chip (filled or clear)",
     ui: {
       component: "select",
       options: [

--- a/components/blocksSubtemplates/pillGroup.tsx
+++ b/components/blocksSubtemplates/pillGroup.tsx
@@ -1,27 +1,27 @@
 import { tinaField } from "tinacms/dist/react";
 
-export const PillGroup = ({ data }) => {
-  return (
-    <div className="flex gap-2 py-2">
-      {data.filledChipText && (
-        <span
-          data-tina-field={tinaField(data, "filledChipText")}
-          className="rounded-md bg-neutral-600 px-2 py-1 text-xs font-light text-white"
-        >
-          {data.filledChipText}
-        </span>
-      )}
-      {data.clearChipText && (
-        <span
-          data-tina-field={tinaField(data, "clearChipText")}
-          className="px-2 py-1 text-xs font-light text-white"
-        >
-          {data.clearChipText}
-        </span>
-      )}
-    </div>
-  );
-};
+// export const PillGroup = ({ data }) => {
+//   return (
+//     <div className="flex gap-2 py-2">
+//       {data.filledChipText && (
+//         <span
+//           data-tina-field={tinaField(data, "filledChipText")}
+//           className="rounded-md bg-neutral-600 px-2 py-1 text-xs font-light text-white"
+//         >
+//           {data.filledChipText}
+//         </span>
+//       )}
+//       {data.clearChipText && (
+//         <span
+//           data-tina-field={tinaField(data, "clearChipText")}
+//           className="px-2 py-1 text-xs font-light text-white"
+//         >
+//           {data.clearChipText}
+//         </span>
+//       )}
+//     </div>
+//   );
+// };
 
 export const pillGroupSchema = [
   {
@@ -35,5 +35,53 @@ export const pillGroupSchema = [
     label: "Clear Chip",
     name: "clearChipText",
     description: "Text for the clear chip.",
+  },
+];
+
+export const PillGroup = ({ data }) => {
+  return (
+    <div className="flex gap-2 py-2">
+      {data.chips?.map((chip, index) => {
+        <span
+          key={index}
+          data-tina-field={tinaField(data, `chips[${index}].chipText`)}
+          className={
+            chip.chipType === "filledChip"
+              ? "rounded-md bg-neutral-600 px-2 py-1 text-xs font-light text-white"
+              : "px-2 py-1 text-xs font-light text-white"
+          }
+        >
+          {chip.chipText}
+        </span>;
+      })}
+    </div>
+  );
+};
+
+export const pillGroupSchemaV2 = [
+  {
+    type: "string",
+    label: "Chip text",
+    name: "chipText",
+    description: "Text for the chip",
+  },
+  {
+    type: "string",
+    label: "Select chip type",
+    name: "chipType",
+    description: "Type of the chip (filled or clear)",
+    ui: {
+      component: "select",
+      options: [
+        {
+          label: "Filled Chip",
+          value: "filledChip",
+        },
+        {
+          label: "Clear Chip",
+          value: "clearChip",
+        },
+      ],
+    },
   },
 ];

--- a/components/blocksSubtemplates/pillGroup.tsx
+++ b/components/blocksSubtemplates/pillGroup.tsx
@@ -23,7 +23,7 @@ export const PillGroup = ({ data }) => {
   );
 };
 
-export const pillGroupSchemaV2 = [
+export const pillGroupSchema = [
   {
     type: "string",
     label: "Chip text",

--- a/content/consultingv2/net-upgrade.json
+++ b/content/consultingv2/net-upgrade.json
@@ -19,10 +19,16 @@
       "isH1": true,
       "description": "Upgrade your .NET applications to the latest .NET framework. We guide you past common pitfalls, ensuring you benefit from all the new features.\n",
       "tabletTextAlignment": "Left",
-      "chips": {
-        "filledChipText": "",
-        "clearChipText": ""
-      },
+      "chips": [
+        {
+          "chipText": "",
+          "chipType": "filledChip"
+        },
+        {
+          "chipText": "",
+          "chipType": "clearChip"
+        }
+      ],
       "featureColumns": {
         "twoColumns": true
       },
@@ -169,10 +175,16 @@
           "guid": "ye7r7",
           "image": "",
           "altText": "Speed Up Your Apps",
-          "chips": {
-            "filledChipText": "",
-            "clearChipText": ""
-          },
+          "chips": [
+            {
+              "chipText": "",
+              "chipType": "filledChip"
+            },
+            {
+              "chipText": "",
+              "chipType": "clearChip"
+            }
+          ],
           "icon": "BiTachometer",
           "heading": "Speed Up Your Apps",
           "description": ".NET's latest updates are all about performance, and we'll make sure you're getting the most out of it.",
@@ -203,9 +215,12 @@
           "guid": "imtiro",
           "image": "",
           "altText": "Skip the Upgrade Hassles",
-          "chips": {
-            "filledChipText": ""
-          },
+          "chips": [
+            {
+              "chipText": "",
+              "chipType": "filledChip"
+            }
+          ],
           "icon": "BiSkipNext",
           "heading": "Skip the Upgrade Hassles",
           "description": "We've already solved the tricky bits of .NET migrations. Avoid common pitfalls with",
@@ -236,9 +251,12 @@
           "guid": "m0bkqf",
           "image": "",
           "altText": "Beyond Basic Migration",
-          "chips": {
-            "filledChipText": ""
-          },
+          "chips": [
+            {
+              "chipText": "",
+              "chipType": "filledChip"
+            }
+          ],
           "icon": "BiRocket",
           "heading": "Beyond Basic Migration",
           "description": "Our team isn't just good with upgrades. We're .NET experts and can optimize your code for this new version.",
@@ -281,10 +299,16 @@
       "isH1": false,
       "description": "We Marie Kondo'd [BizCover's](https://www.bizcover.com.au/) codebase, swapping their microservice sprawl for a tidy .NET8 modular monolith (MoMo). Domain-driven design helped us define the modules, while OpenTelemetry, Prometheus, and Grafana kept things monitored.\n",
       "tabletTextAlignment": "Left",
-      "chips": {
-        "filledChipText": ".NET8",
-        "clearChipText": "Modular Monolith (MoMo)"
-      },
+      "chips": [
+        {
+          "chipText": ".NET8",
+          "chipType": "filledChip"
+        },
+        {
+          "chipText": "Modular Monolith (MoMo)",
+          "chipType": "clearChip"
+        }
+      ],
       "featureColumns": {
         "twoColumns": false,
         "features": [
@@ -334,10 +358,16 @@
           "youtubeUrl": "https://www.youtube.com/watch?v=ocbPkNROnlc",
           "image": "",
           "altText": "Collections in .NET: The performance deep dive you didn't know you needed 🚀",
-          "chips": {
-            "filledChipText": ".NET User Groups",
-            "clearChipText": "1 hour"
-          },
+          "chips": [
+            {
+              "chipText": ".NET User Groups",
+              "chipType": "filledChip"
+            },
+            {
+              "chipText": "1 hour",
+              "chipType": "clearChip"
+            }
+          ],
           "heading": "Collections in .NET: The performance deep dive you didn't know you needed 🚀",
           "description": "Think you know .NET collections? Think again. From array memory layouts to dictionary collision handling, Anton Polkanov breaks down the nitty-gritty details that separate good code from great code.",
           "embeddedButton": {
@@ -351,10 +381,16 @@
           "youtubeUrl": "https://www.youtube.com/watch?v=EjYczs7RYD8",
           "image": "/images/Louis Test Images/Incident-io-batch/cloud_native_net-aspire_16-9.jpg",
           "altText": "Breaking down .NET Aspire: Your gateway to cloud native apps",
-          "chips": {
-            "filledChipText": ".NET Aspire",
-            "clearChipText": "1 hour "
-          },
+          "chips": [
+            {
+              "chipText": ".NET Aspire",
+              "chipType": "filledChip"
+            },
+            {
+              "chipText": "1 hour",
+              "chipType": "clearChip"
+            }
+          ],
           "heading": "Breaking Down .NET Aspire: Your Gateway to Cloud Native Apps",
           "description": "SSW's Matt Wicks teams up with Octopus Deploy's Rob Pearson to demystify .NET Aspire. Dive into real-world orchestration, service integration, and deployment strategies that'll level up your cloud-native game.",
           "embeddedButton": {
@@ -368,10 +404,16 @@
           "youtubeUrl": "https://www.youtube.com/watch?v=Ft2JArXEXcI",
           "image": "/images/Louis Test Images/Incident-io-batch/dotnet_cleanarchitecture.png",
           "altText": "Full-Stack Clean Architecture: The Right Way to Share Code",
-          "chips": {
-            "filledChipText": ".NET User Groups",
-            "clearChipText": "1 hour"
-          },
+          "chips": [
+            {
+              "chipText": ".NET User Groups",
+              "chipType": "filledChip"
+            },
+            {
+              "chipText": "1 hour",
+              "chipType": "clearChip"
+            }
+          ],
           "heading": "Full-Stack Clean Architecture: The right way to share code",
           "description": "Stop wrestling with UI and API code! Matt Goldman (author of .NET MAUI in Action) reveals how to nail Clean Architecture across MAUI and ASP.NET Core without the classic pitfalls. Expect real demos, not just theory.",
           "embeddedButton": {
@@ -434,10 +476,16 @@
       "heading": "Talk to us about your .NET project today",
       "isH1": false,
       "description": "Connect with our Account Managers to discuss how we can help.\n",
-      "chips": {
-        "filledChipText": "",
-        "clearChipText": ""
-      },
+      "chips": [
+        {
+          "chipText": "",
+          "chipType": "filledChip"
+        },
+        {
+          "chipText": "",
+          "chipType": "clearChip"
+        }
+      ],
       "featureColumns": {
         "twoColumns": true,
         "features": [
@@ -473,10 +521,16 @@
       "heading": "",
       "isH1": false,
       "description": "",
-      "chips": {
-        "filledChipText": "",
-        "clearChipText": ""
-      },
+      "chips": [
+        {
+          "chipText": "",
+          "chipType": "filledChip"
+        },
+        {
+          "chipText": "",
+          "chipType": "clearChip"
+        }
+      ],
       "featureColumns": {
         "twoColumns": true
       },


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: [<!-- E.g. `/offices/brisbane`  -->](https://www.ssw.com.au/consulting/net-upgrade)

- Fixed #3472 

**Changes:**
- Allow adding 6 chips
- Chip text has 30 length validation (ToDo - get designer approval for this)
- Chips wrapped in flex container, and if adding new chip exceeds row width, then it will be moved to next row automatically
- When adding a new chip, we can select type also (filled or clear)

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [x] Include done video or screenshots

![image](https://github.com/user-attachments/assets/4409efc1-7653-43b2-9ac0-eec57245979c)
**Figure: Chips list, only allows adding up to 6 chips**

![image](https://github.com/user-attachments/assets/41529811-b279-4a03-869c-f901a19bfa73)
**Figure: Exceeding 30 character length for chip text will show validation error message**

![image](https://github.com/user-attachments/assets/48de9a2c-0f2e-4f3f-b221-90591640359e)
**Figure: How 6 chips are displayed on card**


