### PR TITLE
move email regexp to module scope

### DIFF
--- a/helpers/validator.ts
+++ b/helpers/validator.ts
@@ -1,12 +1,11 @@
 import xss, { type IFilterXSSOptions } from "xss";
 
+// Found at https://emailregex.com/
+/* eslint-disable */
+const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 export const isEmail = (email: string): boolean => {
-  // Found at https://emailregex.com/
-  /* eslint-disable */
-  const regex =
-    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   /* eslint-enable */
-  return regex.test(email);
+  return EMAIL_REGEX.test(email);
 };
 
 export const spanWhitelist = {


### PR DESCRIPTION
The email validation regex (in `validator.ts`) had been defined inside the `isEmail()` function, so it's re-compiled every time the function is called. Moving it to the module scope ensures that it is compiled only once. 

Not too much of a big deal, minimal performance gain.