### PR TITLE
⚡ Speed up Docker builds with layer + pnpm store caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ _docs
 .vs
 Dockerfile
 node_modules
+.next
 npm-debug.log
 README.md
 test-results

--- a/.github/workflows/pr-push-deploy.yml
+++ b/.github/workflows/pr-push-deploy.yml
@@ -122,7 +122,6 @@ jobs:
 
   build:
     name: Build and upload artifacts
-    needs: check-slot-capacity
     uses: ./.github/workflows/template-build.yml
     with:
       tag: pr-${{ github.event.number }}
@@ -133,7 +132,7 @@ jobs:
 
   pr-deploy:
     name: Deploy to slot
-    needs: build
+    needs: [check-slot-capacity, build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -87,6 +87,9 @@ jobs:
           $nodeVersion = (Get-Content .nvmrc).Trim() -replace '^v', ''
           echo "version=$nodeVersion" >> $env:GITHUB_OUTPUT
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker - Build and push
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -106,15 +106,19 @@ jobs:
             NEXT_PUBLIC_GITHUB_SHA=${{ github.sha }}
             NEXT_PUBLIC_TINA_CLIENT_ID=${{ secrets.NEXT_PUBLIC_TINA_CLIENT_ID }}
             NEXT_PUBLIC_TINA_BRANCH=${{ github.head_ref || github.ref_name }}
-            YOUTUBE_PRIVATE_KEY=${{ env.YOUTUBE_PRIVATE_KEY }}
             KEY_VAULT=${{ env.KEY_VAULT }}
             NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING=${{ steps.AppInsight.outputs.AppInsightConnectionString }}
-            TINA_TOKEN=${{ secrets.TINA_TOKEN }}
             NEXT_PUBLIC_CHATBASE_BOT_ID=${{ env.NEXT_PUBLIC_CHATBASE_BOT_ID }}
             SITE_URL=https://www.ssw.com.au
-            TINA_SEARCH_TOKEN=${{ secrets.TINA_SEARCH_TOKEN }}
             JOTFORM_API_KEY=${{ secrets.JOTFORM_API_KEY }}
             NEXT_PUBLIC_SLOT_URL=https://${{ env.APP_SERVICE_NAME}}-pr-${{github.event.number}}.azurewebsites.net/
+
+          # Mounted as secrets (not build-args) so they are not baked into the
+          # exported BuildKit cache (cache-to mode=max).
+          secrets: |
+            TINA_TOKEN=${{ secrets.TINA_TOKEN }}
+            TINA_SEARCH_TOKEN=${{ secrets.TINA_SEARCH_TOKEN }}
+            YOUTUBE_PRIVATE_KEY=${{ env.YOUTUBE_PRIVATE_KEY }}
 
           tags: |
             ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -115,3 +115,5 @@ jobs:
 
           tags: |
             ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}
+          cache-from: type=registry,ref=${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,22 +54,23 @@ ARG KEY_VAULT
 ENV KEY_VAULT=$KEY_VAULT
 ARG NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING
 ENV NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING=$NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING
-ARG TINA_TOKEN
-ENV TINA_TOKEN=$TINA_TOKEN
 ARG NEXT_PUBLIC_CHATBASE_BOT_ID
 ENV NEXT_PUBLIC_CHATBASE_BOT_ID=$NEXT_PUBLIC_CHATBASE_BOT_ID
 ARG SITE_URL
 ENV SITE_URL=$SITE_URL
-ARG YOUTUBE_PRIVATE_KEY
-ENV YOUTUBE_PRIVATE_KEY=$YOUTUBE_PRIVATE_KEY
-ARG TINA_SEARCH_TOKEN
-ENV TINA_SEARCH_TOKEN=$TINA_SEARCH_TOKEN
 ARG NEXT_PUBLIC_SLOT_URL
 ENV NEXT_PUBLIC_SLOT_URL=$NEXT_PUBLIC_SLOT_URL
 
 
 
-RUN \
+# Secrets are mounted (not passed as build-args/ENV) so they are never written
+# to an image layer or the exported BuildKit cache (cache-to mode=max).
+RUN --mount=type=secret,id=TINA_TOKEN \
+    --mount=type=secret,id=TINA_SEARCH_TOKEN \
+    --mount=type=secret,id=YOUTUBE_PRIVATE_KEY \
+  export TINA_TOKEN="$(cat /run/secrets/TINA_TOKEN)" && \
+  export TINA_SEARCH_TOKEN="$(cat /run/secrets/TINA_SEARCH_TOKEN)" && \
+  export YOUTUBE_PRIVATE_KEY="$(cat /run/secrets/YOUTUBE_PRIVATE_KEY)" && \
   if [ -f yarn.lock ]; then yarn run build; \
   elif [ -f package-lock.json ]; then npm run build; \
   elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm run build; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /website
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 
-RUN \
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
   elif [ -f pnpm-lock.yaml ]; then npm i -g corepack@latest && corepack enable pnpm && pnpm i --frozen-lockfile; \

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "dev": "tinacms dev -c \"next dev --turbopack\"",
-    "build": "tinacms build && next build && next-sitemap --config next-sitemap.config.js",
+    "build": "tinacms build --content=local && next build && next-sitemap --config next-sitemap.config.js",
     "partytown": "partytown copylib public/~partytown",
     "postbuild": "next-sitemap --config next-sitemap.config.js",
     "start": "tinacms build && node_modules/next/dist/bin/next start -p $PORT",


### PR DESCRIPTION
## Problem

CI build logs showed avoidable cost on every build:

- **pnpm reinstalled from scratch** — `reused 0, downloaded 2062, added 2075` (~28s) because `build-push-action` had no layer cache.
- **632MB build context** transfer — the local/stale `.next` (790MB) wasn't excluded from the Docker context.
- **`next build` fetched Tina content over the network** every time.
- Build waited on the staging slot-capacity check before starting.

## Changes

- Add registry `cache-from`/`cache-to` to the `build-push-action` step (`:buildcache` tag in ACR) so Docker layers persist across runs.
- Mount a BuildKit cache for the pnpm store in the `deps` stage — installs reuse downloads even on a partial layer-cache miss.
- Exclude `.next` from the Docker build context.
- Use the `docker-container` Buildx driver so registry cache export (`cache-to`) actually works.
- Start the build in parallel with the slot-capacity check instead of waiting on it — the build no longer `needs` that ~38s job, so it kicks off **~30s sooner** (deploy still gates on both).
- `tinacms build --content=local` — build from local content instead of fetching from Tina cloud.

## Results (measured)

`Docker - Build and push` step:

| Build | Cache | Source | Docker build |
|-------|-------|--------|--------------|
| [#28144171901](https://github.com/SSWConsulting/SSW.Website/actions/runs/28144171901?pr=4801) attempt 1 | cold (writes cache) | — | **11m 18s** |
| [#28144171901](https://github.com/SSWConsulting/SSW.Website/actions/runs/28144171901?pr=4801) attempt 2 | warm | unchanged | **7m 39s** |
| [#28147978545](https://github.com/SSWConsulting/SSW.Website/actions/runs/28147978545?pr=4801) | warm | changed | **8m 09s** |

≈ **3–3.5 min faster (~30%)** once the cache is warm. With an unchanged tree the `deps` and `builder` layers come straight from ACR (`CACHED`), skipping pnpm install and `next build` entirely; with a code change the `deps` layer still hits, so only `next build` reruns.

Plus **~30s off the wall clock** end-to-end: the build no longer waits on the ~38s slot-capacity check before starting.

## Notes

- First build after merge is cold (writes the cache). Wins land on subsequent runs.
- Deps layer keys off `pnpm-lock.yaml`, so lockfile changes still rebuild correctly.
- The `staticGeneration*` knobs in `next.config.mjs` are already optimal for the 4-core runner — left untouched. The real SSG lever is more cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
