### PR TITLE
use replaceAll for dehyphenation

### DIFF
--- a/services/server/dehyphenateUrl.ts
+++ b/services/server/dehyphenateUrl.ts
@@ -1,3 +1,3 @@
 export const dehyphenateUrl = (name: string) => {
-  return name.replace("-", " ");
+  return name.replaceAll("-", " ");
 };


### PR DESCRIPTION
This fixes an issue with the dehyphenateUrl function, which previously only replaces the first hyphen in a string. For URLs with multiple hyphens (e.g., `foo-bar-foo`), would incorrectly return `foo bar-foo`.

The fix was to use `replaceAll()` instead of `replace()`.

