### PR TITLE
Update builtOnAzure.tsx

### DIFF
--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -37,16 +37,16 @@ export const BuiltOnAzure = ({ data }: BuiltOnAzureProps) => {
 
   return (
     <Section color={footerColor as SectionColor} className="py-2">
-      <Container className="grid grid-cols-1 text-base md:text-lg lg:grid-cols-2">
+      <Container className="grid grid-cols-1 text-base py-8 md:text-lg lg:grid-cols-2">
         <Link
           data={data}
-          href="/consulting/azure"
-          className="hover:border-azure hover:text-azure"
-          text="Built on Microsoft Azure"
+          href="https://tina.io"
+          className="hover:border-tina hover:text-tina py-2"
+          text="Powered by TinaCMS"
           image={
             <Image
-              src="/images/logos/azure.png"
-              alt="Microsoft Azure Logo"
+              src="/images/logos/tina-llama-orange.png"
+              alt="TinaCMS logo"
               height={30}
               width={30}
               loading="lazy"
@@ -56,13 +56,13 @@ export const BuiltOnAzure = ({ data }: BuiltOnAzureProps) => {
 
         <Link
           data={data}
-          href="https://tina.io"
-          className="hover:border-tina hover:text-tina"
-          text="Powered by TinaCMS"
+          href="/consulting/azure"
+          className="hover:border-azure hover:text-azure py-2"
+          text="Built on Microsoft Azure"
           image={
             <Image
-              src="/images/logos/tina-llama-orange.png"
-              alt="TinaCMS logo"
+              src="/images/logos/azure.png"
+              alt="Microsoft Azure Logo"
               height={30}
               width={30}
               loading="lazy"

--- a/components/blocks/builtOnAzure.tsx
+++ b/components/blocks/builtOnAzure.tsx
@@ -37,11 +37,11 @@ export const BuiltOnAzure = ({ data }: BuiltOnAzureProps) => {
 
   return (
     <Section color={footerColor as SectionColor} className="py-2">
-      <Container className="grid grid-cols-1 text-base py-8 md:text-lg lg:grid-cols-2">
+      <Container className="grid grid-cols-1 py-8 text-base md:text-lg lg:grid-cols-2">
         <Link
           data={data}
           href="https://tina.io"
-          className="hover:border-tina hover:text-tina py-2"
+          className="py-2 hover:border-tina hover:text-tina"
           text="Powered by TinaCMS"
           image={
             <Image
@@ -57,7 +57,7 @@ export const BuiltOnAzure = ({ data }: BuiltOnAzureProps) => {
         <Link
           data={data}
           href="/consulting/azure"
-          className="hover:border-azure hover:text-azure py-2"
+          className="py-2 hover:border-azure hover:text-azure"
           text="Built on Microsoft Azure"
           image={
             <Image


### PR DESCRIPTION
fixes: #4128 

As per @adamcogan 's email: **CSS - SSW Developer Internship**

Switched Tina and Azure order on pre-footer + improved spacing, especially on mobile

- Affected routes: all pages

1. Put Tina above Azure

<img width="1290" height="2796" alt="image0" src="https://github.com/user-attachments/assets/085416f4-3ce0-45ea-a4c4-6fd7752b593d" />

