### PR TITLE
fix: replace font-thin with font-light to match site-wide typography convention

### DIFF
--- a/components/blocks/bigCardContent.tsx
+++ b/components/blocks/bigCardContent.tsx
@@ -46,7 +46,7 @@ const BigCardContent = memo(
             )}
             <div className="relative flex grow flex-col p-8">
               <h3
-                className="flex pb-3 text-2xl font-thin lg:pt-8"
+                className="flex pb-3 text-2xl font-light lg:pt-8"
                 data-tina-field={tinaField(
                   schema.bigCards[index],
                   serviceCards.bigCards.title


### PR DESCRIPTION
The `h3` title in the BigCardContent component was using `font-thin` (`font-weight:100`), while every other element across the codebase that uses a lighter font weight uses `font-light` (`font-weight:300`). This inconsistency appears to be an unintentional typo, `font-light` is the project's established convention for thinner headings.

<img width="1510" height="375" alt="Screenshot 2026-03-24 at 5 57 21 pm" src="https://github.com/user-attachments/assets/71eb2032-f286-409e-8b4c-4856bb262128" />

**Figure - Before**


<img width="1523" height="375" alt="Screenshot 2026-03-24 at 5 56 59 pm" src="https://github.com/user-attachments/assets/c97c8992-7ee8-4ccc-9dd9-db24d865ceab" />

**Figure - After**

- Affected routes: / (Service Cards block on the home page)

- Fixes #4606

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [ ] If updating the livestream banner, I have tested and followed the steps in [Wiki - Testing the live banner](https://github.com/SSWConsulting/SSW.Website/wiki/Testing-the-live-banner) 

- [x] Include Done Video or screenshots