### PR TITLE
✨ Add Eventbrite booking page for AI for Business Leaders event

### DIFF
--- a/components/blocks-renderer.tsx
+++ b/components/blocks-renderer.tsx
@@ -54,6 +54,13 @@ const JotFormEmbed = dynamic(
   }
 );
 
+const EventbriteEmbed = dynamic(
+  () => import("./blocks/eventbriteEmbed").then((mod) => mod.EventbriteEmbed),
+  {
+    ssr: false,
+  }
+);
+
 import { ServiceCards } from "./blocks/serviceCards";
 
 const TableLayout = dynamic(() =>
@@ -179,6 +186,7 @@ const componentMap = {
   LatestTech,
   VideoEmbed,
   JotFormEmbed,
+  EventbriteEmbed,
   ColorBlock,
   DownloadBlock,
   GridLayout,

--- a/components/blocks/eventbriteEmbed.tsx
+++ b/components/blocks/eventbriteEmbed.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Script from "next/script";
+import React, { useCallback, useEffect, useState } from "react";
+import { twMerge } from "tailwind-merge";
+import { Template } from "tinacms";
+import { tinaField } from "tinacms/dist/react";
+
+const EVENTBRITE_WIDGET_SRC =
+  "https://www.eventbrite.com/static/widgets/eb_widgets.js";
+
+declare global {
+  interface Window {
+    EBWidgets?: {
+      createWidget: (options: {
+        widgetType: "checkout";
+        eventId: string;
+        iframeContainerId: string;
+        iframeContainerHeight?: number;
+      }) => void;
+    };
+  }
+}
+
+export interface EventbriteEmbedProps {
+  data: {
+    eventId?: string;
+    iframeHeight?: number;
+    fallbackUrl?: string;
+    containerClass?: string;
+  };
+}
+
+export const EventbriteEmbed: React.FC<EventbriteEmbedProps> = ({ data }) => {
+  const { eventId, iframeHeight, fallbackUrl, containerClass } = data ?? {};
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+  const containerId = eventId
+    ? `eventbrite-widget-container-${eventId}`
+    : undefined;
+
+  const createWidget = useCallback(() => {
+    if (!eventId || !containerId) return;
+    if (typeof window === "undefined" || !window.EBWidgets) return;
+    window.EBWidgets.createWidget({
+      widgetType: "checkout",
+      eventId,
+      iframeContainerId: containerId,
+      iframeContainerHeight: iframeHeight || 650,
+    });
+  }, [eventId, containerId, iframeHeight]);
+
+  // Handle the case where the widget script is already on the page
+  // (e.g. after a client-side navigation back to this route).
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.EBWidgets) {
+      setScriptLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (scriptLoaded) createWidget();
+  }, [scriptLoaded, createWidget]);
+
+  // No event configured yet — show an editor-facing placeholder rather than
+  // an empty container. Lets the booking page ship before the Eventbrite
+  // event exists.
+  if (!eventId) {
+    return (
+      <div
+        data-tina-field={data && tinaField(data, "eventId")}
+        className={twMerge(
+          "mx-auto flex min-h-64 w-full max-w-3xl items-center justify-center rounded-lg border border-dashed border-gray-400 p-8 text-center text-gray-500",
+          containerClass
+        )}
+      >
+        Add an Eventbrite Event ID in Tina to embed the booking widget.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Script
+        src={EVENTBRITE_WIDGET_SRC}
+        strategy="afterInteractive"
+        onLoad={() => setScriptLoaded(true)}
+      />
+      <div
+        data-tina-field={data && tinaField(data, "eventId")}
+        className={twMerge("mx-auto w-full max-w-3xl", containerClass)}
+      >
+        <div id={containerId} />
+        {fallbackUrl && (
+          <noscript>
+            <a href={fallbackUrl}>Book tickets on Eventbrite</a>
+          </noscript>
+        )}
+      </div>
+    </>
+  );
+};
+
+export const eventbriteEmbedSchema: Template = {
+  name: "EventbriteEmbed",
+  label: "Eventbrite Embed",
+  ui: {
+    itemProps: (item) => ({
+      label: item?.eventId
+        ? `Eventbrite Embed (${item.eventId})`
+        : "Eventbrite Embed (no event id)",
+    }),
+  },
+  fields: [
+    {
+      type: "string",
+      name: "eventId",
+      label: "Eventbrite Event ID",
+      description:
+        "Numeric event ID from the Eventbrite event URL, e.g. eventbrite.com/e/<name>-<EVENT_ID>. Leave blank to show a placeholder.",
+    },
+    {
+      type: "number",
+      name: "iframeHeight",
+      label: "Embed Height (px)",
+      description: "Height of the embedded checkout. Defaults to 650.",
+    },
+    {
+      type: "string",
+      name: "fallbackUrl",
+      label: "Fallback Eventbrite URL",
+      description:
+        "Full Eventbrite event URL — used as a no-JS fallback link below the embed.",
+    },
+    {
+      type: "string",
+      name: "containerClass",
+      label: "Container Class",
+    },
+  ],
+};

--- a/components/blocks/index.ts
+++ b/components/blocks/index.ts
@@ -32,6 +32,7 @@ import { customImageBlockSchema } from "./customImage";
 import { domainFromQuerySchema } from "./domainFromQuery.schema";
 import { downloadBlockSchema } from "./downloadBlock";
 import { dynamicColumnsSchema } from "./dynamicColumns";
+import { eventbriteEmbedSchema } from "./eventbriteEmbed";
 import { eventLinkSchema } from "./eventLink";
 import { fixedColumnsSchema } from "./fixedColumns";
 import { fixedTabsLayoutSchema } from "./fixedTabsLayout";
@@ -86,6 +87,7 @@ export const pageBlocks: Template[] = [
   downloadBlockSchema,
   dynamicColumnsSchema,
   eventBookingSchema,
+  eventbriteEmbedSchema,
   eventLinkSchema,
   flagSchema,
   fixedColumnsSchema,

--- a/content/eventsv2/ai-for-business-leaders-booking.json
+++ b/content/eventsv2/ai-for-business-leaders-booking.json
@@ -1,0 +1,45 @@
+{
+  "seo": {
+    "title": "Book Your Seat | AI for Business Leaders Workshop | SSW",
+    "description": "Secure your ticket to SSW's half-day live AI workshop for Australian C-Suite executives. Choose your city and complete your booking below."
+  },
+  "blocks": [
+    {
+      "spacerHeight": "90px",
+      "background": {
+        "backgroundColour": 0,
+        "backgroundImage": "",
+        "bleed": false
+      },
+      "_template": "spacer"
+    },
+    {
+      "topLabel": {
+        "labelText": "Reserve Your Seat"
+      },
+      "heading": "Secure Your **$99 Seat**",
+      "isH1": true,
+      "description": "You're one step away. Choose your city and complete your booking below — payment is handled securely through Eventbrite.\n",
+      "tabletTextAlignment": "Center",
+      "background": {
+        "backgroundColour": 0
+      },
+      "_template": "imageTextBlock"
+    },
+    {
+      "eventId": "",
+      "iframeHeight": 650,
+      "fallbackUrl": "",
+      "_template": "EventbriteEmbed"
+    },
+    {
+      "spacerHeight": "120px",
+      "background": {
+        "backgroundColour": 0,
+        "backgroundImage": "",
+        "bleed": false
+      },
+      "_template": "spacer"
+    }
+  ]
+}


### PR DESCRIPTION
Parent: #4738

## Summary
Adds the **dedicated booking page** for the AI for Business Leaders event — the Eventbrite booking/payment flow lives here, on its own page, instead of being embedded on the landing page. This keeps the heavy Eventbrite widget off the landing page so its mobile performance stays fast (the reason the original thank-you-page approach in #4736 was dropped).

**New flow:** landing page (#4715) → CTA buttons → **this booking page** (embedded Eventbrite) → ticket purchase.

## Changes
- **New reusable `EventbriteEmbed` Tina block** (`components/blocks/eventbriteEmbed.tsx`) — inline-embeds the Eventbrite checkout widget via the official `eb_widgets.js` script. Editable fields: Event ID, embed height, no-JS fallback URL, container class. Renders an editor-facing placeholder when no Event ID is set, so the page can ship before the Eventbrite event exists.
- Registered the block in `pageBlocks` (`components/blocks/index.ts`) and the renderer (`components/blocks-renderer.tsx`, `ssr: false` like `JotFormEmbed`).
- **New page** `content/eventsv2/ai-for-business-leaders-booking.json` → **`/events/ai-for-business-leaders-booking`**. Reuses the existing `eventsv2` collection, route and blocks — no new collection.

## TODO (tracked in #4738)
- Paste the real Eventbrite **Event ID** into the `EventbriteEmbed` block via Tina once the event exists
- Repoint the landing page's 10 CTAs (#4715) at this page, then remove the now-dead lead-capture code (`reserveYourSeatJotFormId` + cardCarousel lead-capture button)

## Test plan
**Preview: https://app-sswwebsite-9eb3-pr-4742.azurewebsites.net/events/ai-for-business-leaders-booking**
- [x] `tsc --noEmit` and `eslint` pass
- [x] Tina schema indexes the new block + content with no errors (local datalayer); `EventbriteEmbed` present in generated types
- [x] `/events/ai-for-business-leaders-booking` returns 200 and renders the hero locally (`next dev`)
- [ ] Reviewer: set a real Eventbrite Event ID and confirm the widget loads on the PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
