### PR TITLE
⚡ Apply fetchpriority=high to priority media block images

### DIFF
--- a/components/blocks/imageComponents/ImageComponentLayout.tsx
+++ b/components/blocks/imageComponents/ImageComponentLayout.tsx
@@ -92,6 +92,11 @@ export const ImageComponentLayout = ({ data, children, priority = false }) => {
                 <Image
                   width={data.mediaConfiguration?.imageWidth}
                   priority={loadWithPriority}
+                  // next/image's `priority` alone no longer emits the
+                  // fetchpriority="high" hint (Next 15.5 only forwards an
+                  // explicit fetchPriority prop), and Lighthouse flags the
+                  // LCP image without it
+                  fetchPriority={loadWithPriority ? "high" : undefined}
                   sizes="(min-width: 768px) 50vw, 100vw"
                   height={data.mediaConfiguration?.imageHeight}
                   className={cn("w-full rounded-md")}


### PR DESCRIPTION
## TL;DR

The LCP hero image on event pages was preloaded but still fetched at default priority — Lighthouse flags "fetchpriority=high should be applied" and mobile LCP sits at ~3.2 s. `ImageComponentLayout` now passes an explicit `fetchPriority="high"` alongside `priority`.

## Why

In Next 15.5, `next/image`'s `priority` boolean only disables lazy-loading and emits the preload; unlike earlier versions it no longer derives the `fetchpriority="high"` hint — `get-img-props.js` only forwards an explicitly passed `fetchPriority` prop. So the CMS "Load with priority" tick worked (preload present in HTML) but the browser still queued the image at default priority.

Verified locally: the rendered hero `<img>` now carries `fetchPriority="high"`.

## Links

- Closes #4725
- Follows #4744 and #4741