### PR TITLE
⚡ Homepage performance, accessibility, and live-stream fixes

### DIFF
--- a/app/components/page-layout.tsx
+++ b/app/components/page-layout.tsx
@@ -13,7 +13,7 @@ const PageLayout = ({
 }: PageLayoutProps) => {
   return (
     <HeaderAppearanceProvider>
-      <div className="flex h-screen min-h-screen flex-col">
+      <div className="flex min-h-screen flex-col">
         <header className="no-print z-1">
           {phishingBanner}
           {megaMenu}

--- a/app/live-steam-banner/live-stream.tsx
+++ b/app/live-steam-banner/live-stream.tsx
@@ -52,6 +52,12 @@ interface LiveStreamProps extends PropsWithChildren {
 export function LiveStream({ event, children }: LiveStreamProps) {
   const [countdownMins, setCountdownMins] = useState<number>();
   const [liveStreamDelayMinutes, setLiveStreamDelayMinutes] = useState(0);
+  // Gate all time-dependent output behind mount so the server render and the
+  // first client render are identical. The root layout is cached (revalidate),
+  // so a render-time clock check would otherwise disagree between the cached
+  // server HTML and the live client, causing a hydration mismatch (React #418).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   const eventDynamic: EventInfo = {
     ...event,
@@ -106,37 +112,41 @@ export function LiveStream({ event, children }: LiveStreamProps) {
 
   return (
     <>
-      {showBanner ? (
-        <LiveStreamBanner
-          countdownMins={countdownMins}
-          liveStreamData={eventDynamic}
-          isLive={!!isLive}
-        />
-      ) : (
-        <LiveStreamClient param={"liveBanner"}>
-          {" "}
-          <LiveStreamBanner
-            countdownMins={countdownMins}
-            liveStreamData={eventDynamic}
-            isLive={!!isLive}
-          />
-        </LiveStreamClient>
-      )}
+      {mounted && (
+        <>
+          {showBanner ? (
+            <LiveStreamBanner
+              countdownMins={countdownMins}
+              liveStreamData={eventDynamic}
+              isLive={!!isLive}
+            />
+          ) : (
+            <LiveStreamClient param={"liveBanner"}>
+              {" "}
+              <LiveStreamBanner
+                countdownMins={countdownMins}
+                liveStreamData={eventDynamic}
+                isLive={!!isLive}
+              />
+            </LiveStreamClient>
+          )}
 
-      {isLive ? (
-        <LiveStreamWidget
-          {...{ eventDynamic, liveStreamDelayMinutes }}
-          event={eventDynamic}
-          isLive={!!isLive}
-        />
-      ) : (
-        <LiveStreamClient param={"liveStream"}>
-          <LiveStreamWidget
-            {...{ eventDynamic, liveStreamDelayMinutes }}
-            event={eventDynamic}
-            isLive={!!isLive}
-          />
-        </LiveStreamClient>
+          {isLive ? (
+            <LiveStreamWidget
+              {...{ eventDynamic, liveStreamDelayMinutes }}
+              event={eventDynamic}
+              isLive={!!isLive}
+            />
+          ) : (
+            <LiveStreamClient param={"liveStream"}>
+              <LiveStreamWidget
+                {...{ eventDynamic, liveStreamDelayMinutes }}
+                event={eventDynamic}
+                isLive={!!isLive}
+              />
+            </LiveStreamClient>
+          )}
+        </>
       )}
 
       <MenuWrapper>{children}</MenuWrapper>

--- a/components/blocks/v3/globe/globe.tsx
+++ b/components/blocks/v3/globe/globe.tsx
@@ -152,15 +152,21 @@ export function V3Globe({ data }) {
               )}
             </div>
 
-            {/* Right: 3D globe stage. */}
-            {offices.length > 0 && isDesktop && (
+            {/* Right: 3D globe stage. The stage box is gated purely by CSS
+                (`hidden lg:block`) so its height is reserved in the server HTML
+                at first paint — this stops the section, and the footer below
+                it, from jumping when the client-only WebGL canvas mounts. Only
+                the canvas itself waits for `isDesktop` (see note above). */}
+            {offices.length > 0 && (
               <div className="relative z-0 hidden lg:col-span-7 lg:block">
                 <div
                   className={cn(
                     "relative flex min-h-[34rem] w-full items-center justify-center xl:min-h-[40rem]"
                   )}
                 >
-                  <OfficeMap offices={offices} selectedIndex={openIndex} />
+                  {isDesktop && (
+                    <OfficeMap offices={offices} selectedIndex={openIndex} />
+                  )}
                 </div>
               </div>
             )}

--- a/components/blocks/v3/heroBox/heroBox.tsx
+++ b/components/blocks/v3/heroBox/heroBox.tsx
@@ -119,7 +119,7 @@ export const V3HeroBox = ({ data, priority = false }) => {
                 fill
                 priority={priority && index === 0}
                 fetchPriority={priority && index === 0 ? "high" : undefined}
-                quality={100}
+                quality={75}
                 sizes="(min-width: 1440px) 1312px, 100vw"
                 src={slide.backgroundMedia.imageSource}
                 alt={slide.backgroundMedia.altText ?? "Hero background"}

--- a/components/blocks/v3/testimonials/testimonials.tsx
+++ b/components/blocks/v3/testimonials/testimonials.tsx
@@ -64,34 +64,38 @@ function ClipTextReveal({ text }: { text: string }) {
   let wordIndex = -1;
 
   return (
-    <span aria-label={text.replace(/\*\*/g, "")}>
-      {tokens.map((tok, ti) => {
-        if (tok.space) return <span key={`sp-${ti}`}> </span>;
-        const i = ++wordIndex;
-        return (
-          <span
-            key={`w-${ti}`}
-            ref={(el) => {
-              wordRefs.current[i] = el;
-            }}
-            aria-hidden
-            className="-mb-descender inline-block overflow-hidden pb-descender align-bottom"
-          >
-            <motion.span
-              className={`inline-block ${tok.red ? "text-sswRed" : ""}`}
-              initial={{ y: "110%" }}
-              animate={lineIndices ? { y: 0 } : { y: "110%" }}
-              transition={{
-                duration: 1,
-                delay: lineIndices ? lineIndices[i] * 0.12 : 0,
-                ease: [0.22, 1, 0.36, 1],
+    <span>
+      {/* Readable copy for assistive tech; the animated words below are
+          split per-word and hidden, so this carries the full quote. */}
+      <span className="sr-only">{text.replace(/\*\*/g, "")}</span>
+      <span aria-hidden="true">
+        {tokens.map((tok, ti) => {
+          if (tok.space) return <span key={`sp-${ti}`}> </span>;
+          const i = ++wordIndex;
+          return (
+            <span
+              key={`w-${ti}`}
+              ref={(el) => {
+                wordRefs.current[i] = el;
               }}
+              className="-mb-descender inline-block overflow-hidden pb-descender align-bottom"
             >
-              {tok.word}
-            </motion.span>
-          </span>
-        );
-      })}
+              <motion.span
+                className={`inline-block ${tok.red ? "text-sswRed" : ""}`}
+                initial={{ y: "110%" }}
+                animate={lineIndices ? { y: 0 } : { y: "110%" }}
+                transition={{
+                  duration: 1,
+                  delay: lineIndices ? lineIndices[i] * 0.12 : 0,
+                  ease: [0.22, 1, 0.36, 1],
+                }}
+              >
+                {tok.word}
+              </motion.span>
+            </span>
+          );
+        })}
+      </span>
     </span>
   );
 }

--- a/components/blocksSubtemplates/buttonRow.tsx
+++ b/components/blocksSubtemplates/buttonRow.tsx
@@ -4,51 +4,52 @@ import { cn } from "@/lib/utils";
 
 import classNames from "classnames";
 import Link from "next/link";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { useResizeObserver } from "usehooks-ts";
 import { Button } from "../button/templateButton";
 
 const ButtonRow = ({ className, data }) => {
   const buttonContainer = useRef<HTMLDivElement>(null);
   const buttonRefs = useRef<HTMLButtonElement[]>([]);
-  const [buttonContainerWidth, setButtonContainerWidth] = React.useState(0);
-  const [fullWidthButtonIndex, setFullWidthButtonIndex] = useState<
-    number | null
-  >(null);
+  const [buttonIsFullWidth, setButtonIsFullWidth] = useState(false);
+  // Remembers the button that first filled the row, so a later resize can tell
+  // when it no longer does (prevents flicker between the full-width and auto
+  // states). A ref, not state, so `measure` can stay a stable `[]` callback
+  // without stale closures. It's written synchronously right before the
+  // `setButtonIsFullWidth` that triggers the re-render, so the className read
+  // below sees a value coherent with `buttonIsFullWidth`.
+  const fullWidthButtonIndex = useRef<number | null>(null);
 
-  useEffect(() => {
-    const findFullWidthButton = () => {
-      for (let i = 0; i < buttonRefs.current.length; i++) {
-        const el = buttonRefs.current[i];
-        if (!el) return;
-        if (
-          i === fullWidthButtonIndex &&
-          el.clientWidth < buttonContainerWidth
-        ) {
-          setButtonIsFullWidth(false);
-          return;
-        }
-        if (buttonRefs.current[i].clientWidth === buttonContainerWidth) {
-          setButtonIsFullWidth(true);
-          if (fullWidthButtonIndex === null) {
-            setFullWidthButtonIndex(i);
-          }
-          return;
-        }
+  // Read the container and every button in one pass. This runs from the
+  // ResizeObserver callback, which fires *after* layout is already computed —
+  // so the geometry reads don't force a synchronous reflow the way the old
+  // post-render effect did (that read was this component's forced-reflow cost).
+  // Button sets are static per render, so the observer's initial + resize fires
+  // cover every case the old `data.buttons` dependency did.
+  const measure = useCallback(() => {
+    const container = buttonContainer.current;
+    if (!container) return;
+    const containerWidth = container.clientWidth;
+    for (let i = 0; i < buttonRefs.current.length; i++) {
+      const el = buttonRefs.current[i];
+      if (!el) return;
+      const width = el.clientWidth;
+      if (i === fullWidthButtonIndex.current && width < containerWidth) {
+        setButtonIsFullWidth(false);
+        return;
       }
-      setButtonIsFullWidth(false);
-    };
-    findFullWidthButton();
-  }, [buttonContainerWidth, fullWidthButtonIndex, data.buttons]);
+      if (width === containerWidth) {
+        setButtonIsFullWidth(true);
+        if (fullWidthButtonIndex.current === null) {
+          fullWidthButtonIndex.current = i;
+        }
+        return;
+      }
+    }
+    setButtonIsFullWidth(false);
+  }, []);
 
-  const [buttonIsFullWidth, setButtonIsFullWidth] = React.useState(false);
-  useResizeObserver({
-    ref: buttonContainer,
-    onResize: () => {
-      const width = buttonContainer?.current?.clientWidth;
-      width && setButtonContainerWidth(width);
-    },
-  });
+  useResizeObserver({ ref: buttonContainer, onResize: measure });
   return (
     <>
       {data.buttons?.length > 0 && (
@@ -62,14 +63,15 @@ const ButtonRow = ({ className, data }) => {
                 ref={(node) => {
                   buttonRefs.current[index] = node;
                   return () => {
-                    index === fullWidthButtonIndex &&
-                      setFullWidthButtonIndex(null);
+                    if (fullWidthButtonIndex.current === index) {
+                      fullWidthButtonIndex.current = null;
+                    }
                     delete buttonRefs.current[index];
                   };
                 }}
                 className={cn(
                   "text-base font-semibold",
-                  index !== fullWidthButtonIndex &&
+                  index !== fullWidthButtonIndex.current &&
                     buttonIsFullWidth &&
                     "w-full sm:w-auto"
                 )}

--- a/components/layout/footer/footer.tsx
+++ b/components/layout/footer/footer.tsx
@@ -103,7 +103,7 @@ export const Footer = () => {
               </CustomLink>
             ))}
           </div>
-          <div className="flex flex-wrap gap-x-6 gap-y-2 text-xs uppercase tracking-wider text-gray-500">
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-xs uppercase tracking-wider text-gray-400">
             {bottomBar?.poweredBy?.map((item, index) =>
               item.url ? (
                 <CustomLink

--- a/components/liveStream/liveStreamBanner.tsx
+++ b/components/liveStream/liveStreamBanner.tsx
@@ -3,9 +3,15 @@
 import { EventInfo } from "@/services/server/events-types";
 import classNames from "classnames";
 import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import { useEffect, useState } from "react";
 import countdownTextFormat from "../../helpers/countdownTextFormat";
+import { CITY_TIMEZONES } from "../util/constants/country";
 import { CustomLink } from "../customLink";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 type LiveStreamBannerProps = {
   liveStreamData: EventInfo;
@@ -18,28 +24,58 @@ const LiveStreamBanner = ({
   isLive,
   countdownMins,
 }: LiveStreamBannerProps) => {
-  const { title, liveStreamDelayMinutes } = liveStreamData;
+  const { title, liveStreamDelayMinutes, city } = liveStreamData;
 
   const { startDateTime } = liveStreamData;
   const [countdownText, setCountdownText] = useState("");
 
+  // The streamed chapter drives the timezone and label — not a fixed city.
+  // Reading it from event data (not the runtime clock/zone) keeps the rendered
+  // text deterministic across the cached server render and the live client.
+  const cityKey = city?.toLowerCase().replace(/[-\s]/g, "_");
+  const timeZone =
+    (cityKey && CITY_TIMEZONES[cityKey as keyof typeof CITY_TIMEZONES]) ||
+    "Australia/Sydney";
+  const cityLabel = city
+    ? city
+        .replace(/[-_]/g, " ")
+        .split(" ")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ")
+    : "Sydney";
+
   const scheduledTimeText = (startDateTime: dayjs.Dayjs) => {
-    const sydStartTime = startDateTime.tz("Australia/Sydney").format("h:mm a");
-    const sydLiveTime = startDateTime
+    const doorsTime = startDateTime.tz(timeZone);
+    const streamTime = startDateTime
       .add(liveStreamDelayMinutes, "minute")
-      .tz("Australia/Sydney")
-      .format("h:mm a");
-    return `Live stream starts at ${sydLiveTime} Sydney, doors open at ${sydStartTime} Sydney. ${startDateTime.format(
-      "Do MMM YYYY "
-    )} #NetUG`;
+      .tz(timeZone);
+    return `Live stream starts at ${streamTime.format(
+      "h:mm a"
+    )} ${cityLabel}, doors open at ${doorsTime.format(
+      "h:mm a"
+    )} ${cityLabel}. ${doorsTime.format("Do MMM YYYY ")} #NetUG`;
   };
 
   useEffect(() => {
-    const formattedCountdown = countdownTextFormat(countdownMins);
-    setCountdownText(`Airing in ${formattedCountdown}. `);
+    // Only surface a countdown for a genuinely upcoming stream. Once it reaches
+    // zero the parent flips to "live"; a value at/below zero while not live
+    // means the stream has finished, so never render it as a fake countdown.
+    if (countdownMins != null && countdownMins > 0) {
+      setCountdownText(`Airing in ${countdownTextFormat(countdownMins)}. `);
+    } else {
+      setCountdownText("");
+    }
   }, [liveStreamData, countdownMins]);
 
+  const hasFinished = !isLive && countdownMins != null && countdownMins <= 0;
+
   const liveText = "Streaming live now.";
+  const statusText = isLive
+    ? liveText
+    : hasFinished
+      ? "Streaming has finished."
+      : countdownText || "Calculating...";
+
   return (
     <div className="w-full bg-ssw-black">
       <CustomLink className="unstyled" href="/live">
@@ -51,10 +87,8 @@ const LiveStreamBanner = ({
         >
           <h1 className="m-0 py-0 text-xl font-light text-gray-300">{title}</h1>
           <p className="py-0 text-xs text-white">
-            <span className="block text-sswRed">
-              {(isLive ? liveText : countdownText) || "Calculating..."}
-            </span>
-            {!isLive && scheduledTimeText(dayjs(startDateTime))}
+            <span className="block text-sswRed">{statusText}</span>
+            {!isLive && !hasFinished && scheduledTimeText(dayjs(startDateTime))}
           </p>
         </div>
       </CustomLink>

--- a/helpers/countdownTextFormat.ts
+++ b/helpers/countdownTextFormat.ts
@@ -1,6 +1,9 @@
 export default function countdownTextFormat(countdownMins: number) {
-  const hours = Math.floor(countdownMins / 60);
-  const minutes = countdownMins % 60;
+  // Guard against negative input (a stream that has already started or
+  // finished); otherwise the floor/modulo maths below yields nonsensical text.
+  const remaining = Math.max(0, countdownMins);
+  const hours = Math.floor(remaining / 60);
+  const minutes = remaining % 60;
 
   let countdownText = "";
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,7 @@ const config = {
     ignoreDuringBuilds: true,
   },
   images: {
-    deviceSizes: [384, 640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+    deviceSizes: [384, 640, 750, 828, 1080, 1200, 1440, 1920, 2048, 3840],
     minimumCacheTTL: 60,
 
     remotePatterns: [


### PR DESCRIPTION
## TL;DR

Works through the homepage's Lighthouse findings — a heavy LCP hero image, a 0.698 CLS footer jump, and a forced reflow — and folds in a footer-contrast fix, a testimonial ARIA fix, and a site-wide live-stream hydration error. No visual or behavioural change is intended; the perf items map 1:1 to the flagged Lighthouse audits.

## What's here

Three independent concerns on one branch:

**⚡ Page-speed (Lighthouse)**
- **LCP / image weight** — hero background dropped from `quality={100}` to `75` (imperceptible under its gradient overlay + 60% opacity) and a `1440` device size closes the `1200 → 1920` srcset gap, so ~1250–1310px slots stop pulling the oversized 1920 candidate. Hero est. ~126 KiB → ~40 KiB.
- **CLS (0.698)** — the globe stage (34–40rem tall) was gated on a client-only media query, so it was absent from the SSR HTML and only appeared after hydration, shoving the footer (the last block on the page) down ~a full viewport. The stage box is now reserved via CSS (`hidden lg:block`) with only the WebGL canvas waiting on `isDesktop`; also drops a redundant `h-screen` from the page wrapper.
- **Forced reflow** — `ButtonRow` read each button's `clientWidth` in a post-render effect (a synchronous layout, once per ButtonRow). The reads now run inside the `ResizeObserver` callback, which fires after layout is already computed.

**♿ Accessibility**
- Testimonials: prohibited `aria-label` on a generic span replaced with an sr-only quote copy + `aria-hidden` animated words.
- Footer "powered by" row: `text-gray-500` (3.33:1) → `text-gray-400` (6.34:1) to clear WCAG AA contrast.

**🐛 Live-stream banner**
- Mount-gate the time-dependent banner so cached SSR HTML and the first client render match, resolving the site-wide React #418 hydration error.
- Derive banner timezone/labels from the streamed chapter's city (Sydney stays as fallback), show "Streaming has finished." for past events, and clamp `countdownTextFormat` against negative input.

## Files

| File | Concern |
|---|---|
| `components/blocks/v3/heroBox/heroBox.tsx`, `next.config.mjs` | LCP / image weight |
| `components/blocks/v3/globe/globe.tsx`, `app/components/page-layout.tsx` | CLS |
| `components/blocksSubtemplates/buttonRow.tsx` | Forced reflow |
| `components/blocks/v3/testimonials/testimonials.tsx`, `components/layout/footer/footer.tsx` | A11y |
| `app/live-steam-banner/live-stream.tsx`, `components/liveStream/liveStreamBanner.tsx`, `helpers/countdownTextFormat.ts` | Live-stream |

## Reviewer notes

- **Perf items map 1:1 to Lighthouse.** The image "larger than needed" flag, the 0.698 footer CLS, and the forced-reflow audit — re-run Lighthouse on the homepage to confirm.
- **Button wrap behaviour unchanged.** When one button fills the row, the others still stack full-width; the measurement just moved off the render path.