### PR TITLE
📝 Update limited liability clause in SSW terms

### DIFF
--- a/content/pages/terms-and-conditions.mdx
+++ b/content/pages/terms-and-conditions.mdx
@@ -266,7 +266,9 @@ The Client authorizes SSW to provide the resources suitable for the project. SSW
     
     ### 02 - Limited Liability
     
-    In no event shall SSW or its suppliers be liable for any accidental, consequential, incidental or indirect damages of any kind (including without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out of the use or of the inability to use the software. In no event shall SSW's liability for any claims whether in contract, tort or other theory of liability exceed the purchase price of the subject products or services, unless such limitation of liability is otherwise prohibited by law.
+    In no event shall SSW or its suppliers be liable for any accidental, consequential, incidental or indirect
+    damages of any kind (including without limitation, damages for loss of business profits, business
+    interruption, loss of business information, or other pecuniary loss) arising out of the use or of the inability to use the software. In no event shall SSW's liability for any claims whether in contract, tort or other theory of liability exceed 1.5 times the purchase price of the subject products or services in the 12 months preceding the claim, unless such limitation of liability is otherwise prohibited by law.
     
     ### 03 - Copyright
     

--- a/content/pages/terms-and-conditions.mdx
+++ b/content/pages/terms-and-conditions.mdx
@@ -266,9 +266,7 @@ The Client authorizes SSW to provide the resources suitable for the project. SSW
     
     ### 02 - Limited Liability
     
-    In no event shall SSW or its suppliers be liable for any accidental, consequential, incidental or indirect
-    damages of any kind (including without limitation, damages for loss of business profits, business
-    interruption, loss of business information, or other pecuniary loss) arising out of the use or of the inability to use the software. In no event shall SSW's liability for any claims whether in contract, tort or other theory of liability exceed 1.5 times the purchase price of the subject products or services in the 12 months preceding the claim, unless such limitation of liability is otherwise prohibited by law.
+    In no event shall SSW or its suppliers be liable for any accidental, consequential, incidental or indirect damages of any kind (including without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out of the use or of the inability to use the software. In no event shall SSW's liability for any claims whether in contract, tort or other theory of liability exceed 1.5 times the purchase price of the subject products or services in the 12 months preceding the claim, unless such limitation of liability is otherwise prohibited by law.
     
     ### 03 - Copyright
     


### PR DESCRIPTION
## TL;DR

Caps SSW's liability at **1.5× the purchase price of the products/services in the 12 months preceding the claim**, replacing the previous flat "purchase price of the subject products or services" cap. Content-only change to the Limited Liability clause in the Terms & Conditions.

## Why

As per @Levijj22's email *"Re: Change to SSW Terms and Conditions - Limited Liability"*. cc @adamcogan

## Reviewer notes

- **Single content change.** Only `content/pages/terms-and-conditions.mdx`, clause 02 – Limited Liability.
- **Re-opened off a non-bot branch.** Replaces #4729, whose `copilot/*` branch TinaCloud refuses to index (build failed with "Branch is not on TinaCloud"). Identical content.

## Links

- Supersedes #4729