### PR TITLE
Revert #4761 (event youTubeId) — site went down

### DIFF
--- a/content/events-calendar/2026/June-User-Group---Talk-Title-TBA.json
+++ b/content/events-calendar/2026/June-User-Group---Talk-Title-TBA.json
@@ -18,8 +18,7 @@
   "city": "Sydney",
   "category": "Artificial Intelligence",
   "abstract": "Join SSW's VP of AI, Calum Simpson, for a talk about the current state of AI-assisted development and what you really need to know about to get the most out of the tools. \n\nCalum will explain what AI Skills are and how to use them, share some practical examples with you, and leave you with thoughts on the Human Skills required to succeed in the world of AI.\n\n",
-  "description": "Join SSW's VP of AI, Calum Simpson, for a talk about the current state of AI-assisted development and what you really need to know about to get the most out of the tools.\n\nCalum will explain what AI Skills are and how to use them, share some practical examples with you, and leave you with thoughts on the Human Skills required to succeed in the world of AI.\n",
-  "youTubeId": "xXTg10XxH1w",
+  "description": "Join SSW's VP of AI, Calum Simpson, for a talk about the current state of AI-assisted development and what you really need to know about to get the most out of the tools. \n\nCalum will explain what AI Skills are and how to use them, share some practical examples with you, and leave you with thoughts on the Human Skills required to succeed in the world of AI.\n",
   "liveStreamDelayMinutes": 30,
   "hostedAtSsw": true,
   "enabled": true


### PR DESCRIPTION
Reverts commit 4ed4bb9af (#4761), which added a `youTubeId` to `content/events-calendar/2026/June-User-Group---Talk-Title-TBA.json`.

The site went down after this commit landed, so reverting to restore it. Re-apply once the cause is understood.