### PR TITLE
Logo index page - Increase More breathing space

### DIFF
--- a/components/blocks/gridLayout.tsx
+++ b/components/blocks/gridLayout.tsx
@@ -42,7 +42,7 @@ export const GridLayout = ({ data }: GridLayoutProps) => {
             </h2>
           )}
           {grid.showHeaderDivider && <hr />}
-          <Section className="mx-auto my-12 grid w-full grid-cols-1 gap-x-12 sm:grid-cols-2 lg:ml-0 lg:grid-cols-4">
+          <Section className="mx-auto my-12 grid w-full grid-cols-1 gap-x-12 gap-y-6 sm:grid-cols-2 lg:ml-0 lg:grid-cols-4">
             {grid.blocks?.map((block, i) => (
               <Section
                 className={`${grid.offsetGridStart && i === 0 ? "lg:col-start-2" : ""} flex-col items-center`}


### PR DESCRIPTION
- Affected routes:  /logo

- Fixed #4647 

We need some padding between items to give the page more breathing space



