### PR TITLE
✨ Make PR staging deploys opt-in via /deploy and cap slots at 5

### DIFF
--- a/.github/.env
+++ b/.github/.env
@@ -10,4 +10,4 @@ APP_INSIGHT_PROD=appInsight-sswwebsite-9eb3
 APP_INSIGHT_DEV=appInsight-sswwebsite-dev-9eb3
 NEXT_PUBLIC_CHATBASE_BOT_ID=gnbZXuG_5tgI_R3yzKcOn
 # Max concurrent PR staging slots. New PRs are refused a slot above this to stop the plan being starved. Tune to your App Service Plan's headroom.
-MAX_PR_SLOTS=10
+MAX_PR_SLOTS=5

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -29,6 +29,10 @@ inputs:
   AZURE_SERVICE_PRINCIPAL_OBJECT_ID:
     description: Object Id of Service Principal
     required: true
+  create_slot:
+    description: create the slot (and its ACR/Key Vault roles) before deploying - PR slots only
+    default: "false"
+    required: false
 
 outputs:
   url:
@@ -48,7 +52,7 @@ runs:
     - name: AppService - Create slot
       shell: pwsh
       id: create-slot
-      if: github.event_name == 'pull_request'
+      if: inputs.create_slot == 'true'
       run: |
         # create the environment
         az deployment group create `

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,21 @@
+name: PR - build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.event.number }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and upload artifacts
+    uses: ./.github/workflows/template-build.yml
+    with:
+      tag: pr-${{ github.event.number }}
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit

--- a/.github/workflows/pr-deploy-command.yml
+++ b/.github/workflows/pr-deploy-command.yml
@@ -19,10 +19,12 @@ defaults:
 jobs:
   validate:
     name: Validate /deploy command
-    if: github.event.issue.pull_request && github.event.comment.body == '/deploy'
+    # startsWith so trailing whitespace/text doesn't silently ignore the command
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy')
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     outputs:
       pr_number: ${{ steps.pr.outputs.pr_number }}

--- a/.github/workflows/pr-deploy-command.yml
+++ b/.github/workflows/pr-deploy-command.yml
@@ -1,13 +1,15 @@
-name: PR - build and deploy to slot
+name: PR - deploy to slot on /deploy
+
+# Staging slots are opt-in: comment `/deploy` on a PR to build it and deploy it
+# to a pr-<number> slot. Slots are a shared, limited resource (MAX_PR_SLOTS) -
+# see https://github.com/SSWConsulting/SSW.Website/issues/4767.
 
 on:
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: ci-${{ github.event.number }}-${{ github.workflow }}
+  group: ci-${{ github.event.issue.number }}-${{ github.workflow }}
   cancel-in-progress: true
 
 defaults:
@@ -15,8 +17,58 @@ defaults:
     shell: pwsh
 
 jobs:
+  validate:
+    name: Validate /deploy command
+    if: github.event.issue.pull_request && github.event.comment.body == '/deploy'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check commenter has write access
+        run: |
+          $login = '${{ github.event.comment.user.login }}'
+          $permission = gh api "repos/${{ github.repository }}/collaborators/$login/permission" --jq '.permission'
+
+          if ($permission -notin @('admin', 'maintain', 'write')) {
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" `
+              -f body="🛑 Sorry @$login - write access to this repo is required to deploy a staging slot." --silent
+            Write-Host "::error::$login has '$permission' permission - write access is required to deploy."
+            exit 1
+          }
+
+          Write-Host "✅ $login has '$permission' permission - proceeding."
+
+      - name: Get PR details
+        id: pr
+        run: |
+          $prNumber = '${{ github.event.issue.number }}'
+          $pr = gh api "repos/${{ github.repository }}/pulls/$prNumber" | ConvertFrom-Json
+
+          if ($pr.state -ne 'open') {
+            Write-Host "::error::PR #$prNumber is not open (state: $($pr.state)) - nothing to deploy."
+            exit 1
+          }
+
+          "pr_number=$prNumber" >> $env:GITHUB_OUTPUT
+          "head_ref=$($pr.head.ref)" >> $env:GITHUB_OUTPUT
+          "head_sha=$($pr.head.sha)" >> $env:GITHUB_OUTPUT
+          Write-Host "✅ Deploying PR #$prNumber ($($pr.head.ref) @ $($pr.head.sha))"
+
+      - name: React to comment
+        run: |
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" `
+            -f content=rocket --silent
+
   check-slot-capacity:
     name: Check staging slot capacity
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -40,16 +92,10 @@ jobs:
       - name: Enforce slot cap
         id: cap
         env:
-          PR_SLOT: pr-${{ github.event.number }}
+          PR_SLOT: pr-${{ needs.validate.outputs.pr_number }}
         run: |
-          # Only PRs create slots (the deploy step is PR-gated); skip the cap on manual dispatch
-          if ("${{ github.event_name }}" -ne "pull_request") {
-            Write-Host "Not a pull_request event - slot cap not applicable, skipping."
-            exit 0
-          }
-
-          # Default to 10; only override if MAX_PR_SLOTS is a valid positive int
-          $max = 10
+          # Default to 5; only override if MAX_PR_SLOTS is a valid positive int
+          $max = 5
           $parsed = 0
           if ([int]::TryParse("${{ env.MAX_PR_SLOTS }}", [ref]$parsed) -and $parsed -gt 0) { $max = $parsed }
 
@@ -65,14 +111,14 @@ jobs:
 
           Write-Host "Open PR slots: $count / $max"
 
-          # An existing PR re-running is an update to its own slot, not a new one - always allow
+          # An existing PR re-deploying is an update to its own slot, not a new one - always allow
           if ($slotArray -contains "$env:PR_SLOT") {
             Write-Host "✅ This PR already owns slot $env:PR_SLOT - allowing (update, not a new slot)."
             exit 0
           }
 
           if ($count -ge $max) {
-            $msg = "🛑 **Staging slot limit reached ($count/$max).** This PR can't get a staging deployment until one frees up. Please close or merge another open PR to release its slot, then re-run this workflow."
+            $msg = "🛑 **Staging slot limit reached ($count/$max).** This PR can't get a staging deployment until one frees up. Please close or merge another open PR to release its slot, then comment ``/deploy`` again."
             "blocked=true"   >> $env:GITHUB_OUTPUT
             "message=$msg"   >> $env:GITHUB_OUTPUT
             Write-Host $msg
@@ -89,42 +135,16 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           allow-repeats: false
 
-  run-tests-and-coverage:
-    name: Run tests & coverage
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-        with:
-          package_json_file: package.json
-          standalone: true
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Run Tests & Coverage
-        run: pnpm test-and-coverage --outputFile=coverage-report.json
-
-      - name: Upload Coverage Report to PR
-        uses: ArtiomTr/jest-coverage-report-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          coverage-file: coverage-report.json
-          base-coverage-file: coverage-report.json
-          skip-step: all
-          annotations: none
-
   build:
     name: Build and upload artifacts
+    # Gated behind the slot cap so a blocked PR doesn't push a throwaway image to ACR
+    needs: [validate, check-slot-capacity]
     uses: ./.github/workflows/template-build.yml
     with:
-      tag: pr-${{ github.event.number }}
+      tag: pr-${{ needs.validate.outputs.pr_number }}
+      ref: ${{ needs.validate.outputs.head_sha }}
+      tina_branch: ${{ needs.validate.outputs.head_ref }}
+      pr_number: ${{ needs.validate.outputs.pr_number }}
     permissions:
       id-token: write
       contents: read
@@ -132,7 +152,7 @@ jobs:
 
   pr-deploy:
     name: Deploy to slot
-    needs: [check-slot-capacity, build]
+    needs: [validate, check-slot-capacity, build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -152,7 +172,8 @@ jobs:
         uses: ./.github/actions/deploy
         id: deploy
         with:
-          slot_name: pr-${{ github.event.number }}
+          slot_name: pr-${{ needs.validate.outputs.pr_number }}
+          create_slot: "true"
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -167,6 +188,8 @@ jobs:
         with:
           message: |
             Deployed changes to <${{ steps.deploy.outputs.url }}>
+
+            ℹ️ Staging slots are no longer created automatically - comment `/deploy` to deploy new commits.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           allow-repeats: true
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.event.number }}-${{ github.workflow }}
+  # Fall back to run_id so manual dispatch runs don't share one group and cancel each other
+  group: ci-${{ github.event.number || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 
 defaults:
@@ -19,7 +20,7 @@ jobs:
     name: Run tests & coverage
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,47 @@
+name: PR - tests and coverage
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.event.number }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  run-tests-and-coverage:
+    name: Run tests & coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: package.json
+          standalone: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Tests & Coverage
+        run: pnpm test-and-coverage --outputFile=coverage-report.json
+
+      - name: Upload Coverage Report to PR
+        uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-file: coverage-report.json
+          base-coverage-file: coverage-report.json
+          skip-step: all
+          annotations: none

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -6,6 +6,23 @@ on:
       tag:
         type: string
         required: true
+      # For comment-triggered (issue_comment) builds the event context points at
+      # main, not the PR - so the caller must pass the PR's ref/branch/number.
+      ref:
+        type: string
+        required: false
+        default: ""
+        description: "Git ref to build; defaults to the ref that triggered the workflow"
+      tina_branch:
+        type: string
+        required: false
+        default: ""
+        description: "Tina branch to build against; defaults to the triggering branch"
+      pr_number:
+        type: string
+        required: false
+        default: ""
+        description: "PR number for the slot URL; defaults to the event's PR number"
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -39,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Load .env file
         uses: xom9ikk/dotenv@v2
@@ -105,16 +124,16 @@ jobs:
             NEXT_PUBLIC_GITHUB_RUN_ID=${{ github.run_id }}
             NEXT_PUBLIC_GITHUB_RUN_NUMBER=${{ github.run_number }}
             NEXT_PUBLIC_GITHUB_REPOSITORY=${{ github.repository }}
-            NEXT_PUBLIC_GITHUB_SHA=${{ github.sha }}
+            NEXT_PUBLIC_GITHUB_SHA=${{ inputs.ref || github.sha }}
             NEXT_PUBLIC_TINA_CLIENT_ID=${{ secrets.NEXT_PUBLIC_TINA_CLIENT_ID }}
-            NEXT_PUBLIC_TINA_BRANCH=${{ github.head_ref || github.ref_name }}
+            NEXT_PUBLIC_TINA_BRANCH=${{ inputs.tina_branch || github.head_ref || github.ref_name }}
             KEY_VAULT=${{ env.KEY_VAULT }}
             NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING=${{ steps.AppInsight.outputs.AppInsightConnectionString }}
             NEXT_PUBLIC_CHATBASE_BOT_ID=${{ env.NEXT_PUBLIC_CHATBASE_BOT_ID }}
             SITE_URL=https://www.ssw.com.au
             JOTFORM_API_KEY=${{ secrets.JOTFORM_API_KEY }}
             POWER_AUTOMATE_LEAD_WEBHOOK_URL=${{ secrets.POWER_AUTOMATE_LEAD_WEBHOOK_URL }}
-            NEXT_PUBLIC_SLOT_URL=https://${{ env.APP_SERVICE_NAME}}-pr-${{github.event.number}}.azurewebsites.net/
+            NEXT_PUBLIC_SLOT_URL=https://${{ env.APP_SERVICE_NAME}}-pr-${{ inputs.pr_number || github.event.number }}.azurewebsites.net/
 
           # Mounted as secrets (not build-args) so they are not baked into the
           # exported BuildKit cache (cache-to mode=max).

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Load .env file
         uses: xom9ikk/dotenv@v2

--- a/.github/workflows/weekly-slots-cleanup.yml
+++ b/.github/workflows/weekly-slots-cleanup.yml
@@ -75,7 +75,7 @@ jobs:
             $updated = ([datetime]$openMap[$slot]).ToUniversalTime()
             if ($updated -lt $cutoff) {
               Write-Host "🧹 pr-$slot - PR #$slot inactive since $updated -> delete + comment"
-              gh pr comment $slot --body "🧹 Your **staging deployment was removed** during weekly cleanup because this PR has been inactive for over $staleDays days. Push a new commit (or re-run the **PR - build and deploy to slot** workflow) to spin up a fresh staging environment."
+              gh pr comment $slot --body "🧹 Your **staging deployment was removed** during weekly cleanup because this PR has been inactive for over $staleDays days. Comment ``/deploy`` on this PR to spin up a fresh staging environment."
               $toDelete += $slot
             }
             else {

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ It generates report and saves into `.lighthouseci` folder. You can also change t
 
 ## Pull Requests
 
-Each Pull Request will be deployed to its own staging environment, the URL to the environment is available in the PR thread.
+Staging deployments are opt-in - comment `/deploy` on a Pull Request to build it and deploy it to its own staging environment (requires write access). The URL to the environment is posted in the PR thread. New commits are not deployed automatically - comment `/deploy` again to update the slot.
+
+Slots are a shared, limited resource (see [#4767](https://github.com/SSWConsulting/SSW.Website/issues/4767)) - they are capped at 5 concurrent PR slots and cleaned up when a PR closes or goes inactive for 7 days.
 
 ⚠️ **Warning**: Changes in the mdx files must be done with TinaCMS. This is because TinaCMS maps mdx files with its fields with specific characters for customized UI (e.g., rich-text field). So avoid direct edits as they may result in build failures or go unnoticed during PR reviews.
 


### PR DESCRIPTION
## TL;DR

Staging slots starved the Basic-tier container registry and took prod down twice (June 15 and July 6 — a worker recycle forced ~12 simultaneous image pulls and 62% of them failed). 

- [ ]  PR slots are now opt-in: comment `/deploy` on a PR to build and deploy it
- [ ]  the concurrent slot cap drops from 10 to 5

## How

- `/deploy` requires write access (comment-triggered workflows run with secrets, so they can't be open to anyone).
- Repeat `/deploy` comments update the PR's existing slot in place and bypass the cap; a capped PR gets a comment explaining how to free a slot.
- The build is gated behind the capacity check, so a blocked PR doesn't push a throwaway ~1 GB image to the already-over-quota registry.

## Links

- Fixes #4767
- [July 6 incident investigation (root cause + evidence)](https://github.com/SSWConsulting/SSW.Website/issues/4767#issuecomment-4890226054)
- [SSW.Rules /deploy reference implementation](https://github.com/SSWConsulting/SSW.Rules/blob/main/.github/workflows/pr-deploy.yml)
