### PR TITLE
Move Melbourne User Group from September to October

### DIFF
--- a/content/events-calendar/2026/October-User-Group---Becoming-an-Agentic-Scrum-Master.json
+++ b/content/events-calendar/2026/October-User-Group---Becoming-an-Agentic-Scrum-Master.json
@@ -1,5 +1,5 @@
 {
-  "title": "September User Group - Becoming an Agentic Scrum Master",
+  "title": "October User Group - Becoming an Agentic Scrum Master",
   "slug": "becoming-an-agentic-scrum-master",
   "url": "https://www.meetup.com/melbourne-net-user-group/events/315677548",
   "thumbnail": "/images/events/melbourne-ug-thumb.jpg",
@@ -10,10 +10,10 @@
     }
   ],
   "headerLayout": "avatars",
-  "startDateTime": "2026-09-16T08:00:00.000Z",
-  "endDateTime": "2026-09-16T11:00:00.000Z",
-  "startShowBannerDateTime": "2026-09-15T14:00:00.000Z",
-  "endShowBannerDateTime": "2026-09-16T12:00:00.000Z",
+  "startDateTime": "2026-10-21T07:00:00.000Z",
+  "endDateTime": "2026-10-21T09:00:00.000Z",
+  "startShowBannerDateTime": "2026-10-20T13:00:00.000Z",
+  "endShowBannerDateTime": "2026-10-21T11:00:00.000Z",
   "calendarType": "User Groups",
   "city": "Melbourne",
   "category": "Artificial Intelligence",


### PR DESCRIPTION
## Summary

- Rename the Melbourne User Group event file from September to October
- Update the visible title to October
- Move the event to Wednesday 21 October 2026
- Convert the confirmed 6–8 pm AEDT Meetup schedule to UTC
- Update the livestream banner window for daylight saving

- Affected routes: `/events`, `/netug/melbourne`

## Source

- Meetup event `315677548`: Wednesday 21 October 2026, 6–8 pm AEDT
- The existing Meetup event URL remains valid

## Validation

- Parsed the event JSON successfully
- Verified the event resolves to 21 October, 6–8 pm in Melbourne
- Verified the banner resolves to midnight–10 pm in Melbourne
- Verified the Eli Kent presenter profile and Melbourne thumbnail exist
- Verified `Artificial Intelligence` is a valid event category
- Verified the old September filename is removed and the October filename exists