### PR TITLE
Fixing Typo from NET-MAU to NET-MAUI

### DIFF
--- a/content/consultingv2/mobile-application-development.json
+++ b/content/consultingv2/mobile-application-development.json
@@ -332,7 +332,7 @@
           "technology": "content/v2Technologies/technologies/Ionic.mdx"
         },
         {
-          "technology": "content/v2Technologies/technologies/NET-MAU.mdx"
+          "technology": "content/v2Technologies/technologies/NET-MAUI.mdx"
         },
         {
           "technology": "content/v2Technologies/technologies/flutter.mdx"

--- a/content/v2Technologies/technologies/NET-MAUI.mdx
+++ b/content/v2Technologies/technologies/NET-MAUI.mdx
@@ -1,5 +1,5 @@
 ---
-name: .NET MAU
+name: .NET MAUI
 icon: BiLogoMicrosoft
 readMoreSlug: 'https://dotnet.microsoft.com/en-us/apps/maui'
 associatedGroup: content/v2Technologies/groups/mobile-development.mdx


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: `/consulting/mobile-application-development`

Fixing the content of the .NET MAUI card from "NET MAU" to "NET MAUI"
![NET MAU](https://github.com/user-attachments/assets/e94d73e5-2612-4cbf-97ea-8034c8684fe4)
**Figure: The live website with the typo visible, showing "NET MAU"**

![NET MAUI](https://github.com/user-attachments/assets/9aa89827-cff7-4eb6-a695-fbbfeb4cf757)
**Figure: The updated view with the adjusted name, showing "NET MAUI"**



