### PR TITLE
🐛 Fix JotForm location field crashing the submission viewer

### DIFF
--- a/components/blocks/v3/leadCapture/leadCapture.tsx
+++ b/components/blocks/v3/leadCapture/leadCapture.tsx
@@ -92,13 +92,13 @@ export function V3LeadCapture({ data }) {
 
   const selectedCountry = LOCATIONS.find((l) => l.label === country);
   const needsRegion = (selectedCountry?.states.length ?? 0) > 0;
-  // JotForm's location field takes country and state as two separate options
-  // (e.g. "Australia" + "New South Wales") rather than one combined string.
+  // JotForm's location widget stores a newline-separated string and renders
+  // each line as its own tag (e.g. "Australia\nNew South Wales" → two tags).
+  // Submitting a real array instead crashes its submission viewer with
+  // "items.map is not a function".
   const regionName =
     needsRegion && region ? (AU_STATE_NAMES[region] ?? region) : "";
-  const locationValue: string | string[] = regionName
-    ? [country, regionName]
-    : country;
+  const locationValue = regionName ? `${country}\n${regionName}` : country;
 
   const screen1Valid =
     name.trim().length > 0 &&


### PR DESCRIPTION
## TL;DR

The lead-capture Location field crashed JotForm's submission viewer with `TypeError: items.map is not a function`. The field is a `control_widget` that stores a **newline-separated string** and renders each line as a tag — but the client submitted a JSON **array** for the Australia case, which the widget can't render. This joins country and state with `\n` so the stored value matches the format every working submission uses.

## Diagnosis

Comparing stored submissions via the JotForm API made the cause obvious:

| Stored value | Type | Result |
|---|---|---|
| `"Australia\nNew South Wales"` | string | renders as two tags ✓ |
| `["Australia","New South Wales"]` | array | viewer crashes (`items.map`) ✗ |

The screenshot below shows it directly — the top row (newline string) renders as clean **Australia** / **New South Wales** tags, while the array rows show *"Something went wrong."*:

<!-- Josh: drag the JotForm table screenshot in here -->

## How

`leadCapture.tsx` — `locationValue` is now `` `${country}\n${state}` `` when a state applies, otherwise just `country`. No array is ever sent, so the route's existing scalar encoding (`submission[6]=...`) stores the exact string format the widget expects.

<img width="818" height="292" alt="Screenshot 2026-06-24 at 4 25 57 pm" src="https://github.com/user-attachments/assets/5592c15f-42e2-4d0d-ac14-5045a884753e" />

**Figure: Fixes broken location**