### PR TITLE
Fix - Using compatible version for Pnpm to install dependencies  

### DIFF
--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -1,9 +1,6 @@
 name: Weekly - Fetch SSW People Profiles
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * TUE"

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           corepack prepare pnpm@9.15.1 --activate
 
+      - run: pnpm add -w gray-matter
+
       - name: Fetch SSW.People.Profiles
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -29,15 +29,16 @@ jobs:
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
-      - name: enable corepack
+      - name: Enable corepack
         run: |
           corepack enable
 
       - name: Install pnpm
         run: |
-          corepack prepare pnpm@9.15.1 --activate
+          corepack prepare pnpm@9.15.1 --activate # It doesn't work well with pnpm@latest, therefore we use a specific version as per - https://github.com/pnpm/pnpm/issues/9029
 
-      - run: |
+      - name: Install dependencies
+        run: |
           cd ${{ env.GITHUB_WORKSPACE }}
           pnpm add gray-matter
 

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -29,10 +29,7 @@ jobs:
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
-      - run: node --version
-      - name: Install pnpm
-        run: npm install -g pnpm
-
+      - run: pnpm i -g corepack@latest
       - run: corepack enable pnpm
       - run: pnpm add -w gray-matter
 

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
-      - run: echo node --version
+      - run: node --version
       - name: Install pnpm
         run: npm install -g pnpm
 

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -1,6 +1,9 @@
 name: Weekly - Fetch SSW People Profiles
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * TUE"

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -26,13 +26,7 @@ jobs:
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
-      - name: Enable corepack
-        run: |
-          corepack enable
-
-      - name: Prepare pnpm
-        run: |
-          corepack prepare pnpm@9.15.1 --activate # It doesn't work well with pnpm@latest, therefore we use a specific version as per - https://github.com/pnpm/pnpm/issues/9029
+      - uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -29,9 +29,11 @@ jobs:
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
-      - run: corepack enable pnpm
-      - run: corepack prepare pnpm@9.15.0 --activate
-      - run: pnpm add -w gray-matter
+      - name: Install latest pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          pnpm --version  # Verify latest pnpm version
 
       - name: Fetch SSW.People.Profiles
         uses: actions/github-script@v7

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: 20.3.0
+          node-version-file: "20"
           cache: "pnpm"
 
       - run: corepack enable pnpm

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -1,9 +1,6 @@
 name: Weekly - Fetch SSW People Profiles
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * TUE"
@@ -33,7 +30,7 @@ jobs:
         run: |
           corepack enable
 
-      - name: Install pnpm
+      - name: Prepare pnpm
         run: |
           corepack prepare pnpm@9.15.1 --activate # It doesn't work well with pnpm@latest, therefore we use a specific version as per - https://github.com/pnpm/pnpm/issues/9029
 

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
-      - run: pnpm i -g corepack@latest
       - run: corepack enable pnpm
+      - run: pnpm i -g corepack@latest
       - run: pnpm add -w gray-matter
 
       - name: Fetch SSW.People.Profiles

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -30,7 +30,7 @@ jobs:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
       - run: corepack enable pnpm
-      - run: pnpm i -g corepack@latest
+      - run: corepack prepare pnpm@9.15.0 --activate
       - run: pnpm add -w gray-matter
 
       - name: Fetch SSW.People.Profiles

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          corepack prepare pnpm@latest --activate
+          corepack prepare pnpm@9.15.1 --activate
 
       - name: Fetch SSW.People.Profiles
         uses: actions/github-script@v7

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -37,7 +37,9 @@ jobs:
         run: |
           corepack prepare pnpm@9.15.1 --activate
 
-      - run: pnpm add -w gray-matter
+      - run: |
+          cd ${{ env.GITHUB_WORKSPACE }}
+          pnpm add gray-matter
 
       - name: Fetch SSW.People.Profiles
         uses: actions/github-script@v7

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Install pnpm
         run: |
           corepack prepare pnpm@latest --activate
-          pnpm --version  # Verify latest pnpm version
 
       - name: Fetch SSW.People.Profiles
         uses: actions/github-script@v7

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -29,9 +29,12 @@ jobs:
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
 
-      - name: Install latest pnpm
+      - name: enable corepack
         run: |
           corepack enable
+
+      - name: Install pnpm
+        run: |
           corepack prepare pnpm@latest --activate
           pnpm --version  # Verify latest pnpm version
 

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: 20
+          node-version-file: 20.3.0
           cache: "pnpm"
 
       - run: corepack enable pnpm

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -27,10 +27,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
-
-      - name: Install pnpm
-        run: npm install -g pnpm
+          node-version-file: 20
+          cache: "pnpm"
 
       - run: corepack enable pnpm
       - run: pnpm add -w gray-matter

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -1,6 +1,9 @@
 name: Weekly - Fetch SSW People Profiles
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * TUE"
@@ -25,6 +28,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
+
+      - name: Install pnpm
+        run: npm install -g pnpm
 
       - run: corepack enable pnpm
       - run: pnpm add -w gray-matter

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -27,8 +27,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: "20"
-          cache: "pnpm"
+          node-version-file: ${{ env.GITHUB_WORKSPACE }}/.nvmrc
+
+      - run: echo node --version
+      - name: Install pnpm
+        run: npm install -g pnpm
 
       - run: corepack enable pnpm
       - run: pnpm add -w gray-matter

--- a/.github/workflows/fetch-people-profiles.yml
+++ b/.github/workflows/fetch-people-profiles.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd ${{ env.GITHUB_WORKSPACE }}
           pnpm add gray-matter
 
       - name: Fetch SSW.People.Profiles


### PR DESCRIPTION
- Affected routes: <!-- E.g. `/offices/brisbane`  -->

- Fixed #3616 

**Fix for Signature Identity Issue Due to pnpm Version Compatibility**
The issue occurred because the Corepack-managed version of pnpm (9.5.0) was incompatible with Node.js version 22.13.1. This led to a signature identity error during the process. To resolve this, we are adding a step to install the latest version to install the pnpm.

**Changes Made:**
- Removed the corepack and installing the required version for the pnpm  