### PR TITLE
Remove 'slashNEW 2026' from carousel items

### DIFF
--- a/content/pages/home.mdx
+++ b/content/pages/home.mdx
@@ -45,10 +45,6 @@ beforeBody:
         link: 'https://tv.ssw.com/?utm_source=website&utm_medium=banner&utm_campaign=carousel'
         openIn: newWindow
         imgSrc: /images/carousel/SSW-TV-Banner-Master-Your-Skills-v3.jpg
-      - label: slashNEW 2026
-        link: /events/2026/slashnew
-        openIn: newWindow
-        imgSrc: /images/carousel/slashNEW-website-banner2026.png
     backgroundColor: lightgray
     delay: 5
     showOnMobileDevices: false


### PR DESCRIPTION
Removed the 'slashNEW 2026' item from the carousel.

Event is past


