### PR TITLE
fix(infra): make ACR pull role assignment idempotent per principal

### DIFF
--- a/infra/acrRoleAssignment.bicep
+++ b/infra/acrRoleAssignment.bicep
@@ -1,7 +1,6 @@
 param roleName string
 param principalId string
 param acrName string
-param slotName string
 
 var roleIdMapping = {
   'ACR Pull': '7f951dda-4ed3-4680-a7ca-43fe172d538d'
@@ -13,7 +12,7 @@ resource acr 'Microsoft.ContainerRegistry/registries@2021-09-01' existing =  {
 
 
 resource addRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.id, roleIdMapping[roleName], slotName)
+  name: guid(acr.id, principalId, roleIdMapping[roleName])
   scope: acr
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleIdMapping[roleName])

--- a/infra/create-pr-environment.bicep
+++ b/infra/create-pr-environment.bicep
@@ -47,7 +47,6 @@ module acrRoleAssignment 'acrRoleAssignment.bicep' = {
     acrName: acrName
     principalId: appServiceSlot.outputs.slotPrincipalId
     roleName: 'ACR Pull'
-    slotName: slotName
   }
 }
 


### PR DESCRIPTION
Closes #4844

## What

`infra/acrRoleAssignment.bicep` named the "ACR Pull" role assignment with `guid(acr.id, roleIdMapping[roleName], slotName)` — keyed on the **slot name**, not the **principal**. Change it to `guid(acr.id, principalId, roleIdMapping[roleName])` (mirroring `keyVaultRoleAssignment.bicep`, which already keys on `principalId`). `slotName` becomes unused, so the param and its pass-through in `create-pr-environment.bicep` are removed.

## Why

When a PR slot is torn down and recreated (slot cleanup), the new slot's managed identity comes back with a **new `principalId`**, but the role-assignment name is unchanged. The deploy then tries to rewrite the same-named assignment with a different principal, which Azure refuses:

```
RoleAssignmentUpdateNotPermitted: Tenant ID, application ID, principal ID, and scope are not allowed to be updated.
```

That's what fails the **Deploy to slot** step on PRs whose environment has been recycled (e.g. #4781, #4782, and the TinaCMS content PRs) and on `main`. Keying the name on `principalId` makes it idempotent: same principal -> same GUID (re-runs are no-ops), new principal -> new GUID (a fresh assignment instead of an illegal update). The orphaned old assignment is harmless (its principal no longer exists).

## History

Latent since `infra/acrRoleAssignment.bicep` was added in #503 (2023-05-08). It only bites once a slot with the same name is recreated with a new identity, which is why older/recycled PR environments hit it now rather than on first deploy.

## Verification

- `az bicep build infra/create-pr-environment.bicep` compiles clean.
- `keyVaultRoleAssignment.bicep` already uses the principal-keyed pattern; no change needed there.
