### PR TITLE
♿ A11y - Fix heading order, marquee clones and icon labelling (#4907)

### DIFF
--- a/components/blocksSubtemplates/listItem.tsx
+++ b/components/blocksSubtemplates/listItem.tsx
@@ -15,12 +15,12 @@ export const ListItem = ({ data }) => {
         </div>
       )}
       <div className="flex flex-col">
-        <h6
+        <p
           className="w-full p-1 text-base font-semibold dark:text-white"
           data-tina-field={tinaField(data, "heading")}
         >
           {data.heading}
-        </h6>
+        </p>
         <p
           className="w-full p-1 text-base font-light dark:text-gray-200"
           data-tina-field={tinaField(data, "description")}

--- a/components/blocksSubtemplates/tinaFormElements/icon.tsx
+++ b/components/blocksSubtemplates/tinaFormElements/icon.tsx
@@ -237,7 +237,10 @@ export const IconOptions = {
   VscDashboard,
 };
 
-export const Icon = ({ data, className = "", tinaField = "" }) => {
+// `label` opts an icon into being announced (role="img"); without it the icon
+// is decorative and hidden from assistive tech, since every icon here sits
+// beside its own visible text label.
+export const Icon = ({ data, className = "", tinaField = "", label = "" }) => {
   if (IconOptions[data.name] === null || IconOptions[data.name] === undefined) {
     return <></>;
   }
@@ -247,6 +250,13 @@ export const Icon = ({ data, className = "", tinaField = "" }) => {
   const IconSVG = IconOptions[name];
 
   return (
-    <IconSVG data-tina-field={tinaField} className={`${className} shrink-0`} />
+    <IconSVG
+      data-tina-field={tinaField}
+      className={`${className} shrink-0`}
+      focusable="false"
+      {...(label
+        ? { role: "img", "aria-label": label }
+        : { "aria-hidden": "true" })}
+    />
   );
 };

--- a/components/blocksSubtemplates/tinaFormElements/icon.tsx
+++ b/components/blocksSubtemplates/tinaFormElements/icon.tsx
@@ -255,7 +255,12 @@ export const Icon = ({ data, className = "", tinaField = "", label = "" }) => {
       className={`${className} shrink-0`}
       focusable="false"
       {...(label
-        ? { role: "img", "aria-label": label }
+        ? {
+            role: "img",
+            "aria-label": label,
+            "aria-hidden": "false",
+            title: label,
+          }
         : { "aria-hidden": "true" })}
     />
   );

--- a/components/ui/marquee.tsx
+++ b/components/ui/marquee.tsx
@@ -42,6 +42,7 @@ export function Marquee({
         .map((_, i) => (
           <div
             key={i}
+            aria-hidden={i > 0 ? "true" : undefined}
             className={cn(
               "flex shrink-0 justify-around [gap:var(--gap)]",
               {


### PR DESCRIPTION
Closes #4907

## What I did

The PBI notes the a11y items were **code-inferred** and asked to run axe first. I ran `@axe-core/playwright` against the live page `https://www.ssw.com.au/events/ai-for-business-leaders` and reconciled against the issue's guessed list.

### Axe findings (before)

| Rule | Impact | Nodes | Source |
|---|---|---|---|
| `heading-order` | moderate | 9 | `ListItem` renders feature headings as `<h6>` directly under `<h1>`/`<h2>` (hero feature columns + card carousels) |

That was the **only** axe violation on the page. Notably:

- **No `color-contrast` violations.** The issue's guessed contrast item (`text-gray-300`/`font-light`, `text-sswRed`) did **not** fail axe on the live page, so I left the colour tokens untouched — no design change needed.
- Marquee duplicate logos and unlabelled decorative icons are **not** automatically detectable by axe (duplicate `alt` text and an unlabelled decorative inline SVG aren't rule failures), but they are real screen-reader concerns and explicit acceptance criteria (announce each logo once; don't announce decorative icons), so I fixed them in the shared components too.

### Fixes (all in shared components, so other pages benefit)

1. **`components/blocksSubtemplates/listItem.tsx`** — heading changed from `<h6>` to a styled `<p>` (same classes). Removes the `h1 → h6` jump from the document outline. Resolves the confirmed `heading-order` violation.
2. **`components/ui/marquee.tsx`** — clone copies (`i > 0`) now get `aria-hidden="true"`, so the logo list is announced once instead of `repeat` (7) times.
3. **`components/blocksSubtemplates/tinaFormElements/icon.tsx`** — the shared `Icon` is now decorative by default (`aria-hidden="true"` + `focusable="false"`), with an opt-in `label` prop that switches it to `role="img"` + `aria-label`. Every current caller pairs the icon with visible text, so decorative-by-default is safe.

### After

Re-running axe against a build with these changes should report **0 `heading-order` nodes** and no new violations. I could not re-run axe against a deployed build of this branch (the live scan hits production); the change is verified by static reasoning — the 9 flagged nodes were the only `heading-order` source and are no longer headings.

## Deliberately out of scope

- **Colour contrast** — not a confirmed axe violation, left alone.
- **`utilityButton.tsx` / `socialIcons.tsx`** icons — these use `react-icons` directly (not the shared `Icon`); socialIcons links already carry `aria-label`/`title`. No change needed and none made.
- No Tina schema or `tina-lock.json` changes.

## Verification done

- `pnpm lint` — passes (only a pre-existing unrelated Tailwind `z-[2]` warning).
- `prettier --check` on the 3 files — clean.
- `tsc` — my 3 files are error-free; the remaining tsc errors are all pre-existing `@/tina/__generated__/*` missing-module errors (the generated Tina client isn't present without TinaCloud generation), unrelated to this change. A full `next build` needs TinaCloud secrets I don't have.

## Needs a human to confirm

- Re-run axe **and** Lighthouse accessibility on a deployed build of this branch to confirm the score reaches **95+** (was 81) and that no violations were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8genJyZboXaa4vgYhJF4P