### PR TITLE
🐛 Fix the broken Register Now link on the featured event card

### DIFF
--- a/content/pagesv2/home.json
+++ b/content/pagesv2/home.json
@@ -409,7 +409,6 @@
         "buttons": [
           {
             "buttonText": "Register Now",
-            "buttonLink": "/events/2026/storage-wars",
             "colour": 0
           }
         ]


### PR DESCRIPTION
## TL;DR

The featured event card's **Register Now** button was hardcoded to `/events/2026/storage-wars`, an event that doesn't exist in `content/events-calendar/` — so the homepage's most prominent CTA 404'd. Clearing `buttonLink` lets the button fall back to the featured event's own URL.

## Why

The card's title, date, location and presenters are pulled live from the Events Calendar collection (`calendarEvents[0]`), but the button link was a static value in `home.json` that nobody updated as the calendar rotated. Today that means the card advertises **AI Hack Day - Brisbane** while the button pointed at a dead Storage Wars page.

`getFeaturedButton` already handles this — `button.buttonLink || eventUrl` — and the schema documents it: _"Leave Button Link blank to use the featured event page URL."_ The content was just overriding it. With the override gone the button now resolves to `/events/2026/aihackdaybris26`, matching the card.

## Reviewer notes

- **Content-only fix, no code change.** The fallback in `components/blocks/v3/events/events.tsx:169` already did the right thing.
- **Editors can still override.** Setting Button Link in Tina continues to win — this only removes the stale value.

## Links

- Broken link: `/events/2026/storage-wars`