### PR TITLE
⚡ Reduce client JS weight on event/content pages

### DIFF
--- a/app/components/deferred-gtm.tsx
+++ b/app/components/deferred-gtm.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { GoogleTagManager } from "@next/third-parties/google";
+import { useEffect, useState } from "react";
+
+/**
+ * Loads Google Tag Manager off the critical path to reduce Total Blocking Time.
+ *
+ * GTM (and the tags it injects: Clarity, Hotjar, LinkedIn, Facebook Pixel) is
+ * the single largest third-party main-thread cost on first load. None of our
+ * own code calls `sendGTMEvent`/`dataLayer` — every tag fires inside the
+ * container — so it is safe to delay loading until the page is interactive.
+ *
+ * It loads on the first user interaction OR when the browser goes idle,
+ * whichever comes first. The idle callback uses a timeout so the script is
+ * always loaded (within ~3.5s) even for sessions with no interaction, so
+ * pageview tracking is preserved.
+ */
+export function DeferredGoogleTagManager({ gtmId }: { gtmId?: string }) {
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  useEffect(() => {
+    if (!gtmId || typeof window === "undefined") return;
+
+    let triggered = false;
+    const interactionEvents = [
+      "scroll",
+      "mousemove",
+      "touchstart",
+      "keydown",
+      "click",
+    ];
+
+    const cleanup = () => {
+      interactionEvents.forEach((event) =>
+        window.removeEventListener(event, trigger)
+      );
+      if (typeof window.cancelIdleCallback === "function") {
+        window.cancelIdleCallback(idleId);
+      } else {
+        window.clearTimeout(idleId);
+      }
+    };
+
+    const trigger = () => {
+      if (triggered) return;
+      triggered = true;
+      setShouldLoad(true);
+      cleanup();
+    };
+
+    interactionEvents.forEach((event) =>
+      window.addEventListener(event, trigger, { once: true, passive: true })
+    );
+
+    // Guaranteed fallback: load on idle, or after the timeout regardless.
+    const idleId: number =
+      typeof window.requestIdleCallback === "function"
+        ? window.requestIdleCallback(trigger, { timeout: 3500 })
+        : window.setTimeout(trigger, 3500);
+
+    return cleanup;
+  }, [gtmId]);
+
+  if (!shouldLoad || !gtmId) return null;
+  return <GoogleTagManager gtmId={gtmId} />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import { PhishingBanner } from "@/components/phishing-banner/phishing-banner";
 import { MegaMenuWrapper } from "@/components/server/MegaMenuWrapper";
 import { AppInsightsProvider } from "@/context/app-insight-client";
 import { EventInfoStatic } from "@/services/server/events-types";
-import { GoogleTagManager } from "@next/third-parties/google";
+import { DeferredGoogleTagManager } from "./components/deferred-gtm";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import isBetween from "dayjs/plugin/isBetween";
@@ -97,7 +97,9 @@ export default async function RootLayout({
             {/* </Theme> */}
           </PageLayout>
 
-          <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GOOGLE_GTM_ID} />
+          <DeferredGoogleTagManager
+            gtmId={process.env.NEXT_PUBLIC_GOOGLE_GTM_ID}
+          />
           <ChatBaseBot />
         </QueryProvider>
       </body>

--- a/app/providers/query-provider.tsx
+++ b/app/providers/query-provider.tsx
@@ -1,8 +1,18 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import dynamic from "next/dynamic";
 import { ReactNode, useMemo } from "react";
+
+// Dev-only: loaded lazily so it never ships in the production bundle.
+const ReactQueryDevtools =
+  process.env.NODE_ENV === "development"
+    ? dynamic(() =>
+        import("@tanstack/react-query-devtools").then(
+          (mod) => mod.ReactQueryDevtools
+        )
+      )
+    : () => null;
 
 const FIVE_MINS = 1000 * 60 * 5;
 

--- a/components/blocks/imageComponents/ImageComponentLayout.tsx
+++ b/components/blocks/imageComponents/ImageComponentLayout.tsx
@@ -88,7 +88,7 @@ export const ImageComponentLayout = ({ data, children, priority = false }) => {
                 <Image
                   width={data.mediaConfiguration?.imageWidth}
                   priority={priority}
-                  sizes="(min-width: 768px) 50vw, 100vw"
+                  sizes="(min-width: 768px) min(50vw, 640px), 100vw"
                   height={data.mediaConfiguration?.imageHeight}
                   className={cn("w-full rounded-md")}
                   src={data.mediaConfiguration?.imageSource}

--- a/components/layout/v2ComponentWrapper.tsx
+++ b/components/layout/v2ComponentWrapper.tsx
@@ -1,11 +1,37 @@
 "use client";
 import classNames from "classnames";
-import { useInView } from "framer-motion";
 import Image from "next/image";
 
-import { UseInViewOptions } from "framer-motion";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { backgroundOptions } from "../blocksSubtemplates/tinaFormElements/colourOptions/blockBackgroundOptions";
+
+// Lightweight replacement for framer-motion's useInView so the animation
+// engine isn't pulled into the critical bundle for every v2 block.
+function useInViewOnce(
+  ref: React.RefObject<Element>,
+  { margin = "0px" }: { margin?: string } = {}
+) {
+  const [isInView, setIsInView] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      setIsInView(true); // SSR/old browsers: render visible, no fade
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: margin }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref, margin]);
+  return isInView;
+}
 
 type BackgroundData = {
   background?: {
@@ -23,7 +49,7 @@ const V2ComponentWrapper = ({
 }: {
   data: BackgroundData;
   children: React.ReactNode;
-  fadeInMargin?: UseInViewOptions["margin"];
+  fadeInMargin?: string;
   className?: string;
 }) => {
   //Bleed effect setup
@@ -46,7 +72,7 @@ const V2ComponentWrapper = ({
 
   //Fade-in effect setup
   const ref = useRef(null);
-  const isInView = useInView(ref, { once: true, margin: fadeInMargin });
+  const isInView = useInViewOnce(ref, { margin: fadeInMargin });
   useEffect(() => {
     setIsInInitialViewport(isInView);
   }, [isInView]);

--- a/context/app-insight-client.tsx
+++ b/context/app-insight-client.tsx
@@ -4,57 +4,81 @@ import {
   AppInsightsContext,
   ReactPlugin,
 } from "@microsoft/applicationinsights-react-js";
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import React, { ReactNode, useEffect, useMemo } from "react";
 
 export function AppInsightsProvider({ children }: { children: ReactNode }) {
   const reactPlugin = useMemo(() => new ReactPlugin(), []);
   useEffect(() => {
-    // Configuration options with defaults for cost optimization
-    const clientSamplingPercentageRaw = parseFloat(
-      process.env.NEXT_PUBLIC_APPINSIGHTS_CLIENT_SAMPLING_PERCENTAGE || "20"
-    );
-    // Validate sampling percentage is between 1 and 100, default to 20 if invalid
-    const clientSamplingPercentage =
-      !isNaN(clientSamplingPercentageRaw) &&
-      clientSamplingPercentageRaw >= 1 &&
-      clientSamplingPercentageRaw <= 100
-        ? clientSamplingPercentageRaw
-        : 20;
+    let appInsights: { unload: () => void } | undefined;
+    let cancelled = false;
 
-    const appInsights = new ApplicationInsights({
-      config: {
-        connectionString: process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
-        extensions: [reactPlugin],
-        samplingPercentage: clientSamplingPercentage, // Apply client-side sampling
-        autoExceptionInstrumented: true, // Always track exceptions
-        autoTrackPageVisitTime: true,
-        enableRequestHeaderTracking: true,
-        enableResponseHeaderTracking: true,
-        enableAjaxErrorStatusText: true,
-        distributedTracingMode: 0,
-        loggingLevelTelemetry: 1,
-        loggingLevelConsole: 1,
-        extensionConfig: {
-          [reactPlugin.identifier]: {},
+    // Defer loading the heavy applicationinsights-web SDK until the browser is
+    // idle so it stays out of the critical bundle/main-thread on first paint.
+    const init = async () => {
+      // Configuration options with defaults for cost optimization
+      const clientSamplingPercentageRaw = parseFloat(
+        process.env.NEXT_PUBLIC_APPINSIGHTS_CLIENT_SAMPLING_PERCENTAGE || "20"
+      );
+      // Validate sampling percentage is between 1 and 100, default to 20 if invalid
+      const clientSamplingPercentage =
+        !isNaN(clientSamplingPercentageRaw) &&
+        clientSamplingPercentageRaw >= 1 &&
+        clientSamplingPercentageRaw <= 100
+          ? clientSamplingPercentageRaw
+          : 20;
+
+      if (!process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING) {
+        // eslint-disable-next-line no-console
+        console.log("Client side logging is not turned on!");
+        return;
+      }
+
+      const { ApplicationInsights } = await import(
+        "@microsoft/applicationinsights-web"
+      );
+      if (cancelled) return;
+
+      const instance = new ApplicationInsights({
+        config: {
+          connectionString:
+            process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
+          extensions: [reactPlugin],
+          samplingPercentage: clientSamplingPercentage, // Apply client-side sampling
+          autoExceptionInstrumented: true, // Always track exceptions
+          autoTrackPageVisitTime: true,
+          enableRequestHeaderTracking: true,
+          enableResponseHeaderTracking: true,
+          enableAjaxErrorStatusText: true,
+          distributedTracingMode: 0,
+          loggingLevelTelemetry: 1,
+          loggingLevelConsole: 1,
+          extensionConfig: {
+            [reactPlugin.identifier]: {},
+          },
+          disablePageUnloadEvents: ["unload"],
         },
-        disablePageUnloadEvents: ["unload"],
-      },
-    });
-
-    if (appInsights.config.connectionString) {
-      appInsights.loadAppInsights();
+      });
+      instance.loadAppInsights();
+      appInsights = instance;
       // eslint-disable-next-line no-console
       console.log("✅ App Insights - Client Side logging is turned on!");
       // eslint-disable-next-line no-console
       console.log(`   📊 Client Sampling: ${clientSamplingPercentage}%`);
-    } else {
-      // eslint-disable-next-line no-console
-      console.log("Client side logging is not turned on!");
-    }
+    };
+
+    const ric: number =
+      typeof window.requestIdleCallback === "function"
+        ? window.requestIdleCallback(() => init(), { timeout: 4000 })
+        : window.setTimeout(() => init(), 2000);
 
     return () => {
-      appInsights.unload();
+      cancelled = true;
+      if (typeof window.cancelIdleCallback === "function") {
+        window.cancelIdleCallback(ric);
+      } else {
+        window.clearTimeout(ric);
+      }
+      appInsights?.unload();
     };
   }, [reactPlugin]);
 

--- a/helpers/getTrimmedEvents.ts
+++ b/helpers/getTrimmedEvents.ts
@@ -3,7 +3,13 @@ export const buildEventUrl = (node: {
   _sys: { filename: string; breadcrumbs: string[] };
 }): string => {
   const folderYear = node._sys.breadcrumbs.at(-2);
-  const segment = (node.slug || node._sys.filename).toLowerCase();
+  const rawSegment = node.slug || node._sys.filename;
+  const segment = rawSegment ? String(rawSegment).toLowerCase() : "";
+  // Guard against a null/empty slug producing a broken, prefetchable
+  // "/events/null" link — fall back to the events listing instead.
+  if (!segment || segment === "null" || segment === "undefined") {
+    return "/events";
+  }
   return folderYear ? `/events/${folderYear}/${segment}` : `/events/${segment}`;
 };
 


### PR DESCRIPTION
## TL;DR

PageSpeed mobile flags the event pages at **Performance 36** with **1,650 ms Total Blocking Time** and ~3.2 MB of unused JS — driven by heavy client code loaded eagerly on every page, not by page content. This defers or trims the worst offenders (App Insights, framer-motion, GTM) so they stay off the critical path, plus two small content fixes.

**Files to review (7, behaviour-preserving):**

| File | Why |
|---|---|
| `context/app-insight-client.tsx` *(start here)* | Dynamic-import the heavy `applicationinsights-web` core on idle; lightweight React plugin/context stays synchronous so `WebVitals` + error boundary keep working. |
| `components/layout/v2ComponentWrapper.tsx` | Replace framer-motion `useInView` with a small `IntersectionObserver` hook — drops the 2.9 MB package from the wrapper around every v2 block. |
| `app/components/deferred-gtm.tsx` *(new)* | Loads GTM on first interaction or idle, with a guaranteed ~3.5 s fallback. |
| `app/layout.tsx` | Swap `<GoogleTagManager>` for `<DeferredGoogleTagManager>`. |
| `components/blocks/imageComponents/ImageComponentLayout.tsx` | `sizes` cap `min(50vw, 640px)` to stop oversized image fetches. |
| `helpers/getTrimmedEvents.ts` | Guard null/empty slug so no `/events/null` link is prefetched. |
| `app/providers/query-provider.tsx` | `ReactQueryDevtools` → dynamic dev-only import. |

## Why

The page render chain itself is clean — the cost is global/eager client code. Confirmed in-repo: App Insights is instantiated in the root layout on every page; framer-motion is pulled into the wrapper that wraps every block just for one hook; and GTM (which injects Clarity, Hotjar, LinkedIn, FB Pixel) loads `afterInteractive`, contributing ~595 ms of third-party main-thread time.

## How

Each change moves work off the first-load critical path without changing behaviour:

- **App Insights / GTM / devtools** — same code runs, just later (on idle / interaction / dev-only), so they leave the initial bundle and main thread.
- **framer-motion** — the new hook reproduces `useInView(ref, { once: true, margin })` semantics via `IntersectionObserver` `rootMargin`; SSR/no-IO falls back to visible.
- **Images / `/events/null`** — pure correctness: tighter responsive `sizes`, and a slug guard that falls back to `/events`.

## Reviewer notes

- **GTM timing shifts.** Tags fire up to ~3.5 s later (usually sooner). Pageviews still captured for every session via the guaranteed idle/timeout fallback; no code depends on `sendGTMEvent`/`dataLayer`. Dial down `3500` if sub-second tag timing matters.
- **App Insights context intact.** Only the web SDK is lazy; the `ReactPlugin` context is provided immediately, and consumers call it null-safely.
- **Image cap is CSS-px.** Browser still picks the right candidate by DPR, so retina stays crisp; only oversized wide-screen fetches shrink.

## Tests

`tsc --noEmit` clean, ESLint clean on changed files, `jest` 13/13 pass. No runtime/behaviour change to verify beyond the deferral timing above.

## Follow-up

Confirm the named 1.9 MB chunk with `BUNDLE_ANALYSE=true pnpm build` (analyzer already wired in `next.config.mjs`) — these fixes target the most likely contributors (App Insights, framer-motion), but the treemap will show anything else.