### PR TITLE
🐛Bug fix - Fixed users being able to create events with empty presenters

### DIFF
--- a/tina/collections/events-calendar.tsx
+++ b/tina/collections/events-calendar.tsx
@@ -4,13 +4,33 @@ const datetimeFormat = {
   timeFormat: "hh:mm a",
   dateFormat: "ddd DD MMMM YYYY,",
 };
-
+const removeEmptyObjects = (formValues: object, fieldKey: string) => {
+  let field = formValues[fieldKey];
+  if (!field) return formValues;
+  field = field.filter((item: object) => {
+    return Object.keys(item).length > 0;
+  });
+  if (field.length) {
+    return {
+      ...formValues,
+      [fieldKey]: field,
+    };
+  }
+  delete formValues[fieldKey];
+  return formValues;
+};
 export const eventsCalendarSchema: Collection = {
   label: "Events - Calendar",
   name: "eventsCalendar",
   path: "content/events-calendar",
   format: "json",
   ui: {
+    beforeSubmit: async ({ values }) => {
+      return removeEmptyObjects(values, "presenterList") as Record<
+        string,
+        unknown
+      >;
+    },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - upload dir not included in Tina type but works anyway
     defaultItem: () => ({ enabled: true, liveStreamDelayMinutes: 30 }),


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

### Description
We had a pipeline issue earlier today because penny created an event that had presenters that weren't filled out. To fix this I've updated the events schema to remove any presenters that haven't been filled out on save.

- Affected routes: <!-- E.g. `/offices/brisbane`  -->

- Fixed #3648 

- [x] Include done video or screenshots

![fix presenter empty saving](https://github.com/user-attachments/assets/4ef686f2-aa40-4438-9b91-68e030182a5c)

**Figure**: **Event with no attached presenters having presenters removed**




