### PR TITLE
fix(v2ComponentWrapper): don't set background-image when URL is undefined

### DIFF
--- a/components/layout/v2ComponentWrapper.tsx
+++ b/components/layout/v2ComponentWrapper.tsx
@@ -114,10 +114,10 @@ const V2ComponentWrapper = ({
           !isInInitialViewport && isInView && "opacity-100"
         )}
         style={
-          data.background?.bleed
+          data.background?.bleed || !data.background?.backgroundImage
             ? {}
             : {
-                backgroundImage: `url(${data.background?.backgroundImage})`,
+                backgroundImage: `url(${data.background.backgroundImage})`,
                 backgroundSize: "cover",
                 backgroundRepeat: "no-repeat",
                 backgroundPosition: "center",


### PR DESCRIPTION
Closes #2870

## Summary

The v2 block wrapper unconditionally sets an inline `background-image: url(...)` even when no image is configured, producing:

\`\`\`html
<section style=\"background-image:url(undefined);background-size:cover;...\">
\`\`\`

The browser resolves \"undefined\" as a relative URL and fires requests like \`/consulting/<slug>/undefined\`, which is what was causing the mystery \`GET /consulting/undefined\` and \`GET /consulting/null\` hits in dev logs (and the \"Unable to find record content/consultingv2/undefined.json\" GraphQL warnings) that we tracked down in [#4714](https://github.com/SSWConsulting/SSW.Website/pull/4714).

## Change

One-line guard in \`components/layout/v2ComponentWrapper.tsx\` — skip the \`backgroundImage\` style when \`data.background?.backgroundImage\` is falsy. Colour classes and bleed image still work.

## Test plan

- [ ] Any block without a background image no longer emits \`background-image: url(undefined)\` in the DOM
- [ ] Blocks with a background image still render it correctly
- [ ] No \`/consulting/undefined\` requests in the network tab or dev server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)