### PR TITLE
Live Banner - Remove underline from "Chat with us" button

### DIFF
--- a/app/live-steam-banner/liveStreamWidget.tsx
+++ b/app/live-steam-banner/liveStreamWidget.tsx
@@ -159,7 +159,7 @@ export const LiveStreamWidget = ({ isLive, event }: LiveStreamWidgetProps) => {
           <div className="col-span-3 block sm:hidden">
             <CustomLink
               href={youtubeUrls.liveStreamUrl}
-              className="flex h-12 items-center justify-center bg-sswRed text-white"
+              className="unstyled flex h-12 items-center justify-center bg-sswRed text-white"
             >
               Chat with us on Youtube
             </CustomLink>


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->

- Affected routes: <!-- E.g. `/offices/brisbane`  -->
- Fixed: #4659



<img width="1438" height="901" alt="CleanShot 2026-04-17 at 10 42 36" src="https://github.com/user-attachments/assets/1eab5ae3-18b7-473a-ae70-dda676f118ca" />

**Figure: Removed underline from chat with us button for livestream**

