### PR TITLE
fixed consulting page button outline

### DIFF
--- a/components/button/rippleButtonV2.tsx
+++ b/components/button/rippleButtonV2.tsx
@@ -67,9 +67,8 @@ const RippleButton = React.forwardRef<HTMLButtonElement, RippleButtonProps>(
     return (
       <button
         onClick={(e) => onClick(e)}
-        className={cn(
+        className={classNames(
           "text-primary relative cursor-pointer items-center justify-center overflow-hidden rounded-md px-6 py-3 text-center",
-          "",
           variants[variant],
           className
         )}
@@ -110,7 +109,7 @@ const RippleButton = React.forwardRef<HTMLButtonElement, RippleButtonProps>(
 const variants: Record<ColorVariant, string> = {
   primary: "bg-ssw-red hover:bg-sswDarkRed text-white",
   secondary:
-    "bg-transparent outline -outline-1.5 outline-white -outline-offset-1.5 hover:outline-gray-200 hover:text-gray-200 text-white",
+    "bg-transparent outline -outline-1.5  outline-white -outline-offset-1.5 hover:outline-gray-200 hover:text-gray-200 text-white",
 };
 
 RippleButton.displayName = "RippleButton";

--- a/components/button/rippleButtonV2.tsx
+++ b/components/button/rippleButtonV2.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { cn } from "@/lib/utils";
 import classNames from "classnames";
 import React, { MouseEvent, useEffect, useState } from "react";
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
### Description

I noticed the outline effect on some of the consulting page buttons had gone missing. This seems to be an issue with `tailwind-merge` not recognising `outline` as a legitimate class. Guessing this will be fixed when we upgrade to tailwind 4 on the website.

- Affected routes: /consulting/net-upgrade

- Fixed #3756


### Screenshot

![image](https://github.com/user-attachments/assets/1180f9d4-21cd-4698-bca0-54f978b33af3)


