### PR TITLE
fixed z-stacking for bleed images

### DIFF
--- a/app/consulting/[filename]/consulting2.tsx
+++ b/app/consulting/[filename]/consulting2.tsx
@@ -30,7 +30,7 @@ const Consulting2 = memo(
               padding="custom"
               className="w-full p-0"
             >
-              <div className="w-full">
+              <div className="z-0 w-full">
                 {data.consultingv2.blocks ? (
                   <Blocks
                     prefix={"Consultingv2Blocks"}

--- a/app/consulting/[filename]/consulting2.tsx
+++ b/app/consulting/[filename]/consulting2.tsx
@@ -30,7 +30,7 @@ const Consulting2 = memo(
               padding="custom"
               className="w-full p-0"
             >
-              <div className="z-0 w-full">
+              <div className="relative z-0 w-full">
                 {data.consultingv2.blocks ? (
                   <Blocks
                     prefix={"Consultingv2Blocks"}

--- a/components/blocks/breadcrumbs/breadcrumbs.schema.tsx
+++ b/components/blocks/breadcrumbs/breadcrumbs.schema.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import React from "react";
 import { Button, Input, Template, wrapFieldsWithMeta } from "tinacms";
-import { backgroundSchema } from "../../../components/layout/v2ComponentWrapper";
+import { backgroundSchema } from "../../../components/layout/v2ComponentWrapper.schema";
 import { TinaInfo } from "../../tina/tina-info";
 
 export const BreadcrumbSchema: Template = {

--- a/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
+++ b/components/blocks/cardCarousel/cardCarousel/cardCarouselSchema.tsx
@@ -7,7 +7,7 @@ import { cardOptions } from "../../../blocksSubtemplates/tinaFormElements/colour
 import { ColorPickerInput } from "../../../blocksSubtemplates/tinaFormElements/colourSelector";
 import { IconPickerInput } from "../../../blocksSubtemplates/tinaFormElements/iconSelector";
 import { buttonSchema } from "../../../button/templateButton.schema";
-import { backgroundSchema } from "../../../layout/v2ComponentWrapper";
+import { backgroundSchema } from "../../../layout/v2ComponentWrapper.schema";
 import { mediaTypeField } from "../../mediaType.schema";
 import { youtubeEmbedField } from "../../youtubeEmbed.schema";
 

--- a/components/blocks/cardCarousel/technologyCards/technologyCardCarouselSchema.tsx
+++ b/components/blocks/cardCarousel/technologyCards/technologyCardCarouselSchema.tsx
@@ -1,5 +1,5 @@
 import { Template } from "tinacms";
-import { backgroundSchema } from "../../../../components/layout/v2ComponentWrapper";
+import { backgroundSchema } from "../../../../components/layout/v2ComponentWrapper.schema";
 import { cardOptions } from "../../../blocksSubtemplates/tinaFormElements/colourOptions/cardOptions";
 import { ColorPickerInput } from "../../../blocksSubtemplates/tinaFormElements/colourSelector";
 

--- a/components/blocks/imageComponents/ImageComponentLayoutSchema.tsx
+++ b/components/blocks/imageComponents/ImageComponentLayoutSchema.tsx
@@ -1,4 +1,4 @@
-import { backgroundSchema } from "../../../components/layout/v2ComponentWrapper";
+import { backgroundSchema } from "../../../components/layout/v2ComponentWrapper.schema";
 import { optimizedImageSchema } from "../../../tina/collections/shared-fields";
 import { mediaTypeField } from "../mediaType.schema";
 export const ImageComponentLayoutSchema = [

--- a/components/blocks/logoCarousel/logoCarouselSchema.tsx
+++ b/components/blocks/logoCarousel/logoCarouselSchema.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, Template, TinaField, wrapFieldsWithMeta } from "tinacms";
 import alternatingHeadingSchema from "../../../components/blocksSubtemplates/alternatingHeading.schema";
 import tabletTextAlignmentField from "../../../components/blocksSubtemplates/tabletTextAlignment.schema";
-import { backgroundSchema } from "../../../components/layout/v2ComponentWrapper";
+import { backgroundSchema } from "../../../components/layout/v2ComponentWrapper.schema";
 const RangeInput = wrapFieldsWithMeta((props) => {
   return (
     <div className="flex flex-col">

--- a/components/blocks/spacer/spacer.schema.tsx
+++ b/components/blocks/spacer/spacer.schema.tsx
@@ -1,4 +1,4 @@
-import { backgroundSchema } from "@/components/layout/v2ComponentWrapper";
+import { backgroundSchema } from "@/components/layout/v2ComponentWrapper.schema";
 import { Template } from "tinacms";
 
 export const SpacerSchema: Template = {

--- a/components/layout/v2ComponentWrapper.schema.tsx
+++ b/components/layout/v2ComponentWrapper.schema.tsx
@@ -1,0 +1,43 @@
+import { backgroundOptions } from "../blocksSubtemplates/tinaFormElements/colourOptions/blockBackgroundOptions";
+
+import { ColorPickerInput } from "../blocksSubtemplates/tinaFormElements/colourSelector";
+
+export const backgroundSchema = {
+  type: "object",
+  label: "Background",
+  name: "background",
+  fields: [
+    {
+      type: "number",
+      label: "Background Colour",
+      name: "backgroundColour",
+      ui: {
+        component: ColorPickerInput(backgroundOptions),
+      },
+    },
+    {
+      type: "image",
+      label: "Background Image",
+      name: "backgroundImage",
+      ui: {
+        validate: (value) => {
+          const lastSegment = value?.split("/")?.slice(-1)[0];
+          if (!lastSegment) {
+            return;
+          }
+          if (lastSegment?.indexOf(" ") > -1) {
+            return "image names cannot have spaces";
+          }
+        },
+      },
+      description:
+        "An optional background image, overlay on top of the colour. Streched to fit. File names cannot contain spaces.",
+    },
+    {
+      type: "boolean",
+      label: "Bleed",
+      name: "bleed",
+      description: "If true, the background will bleed into lower blocks.",
+    },
+  ],
+};

--- a/components/layout/v2ComponentWrapper.tsx
+++ b/components/layout/v2ComponentWrapper.tsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 import { UseInViewOptions } from "framer-motion";
 import React, { useEffect, useRef } from "react";
 import { backgroundOptions } from "../blocksSubtemplates/tinaFormElements/colourOptions/blockBackgroundOptions";
-import { ColorPickerInput } from "../blocksSubtemplates/tinaFormElements/colourSelector";
 
 type BackgroundData = {
   background?: {
@@ -63,11 +62,11 @@ const V2ComponentWrapper = ({
         className
       )}
     >
-      {data.background?.bleed && data.background?.backgroundImage ? (
+      {data.background?.bleed && data.background?.backgroundImage && (
         <Image
           ref={bleed}
           src={data.background?.backgroundImage}
-          className="absolute inset-0 z-0 grid w-full place-items-center overflow-visible"
+          className="absolute inset-0 z-20 grid w-full place-items-center overflow-visible"
           alt="background image"
           width={
             (elementWidth || bleed.current?.getBoundingClientRect()?.width) ?? 0
@@ -86,13 +85,11 @@ const V2ComponentWrapper = ({
             );
           }}
         />
-      ) : (
-        <></>
       )}
       <section
         ref={ref}
         className={classNames(
-          "z-5 relative transition-opacity duration-300",
+          "relative z-30 transition-opacity duration-300",
           isInInitialViewport === false && "opacity-0",
           !isInInitialViewport && isInView && "opacity-100"
         )}
@@ -111,46 +108,6 @@ const V2ComponentWrapper = ({
       </section>
     </section>
   );
-};
-
-export const backgroundSchema = {
-  type: "object",
-  label: "Background",
-  name: "background",
-  fields: [
-    {
-      type: "number",
-      label: "Background Colour",
-      name: "backgroundColour",
-      ui: {
-        component: ColorPickerInput(backgroundOptions),
-      },
-    },
-    {
-      type: "image",
-      label: "Background Image",
-      name: "backgroundImage",
-      ui: {
-        validate: (value) => {
-          const lastSegment = value?.split("/")?.slice(-1)[0];
-          if (!lastSegment) {
-            return;
-          }
-          if (lastSegment?.indexOf(" ") > -1) {
-            return "image names cannot have spaces";
-          }
-        },
-      },
-      description:
-        "An optional background image, overlay on top of the colour. Streched to fit. File names cannot contain spaces.",
-    },
-    {
-      type: "boolean",
-      label: "Bleed",
-      name: "bleed",
-      description: "If true, the background will bleed into lower blocks.",
-    },
-  ],
 };
 
 export default V2ComponentWrapper;


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->


### Description
The bleed effect wasn't working because the z-index of the image was lower than the z-index of the background below it. To fix this I've added a z-index of 0 to the root element to establish a stacking context, added a z-index of 20 to the bleeding image, and added a z-index of 30 to the wrapper for the consulting page components to ensure they always sit on top of the image.

- Affected routes: <!-- E.g. `/offices/brisbane`  -->

- Fixed #3637


- [x] Include done video or screenshots

![image](https://github.com/user-attachments/assets/5117d00a-c1bd-46f3-abc2-ef0d770eda77)
**Figure**: **❌Before**

![image](https://github.com/user-attachments/assets/02850227-3aa0-4671-906e-668f9b847b8d)
**Figure**: **✅After**



