### PR TITLE
💄 Fix featured event card overflow on mobile

### DIFF
--- a/components/blocks/v3/events/countdown.tsx
+++ b/components/blocks/v3/events/countdown.tsx
@@ -41,12 +41,12 @@ export function Countdown({ date }: { date?: string }) {
   ];
 
   return (
-    <div className="flex items-center justify-center gap-4 rounded-full bg-white/10 px-8 py-5 backdrop-blur-sm sm:gap-6">
+    <div className="flex items-center justify-center gap-2 rounded-full bg-white/10 px-4 py-4 backdrop-blur-sm sm:gap-6 sm:px-8 sm:py-5">
       {units.map((unit, index) => (
-        <div key={unit.label} className="flex items-center gap-4 sm:gap-6">
+        <div key={unit.label} className="flex items-center gap-2 sm:gap-6">
           {index > 0 && <span className="h-10 w-px bg-white/20" />}
           <div className="flex flex-col items-center">
-            <span className="text-3xl font-semibold tabular-nums text-white sm:text-4xl">
+            <span className="text-2xl font-semibold tabular-nums text-white sm:text-4xl">
               {String(unit.value).padStart(2, "0")}
             </span>
             <span className="text-xs text-gray-300">{unit.label}</span>

--- a/components/blocks/v3/events/countdown.tsx
+++ b/components/blocks/v3/events/countdown.tsx
@@ -41,7 +41,7 @@ export function Countdown({ date }: { date?: string }) {
   ];
 
   return (
-    <div className="flex items-center justify-center gap-2 rounded-full bg-white/10 px-4 py-4 backdrop-blur-sm sm:gap-6 sm:px-8 sm:py-5">
+    <div className="flex items-center justify-center gap-2 rounded-full bg-white/10 p-4 backdrop-blur-sm sm:gap-6 sm:px-8 sm:py-5">
       {units.map((unit, index) => (
         <div key={unit.label} className="flex items-center gap-2 sm:gap-6">
           {index > 0 && <span className="h-10 w-px bg-white/20" />}

--- a/components/blocks/v3/events/events.tsx
+++ b/components/blocks/v3/events/events.tsx
@@ -270,7 +270,7 @@ function FeaturedEvent({ event }) {
       )}
       <div aria-hidden="true" className="absolute inset-0 bg-black/60" />
 
-      <div className="relative z-10 grid items-center gap-12 p-8 md:grid-cols-2 md:p-16">
+      <div className="relative z-10 grid grid-cols-1 items-center gap-12 p-8 md:grid-cols-2 md:p-16">
         {/* Left: title, description, sign-up */}
         <div className="flex flex-col">
           {event?.title && (


### PR DESCRIPTION
## TL;DR

On mobile (iPhone 15 Pro, 393px) the homepage's **featured event card** overflowed its own bounds by ~37px — the title clipped mid-word (`Choosing the righ…`) and the countdown ran off the right edge. Root cause: the card's inner grid had no base `grid-cols-1`, so `display:grid` produced a single **auto-width** column that expanded to fit the rigid ~358px countdown pill.

## Why

`grid items-center … md:grid-cols-2` never set a base column template. On mobile that leaves one implicit `auto` column, which sizes to its widest child. The countdown pill can't shrink (fixed padding + gaps + `text-3xl` digits ≈ 358px min-content), so it forced the column ~52px wider than the card, and the card's `overflow-hidden` chopped the title and countdown. It reads as clipping, not a page scrollbar.

## How

- **`events.tsx`** — add base `grid-cols-1` so the mobile track is capped to the card width and the title wraps.
- **`countdown.tsx`** — shrink the pill's padding, gaps, and digit size on mobile; `sm:` restores the desktop sizing.

Verified at 393px: card `scrollWidth` 394 → 342 (`== clientWidth`, 0 overflow); countdown pill 358px → 236px.

## Before / After

iPhone 15 Pro (393px):

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/SSWConsulting/SSW.Website/pr-assets/4861-mobile-events-card/pr-assets/events-card-before.png) | ![after](https://raw.githubusercontent.com/SSWConsulting/SSW.Website/pr-assets/4861-mobile-events-card/pr-assets/events-card-after.png) |

## Tests

Visual/layout-only change (Tailwind classes). Confirmed on the live page at 393px via measurement + screenshots; `sm:`+ breakpoints unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)