### PR TITLE
Fix: Add UtilityButton to blocks-renderer componentMap

### DIFF
--- a/components/blocks-renderer.tsx
+++ b/components/blocks-renderer.tsx
@@ -18,6 +18,10 @@ const AboutUs = dynamic(() =>
 
 import { Agenda } from "./blocks/agenda";
 
+const UtilityButton = dynamic(() =>
+  import("./button/utilityButton").then((mod) => mod.UtilityButton)
+);
+
 const BuiltOnAzure = dynamic(() =>
   import("./blocks/builtOnAzure").then((mod) => mod.BuiltOnAzure)
 );
@@ -191,6 +195,7 @@ const componentMap = {
   CardCarousel,
   TechnologyCardCarousel,
   Spacer,
+  UtilityButton,
 };
 
 export const Blocks = ({ prefix, blocks }) => {


### PR DESCRIPTION
**Supports PR: #4573**
**Closes Issue: #4572**


## Summary

The `UtilityButton` block was silently not rendering on any legacy page that used it in the `_body` field (e.g. the SSW Internship page `/training/internship-fullstack`).

### Root Cause

`UtilityButton` was registered in the Tina schema but missing from `componentMap` in `blocks-renderer.tsx`. The `<Block>` renderer silently returns `<></>` for unknown types, so the button rendered nothing with no error thrown.

### Changes

**`components/blocks-renderer.tsx`**
- Added a `dynamic` import for `UtilityButton` from `./button/utilityButton`
- Added `UtilityButton` to the `componentMap`

### Impact

Any page using `_template: UtilityButton` in its `_body` blocks will now render it. The intended fix is the **"Apply Now"** CTA button on the SSW Internship page (`/training/internship-fullstack`). 

### Preview
https://app-sswwebsite-9eb3-pr-4589.azurewebsites.net/training/internship-fullstack

## Risk Assessment

Searched all content files for `_template: UtilityButton`. Only the internship page uses it as a top-level `_body` block — this is the only page affected by the fix. All other usages (e.g. `employment/index.mdx`, `logo/index.mdx`) are inline MDX components rendered via `mdxComponentRenderer`, which already had `UtilityButton` registered. No risk of unintended buttons appearing elsewhere.

---

*Summarised with Claude 🤖*