### PR TITLE
🐛 Fix Book a Free Initial Meeting button on some consulting pages

### DIFF
--- a/content/consultingv2/database-development.json
+++ b/content/consultingv2/database-development.json
@@ -33,6 +33,7 @@
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
+          "leadCaptureFormOption": "bookingJotFormId",
           "colour": 0
         }
       ],
@@ -412,6 +413,7 @@
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
+          "leadCaptureFormOption": "bookingJotFormId",
           "colour": 0
         }
       ],

--- a/content/consultingv2/devops.json
+++ b/content/consultingv2/devops.json
@@ -25,6 +25,7 @@
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
+          "leadCaptureFormOption": "bookingJotFormId",
           "colour": 0
         }
       ],
@@ -287,6 +288,7 @@
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
+          "leadCaptureFormOption": "bookingJotFormId",
           "colour": 0
         }
       ],

--- a/content/consultingv2/local-llm-deployment.json
+++ b/content/consultingv2/local-llm-deployment.json
@@ -400,6 +400,7 @@
       "buttons": [
         {
           "buttonText": "👉 Book a Free Initial Meeting",
+          "leadCaptureFormOption": "bookingJotFormId",
           "colour": 0
         }
       ],


### PR DESCRIPTION
Fixes #4848

## Problem

The **Book a Free Initial Meeting** button did nothing when clicked on:

- `/consulting/devops` (both buttons)
- `/consulting/database-development` (both buttons)
- `/consulting/local-llm-deployment` (bottom CTA)

## Cause

These `consultingv2` pages render buttons through `ButtonRow`, which only opens the booking JotForm popup when a button has `leadCaptureFormOption` (or navigates when it has `buttonLink`). The affected buttons had neither, so `templateButton`'s onClick was a no-op:

```tsx
onClick={() => { if (leadCaptureFormOption) setOpen(true); }}
```

Every working consulting page (azure, artificial-intelligence, web-applications, …) sets `"leadCaptureFormOption": "bookingJotFormId"`. These pages were just missing it.

## Fix

Added `"leadCaptureFormOption": "bookingJotFormId"` to the 5 affected buttons. Content-only change (the field already exists in the schema, so no tina-lock regen). A repo-wide scan of all 983 content JSONs confirms these were the only dead booking buttons.

## Repro video

https://youtu.be/zmDqbINpZBA — DevOps button does nothing, then Azure opens the booking form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
