### PR TITLE
Remove download label on download cards

### DIFF
--- a/components/blocks/downloadBlock.tsx
+++ b/components/blocks/downloadBlock.tsx
@@ -84,7 +84,6 @@ const Download = (data: Downloads) => {
             />
           )}
         </div>
-        <div className={"bg-gray-300 p-2 font-bold"}>Download</div>
         <div
           className={classNames(
             "flex gap-x-0.25 border-t-2 border-white text-black"


### PR DESCRIPTION
[#4617](https://github.com/SSWConsulting/SSW.Website/issues/4617)

#4617 

## Summary
- Removes the redundant "Download" text label from download card blocks
- Recreated from `Remove-"download"-on-the-download-cards` branch (which had quotes in the branch name causing CI issues)

## Test plan
- [ ] Verify download cards render correctly without the label
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)