### PR TITLE
Add workflow for auto-merging small content changes based on lines/files changed

### DIFF
--- a/.github/workflows/auto-merge-content-changes.yml
+++ b/.github/workflows/auto-merge-content-changes.yml
@@ -1,0 +1,135 @@
+name: Auto-Merge Small Changes
+
+on:
+  pull_request:
+    types: [ready_for_review]
+    paths:
+      - 'content/**'
+      - 'public/**'
+
+concurrency:
+  group: auto-merge-${{ github.event.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  detect-small-changes:
+    name: Detect Small Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      is-small-change: ${{ steps.analyse-changes.outputs.is-small-change }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Analyse changes
+        id: analyse-changes
+        shell: pwsh
+        run: |
+          # Get the base branch
+          $baseBranch = "${{ github.base_ref }}"
+          if ([string]::IsNullOrEmpty($baseBranch)) {
+            $baseBranch = "main"
+          }
+
+          $maxFiles = 1
+          $maxLines = 10
+
+          $changedFiles = @()
+          $lineChanges = ""
+          $totalLinesChanged = 0
+          
+          $changedFiles = git diff --name-only origin/$baseBranch...HEAD
+          $lineChanges = git diff --stat origin/$baseBranch...HEAD
+          if ($lineChanges.Length -gt 1) {
+            $totalLinesChanged = $($lineChanges.Length) / 2
+          }
+          $contentFiles = $changedFiles | Where-Object { $_ -like "content/*" }
+          $nonContentFiles = $changedFiles | Where-Object { $_ -notlike "content/*" }
+          $isContentOnly = $contentFiles.Count -gt 0 -and $nonContentFiles.Count -eq 0
+          $isSmallChange = $isContentOnly -and $changedFiles.Count -le $maxFiles -and $totalLinesChanged -le $maxLines
+
+          # Debug output
+          Write-Host "Changed files: $($changedFiles -join ', ')"
+          Write-Host "Content files: $($contentFiles -join ', ')"
+          Write-Host "Non-content files: $($nonContentFiles -join ', ')"
+          Write-Host "Total lines changed: $totalLinesChanged"
+          Write-Host "Is content only: $isContentOnly"
+          Write-Host "Is small change: $isSmallChange"
+          Write-Host "Raw git diff stat output: '$lineChanges'"
+
+          echo "is-small-change=$($isSmallChange.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+
+      - name: Comment analysis on PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            🤖 **Small Change Analysis**
+            
+            **Result:** ${{ steps.analyse-changes.outputs.is-small-change == 'true' && '✅ Eligible for auto-merge' || '❌ Not eligible for auto-merge' }}
+            
+            This PR has been analyzed for auto-merge eligibility based on:
+            - Content-only changes
+            - Maximum 1 file changed
+            - Maximum 10 lines changed
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: true
+
+  auto-merge:
+    name: Auto-Merge Small Changes
+    needs: detect-small-changes
+    if: needs.detect-small-changes.outputs.is-small-change == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Auto-merge PR
+        id: auto-merge-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              
+              if (!pr.data.mergeable) {
+                throw new Error('PR is not mergeable. It may have conflicts or not be up to date.');
+              }
+              
+              const result = await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                merge_method: 'squash',
+                commit_title: `Auto-merge: ${{ github.event.pull_request.title }}`,
+                commit_message: `🤖 Auto-merged small content change\n\n- PR: #${{ github.event.number }}\n- Author: @${{ github.event.pull_request.user.login }}`
+              });
+              
+              console.log('Auto-merge successful:', result.data.message);
+            } catch (error) {
+              console.error('Auto-merge failed:', error.message);
+              core.setFailed(`Auto-merge failed: ${error.message}`);
+            }
+
+      - name: Comment merge result
+        uses: mshick/add-pr-comment@v2
+        if: always()
+        with:
+          message: |
+            ${{ steps.auto-merge-pr.outcome == 'success' && '✅ **Auto-merge completed successfully!**' || '❌ **Auto-merge failed** - Please check the workflow logs for details.' }}
+            
+            This PR was automatically merged as a small content change.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: true 

--- a/.github/workflows/auto-merge-content-changes.yml
+++ b/.github/workflows/auto-merge-content-changes.yml
@@ -107,8 +107,8 @@ jobs:
                 pull_number: context.issue.number
               });
               
-              if (!pr.data.mergeable) {
-                throw new Error('PR is not mergeable. It may have conflicts or not be up to date.');
+              if (pr.data.mergeable === false || pr.data.mergeable === null) {
+                throw new Error('PR is not mergeable or its mergeability status is unknown. It may have conflicts or not be up to date.');
               }
               
               const result = await github.rest.pulls.merge({

--- a/.github/workflows/auto-merge-content-changes.yml
+++ b/.github/workflows/auto-merge-content-changes.yml
@@ -55,8 +55,8 @@ jobs:
             $added + $deleted
           }
           $totalLinesChanged = ($lineChanges | Measure-Object -Sum).Sum
-          $contentFiles = $changedFiles | Where-Object { $_ -like "content/*" }
-          $nonContentFiles = $changedFiles | Where-Object { $_ -notlike "content/*" }
+          $contentFiles = $changedFiles | Where-Object { $_ -like "content/*" -or $_ -like "public/*" }
+          $nonContentFiles = $changedFiles | Where-Object { $_ -notlike "content/*" -and $_ -notlike "public/*" }
           $isContentOnly = $contentFiles.Count -gt 0 -and $nonContentFiles.Count -eq 0
           $isSmallChange = $isContentOnly -and $changedFiles.Count -le $maxFiles -and $totalLinesChanged -le $maxLines
 

--- a/.github/workflows/auto-merge-content-changes.yml
+++ b/.github/workflows/auto-merge-content-changes.yml
@@ -44,14 +44,17 @@ jobs:
           $maxLines = 10
 
           $changedFiles = @()
-          $lineChanges = ""
+          $lineChanges = @()
           $totalLinesChanged = 0
           
           $changedFiles = git diff --name-only origin/$baseBranch...HEAD
-          $lineChanges = git diff --stat origin/$baseBranch...HEAD
-          if ($lineChanges.Length -gt 1) {
-            $totalLinesChanged = $($lineChanges.Length) / 2
+          $lineChanges = git diff --numstat origin/$baseBranch...HEAD | ForEach-Object {
+            $parts = $_ -split "`t"
+            [int]$added = $parts[0]
+            [int]$deleted = $parts[1]
+            $added + $deleted
           }
+          $totalLinesChanged = ($lineChanges | Measure-Object -Sum).Sum
           $contentFiles = $changedFiles | Where-Object { $_ -like "content/*" }
           $nonContentFiles = $changedFiles | Where-Object { $_ -notlike "content/*" }
           $isContentOnly = $contentFiles.Count -gt 0 -and $nonContentFiles.Count -eq 0


### PR DESCRIPTION
Small content changes require users to open GitHub, mark the created PR as Ready, get others to review, wait for builds, etc. We should be able to auto-approve/merge these small PRs.

- Fixed #3965

- Created POC repo to test the auto-merge:
<img width="1492" height="972" alt="image" src="https://github.com/user-attachments/assets/668a06ac-3d6f-44c5-ac2f-c746c59dd97e" />
