### PR TITLE
feat: add Melbourne .NET User Group September 2026 - Becoming an Agentic Scrum Master

### DIFF
--- a/content/events-calendar/2026/September-User-Group---Becoming-an-Agentic-Scrum-Master.json
+++ b/content/events-calendar/2026/September-User-Group---Becoming-an-Agentic-Scrum-Master.json
@@ -1,0 +1,25 @@
+{
+  "title": "September User Group - Becoming an Agentic Scrum Master",
+  "slug": "becoming-an-agentic-scrum-master",
+  "url": "/netug/melbourne",
+  "thumbnail": "/images/events/melbourne-ug-thumb.jpg",
+  "thumbnailDescription": "Melbourne .NET User Group",
+  "presenterList": [
+    {
+      "presenter": "content/presenters/eli-kent.mdx"
+    }
+  ],
+  "headerLayout": "avatars",
+  "startDateTime": "2026-09-16T08:00:00.000Z",
+  "endDateTime": "2026-09-16T11:00:00.000Z",
+  "startShowBannerDateTime": "2026-09-15T14:00:00.000Z",
+  "endShowBannerDateTime": "2026-09-16T12:00:00.000Z",
+  "calendarType": "User Groups",
+  "city": "Melbourne",
+  "category": "Artificial Intelligence",
+  "abstract": "Scrum Masters lose hours each week to the same glue-work: Sprint prep, PBI chasing, Retros, and community triage. This session shows how one Scrum Master handed that off to AI agents, using Claude Code with custom skills, self-running routines, and MCP tool integrations into GitHub, PostHog, and more.\n\nExpect a candid look at where agents save real time, where a human still leads, and what it takes to actually go \"agentic\".\n",
+  "description": "Scrum Masters lose hours each week to the same glue-work: Sprint prep, PBI chasing, Retros, and community triage. This session shows how one Scrum Master handed that off to AI agents, using Claude Code with custom skills, self-running routines, and MCP tool integrations into GitHub, PostHog, and more.\n\nExpect a candid look at where agents save real time, where a human still leads, and what it takes to actually go \"agentic\".\n\n**About Eli:**\n\nEli is a Melbourne-based Software Engineer at SSW, originally from Invercargill, New Zealand. He specialises in building scalable, maintainable software using modern Microsoft and JavaScript technologies, working with clients across industries to deliver clean, cloud-first solutions.\n",
+  "liveStreamDelayMinutes": 30,
+  "hostedAtSsw": true,
+  "enabled": true
+}


### PR DESCRIPTION
### Summary

Adds the September 2026 Melbourne .NET User Group event to the events calendar:

- **Talk:** Becoming an Agentic Scrum Master
- **Speaker:** Eli Kent (SSW Melbourne)
- **When:** Wednesday 16 September 2026, 6:00pm-9:00pm AEST (assumed 3rd Wednesday - please confirm)
- **Where:** Melbourne, hosted at SSW

Fields follow the same pattern as other 2026 monthly user group events, with the Melbourne UG URL (/netug/melbourne) and thumbnail. Description supplied by the organiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)