### PR TITLE
handle json ext for links in index.tsx

### DIFF
--- a/app/consulting/index.tsx
+++ b/app/consulting/index.tsx
@@ -27,7 +27,11 @@ export default function ConsultingIndex({ tinaProps }) {
         const mappedPage = {
           url:
             p.externalUrl ||
-            p.page.id.replace("content", "").replace(".mdx", ""),
+            p.page.id
+              .replace("content/consultingv2", "/consulting")
+              .replace("content", "")
+              .replace(".mdx", "")
+              .replace(".json", ""),
           title: p.title,
           description: p.description,
           logo: p.logo,


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: `/consulting/{anything.json}`

The index.tsx was stripping .mdx extensions but not .json. Simply added .json to now support .json pages.

#4365 



