### PR TITLE
🔎SEO - Fix canonical URLs for consult index + articles pages

### DIFF
--- a/app/consulting/page.tsx
+++ b/app/consulting/page.tsx
@@ -10,9 +10,6 @@ export async function generateMetadata(): Promise<Metadata> {
   const tinaProps = await getData();
 
   const seo = tinaProps.props.seo;
-  if (seo && !seo.canonical) {
-    seo.canonical = `${tinaProps.props.header.url}consulting`;
-  }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { seoProps } = useSEO(seo);
@@ -25,7 +22,10 @@ const getData = async () => {
 
   const seo = tinaProps.data.consultingIndex.seo;
   if (seo && !seo.canonical) {
-    seo.canonical = `${tinaProps.data.global.header.url}/consulting`;
+    seo.canonical = new URL(
+      "/consulting",
+      tinaProps.data.global.header.url
+    ).toString();
   }
 
   return {

--- a/content/articles/empowering-education.mdx
+++ b/content/articles/empowering-education.mdx
@@ -4,7 +4,7 @@ seo:
   description: >-
     Discover how Microsoft tools like SharePoint, Power BI, and Power Automate
     are transforming education outcomes with data-driven decisions.
-  canonical: 'https://www.ssw.com.au/empowering-education'
+  canonical: 'https://www.ssw.com.au/articles/empowering-education'
   showBreadcrumb: true
   images:
     - url: /images/ssw-default-og.jpg

--- a/content/articles/net-9-upgrade-future-proof-your-business.mdx
+++ b/content/articles/net-9-upgrade-future-proof-your-business.mdx
@@ -25,7 +25,7 @@ seo:
   description: >-
     Upgrade to .NET 9 for faster performance, cost savings & enhanced security;
     discover proven tips & book your free 1-hour consultation with SSW. 
-  canonical: net-9-upgrade-future-proof-your-business
+  canonical: 'https://www.ssw.com.au/articles/net-9-upgrade-future-proof-your-business'
 bannerImg: /images/articles/4LtbacXcLOVHQGk3nigxp_fa59c02320ad42cdb5f39527a69c2eda.jpg
 title: ".NET\_9 Upgrade: Future-Proof Your Business with Superior Performance and Security"
 subTitle: >


### PR DESCRIPTION
### Description 

The pages listed under affected routes were not being indexed because they had valid canonical URLs to other pages. This PR fixes the canonical URLs.

### Affected routes: <!-- E.g. `/offices/brisbane`  -->

- /consulting
- /articles/empowering-education
- /articles/net-9-upgrade-future-proof-your-business


### Fixed Issue
- Fixed #3782 

~~Include done video or screenshots~~


