### PR TITLE
improve events "Find out more" CTA accessibility

### DIFF
--- a/components/filter/events.tsx
+++ b/components/filter/events.tsx
@@ -403,10 +403,10 @@ const Event = ({ visible, event, jsonLd }: EventProps) => {
         <div className="mb-1 mt-6 p-0 text-end">
           <CustomLink
             href={event.url}
-            title={event.title}
-            className="unstyled rounded bg-ssw-gray px-3 py-2 text-xs font-normal text-white hover:bg-ssw-gray-dark"
+            className="unstyled rounded bg-ssw-gray-dark px-3 py-2 text-sm font-normal text-white hover:bg-sswBlack"
           >
-            <span className="mt-8 text-sm">Find out more...</span>
+            Find out more
+            <span className="sr-only"> about {event.title}</span>
           </CustomLink>
         </div>
       </Transition>


### PR DESCRIPTION
Fixes WCAG AA contrast failure on the event "Find out more" button and adds sr-only context so screen readers can distinguish repeated links.

🤖 Coded with assistance from GitHub Copilot.

<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: `/events`

- Fixed #4612 

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [ ] If updating the livestream banner, I have tested and followed the steps in [Wiki - Testing the live banner](https://github.com/SSWConsulting/SSW.Website/wiki/Testing-the-live-banner) 

- [x] Include Done Video or screenshots

<img width="767" height="213" alt="Screenshot 2026-03-26 at 3 14 25 pm" src="https://github.com/user-attachments/assets/4e1d118f-4b3d-4065-a1ac-6dde0d1039a8" />

**Figure - Before - Button background and link contents are inaccessible.**


<img width="675" height="209" alt="Screenshot 2026-03-26 at 3 15 01 pm" src="https://github.com/user-attachments/assets/02a3b55c-464e-4b7c-9c81-f558eecc0bdc" />

**Figure - After - Button background and link contents are accessible.**