### PR TITLE
Events Calendar - Added kebab casing for event names

### DIFF
--- a/__tests__/helpers/kebab-case.ts
+++ b/__tests__/helpers/kebab-case.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "@jest/globals";
+import { toKebabCase } from "../../helpers/kebab-case";
+
+describe("toKebabCase", () => {
+  it("should convert a string to kebab case", () => {
+    const input = "Hello World";
+    const expectedOutput = "hello-world";
+    expect(toKebabCase(input)).toBe(expectedOutput);
+  });
+
+  it("should handle multiple spaces and special characters", () => {
+    const input = "  Hello   World! This is a test.  ";
+    const expectedOutput = "hello-world-this-is-a-test";
+    expect(toKebabCase(input)).toBe(expectedOutput);
+  });
+
+  it("should handle empty strings", () => {
+    const input = "";
+    const expectedOutput = "";
+    expect(toKebabCase(input)).toBe(expectedOutput);
+  });
+});

--- a/helpers/kebab-case.ts
+++ b/helpers/kebab-case.ts
@@ -1,0 +1,7 @@
+export const toKebabCase = (str: string) => {
+  return str
+    .trim()
+    .toLowerCase()
+    .replaceAll(/\s+/g, "-")
+    .replaceAll(/[^a-zA-Z0-9-]/g, "");
+};

--- a/tina/collections/events-calendar.tsx
+++ b/tina/collections/events-calendar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Collection, TextField } from "tinacms";
+import { kebabCaseFilename } from "./shared-fields";
 
 const datetimeFormat = {
   timeFormat: "hh:mm a",
@@ -26,6 +27,7 @@ export const eventsCalendarSchema: Collection = {
   path: "content/events-calendar",
   format: "json",
   ui: {
+    ...kebabCaseFilename,
     beforeSubmit: async ({ values }) => {
       return removeEmptyObjects(values, "presenterList") as Record<
         string,

--- a/tina/collections/events-calendar.tsx
+++ b/tina/collections/events-calendar.tsx
@@ -1,3 +1,4 @@
+import { toKebabCase } from "@/helpers/kebab-case";
 import React, { useState } from "react";
 import { Collection, TextField } from "tinacms";
 
@@ -28,7 +29,9 @@ export const eventsCalendarSchema: Collection = {
   ui: {
     filename: {
       slugify: (values) => {
-        return values.title?.toLowerCase().replaceAll(" ", "-");
+        if (values.title) {
+          return toKebabCase(values.title);
+        }
       },
     },
     beforeSubmit: async ({ values }) => {

--- a/tina/collections/events-calendar.tsx
+++ b/tina/collections/events-calendar.tsx
@@ -27,7 +27,11 @@ export const eventsCalendarSchema: Collection = {
   path: "content/events-calendar",
   format: "json",
   ui: {
-    ...kebabCaseFilename,
+    filename: {
+      slugify: (values) => {
+        return values.title?.toLowerCase().replaceAll(" ", "-");
+      },
+    },
     beforeSubmit: async ({ values }) => {
       return removeEmptyObjects(values, "presenterList") as Record<
         string,

--- a/tina/collections/events-calendar.tsx
+++ b/tina/collections/events-calendar.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Collection, TextField } from "tinacms";
-import { kebabCaseFilename } from "./shared-fields";
 
 const datetimeFormat = {
   timeFormat: "hh:mm a",


### PR DESCRIPTION
Some of the events have mixed case file names. This issue wasn't visible before, but now that we're using the file names to link to the events we're getting URLs with mixed casing.


To remedy this issue for future events I've used the `slugify` method for Tina to ensure the file name gets converted to kebab case based on the Title.


- Affected routes: <!-- E.g. `/offices/brisbane`  -->

- Fixed: https://github.com/SSWConsulting/SSW.Website/issues/4671


<img width="960" height="571" alt="CleanShot 2026-05-04 at 12 15 28" src="https://github.com/user-attachments/assets/95f80b2f-fa1c-44b3-b0cb-4be834171e77" />

**Figure: file name for event being kebab cased from title**
