### PR TITLE
fix(footer): stop deployment tooltip causing horizontal overflow on mobile

### DIFF
--- a/components/layout/footer/deployment-info.tsx
+++ b/components/layout/footer/deployment-info.tsx
@@ -30,7 +30,7 @@ export const DeploymentInfo = () => {
         {tooltip && (
           <span
             role="tooltip"
-            className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 hidden -translate-x-1/2 whitespace-nowrap rounded bg-white px-2 py-1 text-xs leading-none text-gray-900 opacity-0 shadow-md transition-opacity duration-150 sm:block group-hover:opacity-100"
+            className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 hidden -translate-x-1/2 whitespace-nowrap rounded bg-white px-2 py-1 text-xs leading-none text-gray-900 opacity-0 shadow-md transition-opacity duration-150 group-hover:opacity-100 sm:block"
           >
             {tooltip}
           </span>

--- a/components/layout/footer/deployment-info.tsx
+++ b/components/layout/footer/deployment-info.tsx
@@ -30,7 +30,7 @@ export const DeploymentInfo = () => {
         {tooltip && (
           <span
             role="tooltip"
-            className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 -translate-x-1/2 whitespace-nowrap rounded bg-white px-2 py-1 text-xs leading-none text-gray-900 opacity-0 shadow-md transition-opacity duration-150 group-hover:opacity-100"
+            className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 hidden -translate-x-1/2 whitespace-nowrap rounded bg-white px-2 py-1 text-xs leading-none text-gray-900 opacity-0 shadow-md transition-opacity duration-150 sm:block group-hover:opacity-100"
           >
             {tooltip}
           </span>


### PR DESCRIPTION
As per @adamcogan email **CSS - Azure Marketplace consulting - Publish, sell, co-sell | SSW**
there was issue with UI on mobile phones
<img width="660" height="1434" alt="image" src="https://github.com/user-attachments/assets/7664e66a-0620-4b22-8f67-1bd2821209a0" />

## Summary

Fixes the "weird right-side experience on iPhone" reported on the Azure Marketplace page — reproduces site-wide, not specific to that page.

## Root cause

The footer's "Last updated" deployment info (`components/layout/footer/deployment-info.tsx`) has a hover tooltip showing the exact UTC timestamp. It's centered on its trigger via `absolute left-1/2 -translate-x-1/2`, with `whitespace-nowrap` making it ~272px wide. On narrow viewports where the trigger sits close to the right edge, the centered non-wrapping tooltip spills past the viewport — and because it's `position: absolute`, its layout footprint still expands `document.scrollWidth` even though it's invisible (`opacity-0`, only shown via `group-hover`, which never fires on touch).

## Verification (no local dev server — see note below)

Used a real Playwright mobile-emulated context (iPhone UA, `isMobile: true`, touch) against the **live production site**, not just a plain viewport resize (a plain resize keeps desktop rendering assumptions and didn't reproduce the bug on its first pass):

| Width | Before | After (class patch simulating this diff) |
|---|---|---|
| 375px | 375 (no overflow) | 375 |
| **430px** | **517 (87px overflow)** | **430** |
| **500px** | **537 (37px overflow)** | **500** |
| 600–639px | no overflow | no overflow |
| 640px+ | tooltip `display: block` (unchanged) | tooltip `display: block` (unchanged) |

Isolated the exact cause by removing only the tooltip span — `scrollWidth` dropped from 517 → 430 exactly, confirming it as sole contributor (a separate initial hypothesis, that the Chatbase chat-widget was the cause, was ruled out the same way — removing its DOM had zero effect on `scrollWidth`).

Confirmed the fix doesn't regress desktop: at 640px+ the tooltip's `sm:block` class resolves to `display: block` (the utility is already compiled into the site's CSS bundle), and the pre-existing `group-hover:opacity-100` class is untouched, so hover-to-reveal keeps working exactly as before.


## Test plan

- [x] At 375–639px width, the footer tooltip span doesn't render at all (`display: none`) and the page has zero horizontal overflow
- [x] At 640px+ width, hovering "X ago" in the footer still shows the "Last updated ... UTC" tooltip as before
- [x] Native `title` attribute (accessible on all breakpoints) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
