### PR TITLE
Remove duplicated NDC Sydney banner from homepage carousel

### DIFF
--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -50,10 +50,6 @@ beforeBody:
         link: 'https://tv.ssw.com/?utm_source=website&utm_medium=banner&utm_campaign=carousel'
         openIn: newWindow
         imgSrc: /images/carousel/SSW-TV-Banner-Master-Your-Skills-v3.jpg
-      - label: NDC Sydney - Meet us there!
-        link: 'https://ndcsydney.com/'
-        openIn: newWindow
-        imgSrc: /images/carousel/NDC-Sydney-2026-Homepage-banner.jpg
     backgroundColor: lightgray
     delay: 5
     showOnMobileDevices: false


### PR DESCRIPTION
As per @PennyWalker 's **RE: Banner for NDC Sydney - SSW AI Consulting**




