### PR TITLE
Fixed relative URL for consulting page

### DIFF
--- a/app/consulting/index.tsx
+++ b/app/consulting/index.tsx
@@ -30,7 +30,7 @@ export default function ConsultingIndex({ tinaProps }) {
             return {
               url:
                 p.externalUrl ||
-                p.page.id.replace("content/", "").replace(".mdx", ""),
+                p.page.id.replace("content", "").replace(".mdx", ""),
               title: p.title,
               description: p.description,
               logo: p.logo,


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

This PR should fix "broken link" errors for consulting page on CodeAuditor scan.

- Affected routes: /consulting

- Fixed #3706 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [ ] Include done video or screenshots


