### PR TITLE
Update Instagram social icon gradient in footer

### DIFF
--- a/components/socialIcons/socialIcons.tsx
+++ b/components/socialIcons/socialIcons.tsx
@@ -46,7 +46,7 @@ export const socialStyles: Record<
   },
   instagram: {
     icon: FaInstagram,
-    bgClassName: "bg-gradient-tr-social-instagram",
+    bgClassName: "bg-social-instagram",
   },
   xtwitter: {
     icon: FaXTwitter,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -453,6 +453,8 @@ export default {
           "linear-gradient(#ffffff, transparent 75%), url(/images/404/broken-chain.png)",
         glass:
           "linear-gradient(152.97deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0) 100%)",
+        "social-instagram":
+          "radial-gradient(93.01% 100.01% at 26% 100%, #FF9F4B 3.72%, #FF543E 55.93%, #E44674 100%)",
       },
     },
     linearGradientColors: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -457,15 +457,6 @@ export default {
           "radial-gradient(93.01% 100.01% at 26% 100%, #FF9F4B 3.72%, #FF543E 55.93%, #E44674 100%)",
       },
     },
-    linearGradientColors: {
-      "social-instagram": [
-        "#f09433",
-        "#e6683c 25%",
-        "#dc2743 50%",
-        "#cc2366 75%",
-        "#bc1888",
-      ],
-    },
   },
   variants: {
     // extend: { typography: ["tint", "dark", "primary"] },


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

Worked with @micsblank 

Instagram icon background was missing

- Affected routes: All routes

- Fixed #4550 

<img width="1224" height="474" alt="Screenshot 2026-02-23 at 2 50 25 pm" src="https://github.com/user-attachments/assets/624dc19e-760f-4411-a693-b3e674d2f2f2" />

**Figure: Before, see no bg on Insta icon**

---

<img width="1196" height="496" alt="Screenshot 2026-02-23 at 2 50 33 pm" src="https://github.com/user-attachments/assets/2e3ab7a5-77ba-4d5b-bf15-5960539bdff7" />

**Figure: After, much better**

