### PR TITLE
removed client side logic for hiding carousel images

### DIFF
--- a/components/blocks/carousel.tsx
+++ b/components/blocks/carousel.tsx
@@ -3,8 +3,6 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import * as React from "react";
 import { tinaField } from "tinacms/dist/react";
-
-import { isMobile } from "react-device-detect";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 
@@ -15,21 +13,6 @@ import { carouselBlock } from "./carousel.schema";
 
 export const Carousel = ({ data }) => {
   const router = useRouter();
-
-  // Handle the mobile check after hydration
-  const [shouldRender, setShouldRender] = React.useState(true);
-
-  React.useEffect(() => {
-    if (!data.showOnMobileDevices && isMobile) {
-      setShouldRender(false);
-    } else {
-      setShouldRender(true);
-    }
-  }, [data.showOnMobileDevices]);
-
-  if (!shouldRender) {
-    return null;
-  }
 
   const openItem = ({ link, openIn }) => {
     if (openIn === "newWindow") {


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: ssw.com.au


### Description

This PR removes the client side logic for hiding the carousel. The images do not load unless visible and the library was causing bugs on tablets.

- Fixed #4360



