### PR TITLE
🐛 Resolve mobile header appearance server-side to fix CLS

### DIFF
--- a/app/(events)/events/[...filename]/eventsv2.tsx
+++ b/app/(events)/events/[...filename]/eventsv2.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useMobileHeaderAppearance } from "@/app/components/header-appearance";
+import { HeaderAppearanceMarker } from "@/app/components/header-appearance";
 import { Blocks } from "@/components/blocks-renderer";
 import { Container } from "@/components/util/container";
 import { Section } from "@/components/util/section";
@@ -17,9 +17,9 @@ type EventsV2PageProps<T> = {
 const EventsV2Page = memo(
   function EventsV2Page({ tinaProps }: EventsV2PageProps<object>) {
     const { blocks, appearance } = tinaProps.data.eventsv2;
-    useMobileHeaderAppearance(appearance ?? null);
     return (
       <div className="dark flex h-full flex-col">
+        <HeaderAppearanceMarker appearance={appearance} />
         <Section color={"toggleLightMode"}>
           <Container
             size="custom"

--- a/app/components/header-appearance.tsx
+++ b/app/components/header-appearance.tsx
@@ -1,44 +1,27 @@
-"use client";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
-
 export type MobileHeaderAppearance = {
   hideFlag?: boolean | null;
   hideContactButton?: boolean | null;
 };
-type Ctx = {
-  mobile: MobileHeaderAppearance;
-  setMobile: (v: MobileHeaderAppearance) => void;
-};
-const HeaderAppearanceContext = createContext<Ctx>({
-  mobile: {},
-  setMobile: () => {},
-});
 
-export function HeaderAppearanceProvider({
-  children,
+// The header lives in the root layout and can't see the current page's data, so
+// hiding the mobile flag/Contact button used to happen in a client effect AFTER
+// hydration — reflowing the header and everything below it (CLS). Instead, the page
+// server-renders this hidden marker; CSS in styles.css reads it via `:has()` and hides
+// the elements on first paint, so SSR and hydration match. Client-side navigation swaps
+// the marker in/out with the page, so the header updates without any header-side JS.
+// (Middleware `x-pathname` + server resolution — the other documented fix — was rejected:
+// reading headers() in the root layout breaks the `dynamic = "force-static"` routes.)
+export function HeaderAppearanceMarker({
+  appearance,
 }: {
-  children: React.ReactNode;
+  appearance?: MobileHeaderAppearance | null;
 }) {
-  const [mobile, setMobile] = useState<MobileHeaderAppearance>({});
-  const value = useMemo(() => ({ mobile, setMobile }), [mobile]);
+  if (!appearance?.hideFlag && !appearance?.hideContactButton) return null;
   return (
-    <HeaderAppearanceContext.Provider value={value}>
-      {children}
-    </HeaderAppearanceContext.Provider>
+    <div
+      hidden
+      data-mm-hide-flag={appearance.hideFlag ? "" : undefined}
+      data-mm-hide-contact={appearance.hideContactButton ? "" : undefined}
+    />
   );
-}
-
-export const useHeaderAppearance = () => useContext(HeaderAppearanceContext);
-
-// ponytail: client context → SSR shows full header for one frame before hiding flag/
-// contact. Upgrade path if the flash matters: set `x-pathname` in middleware.ts and
-// resolve appearance server-side in app/layout.tsx so the header renders correctly at SSR.
-export function useMobileHeaderAppearance(
-  value: MobileHeaderAppearance | null
-) {
-  const { setMobile } = useHeaderAppearance();
-  useEffect(() => {
-    setMobile(value ?? {});
-    return () => setMobile({});
-  }, [value, setMobile]);
 }

--- a/app/components/page-layout.tsx
+++ b/app/components/page-layout.tsx
@@ -1,5 +1,4 @@
 import { Footer } from "@/components/layout/footer/footer";
-import { HeaderAppearanceProvider } from "./header-appearance";
 
 type PageLayoutProps = {
   children: React.ReactNode;
@@ -12,16 +11,14 @@ const PageLayout = ({
   megaMenu,
 }: PageLayoutProps) => {
   return (
-    <HeaderAppearanceProvider>
-      <div className="flex min-h-screen flex-col">
-        <header className="no-print z-1">
-          {phishingBanner}
-          {megaMenu}
-        </header>
-        <main className="z-0 grow bg-white">{children}</main>
-        <Footer />
-      </div>
-    </HeaderAppearanceProvider>
+    <div className="flex min-h-screen flex-col">
+      <header className="no-print z-1">
+        {phishingBanner}
+        {megaMenu}
+      </header>
+      <main className="z-0 grow bg-white">{children}</main>
+      <Footer />
+    </div>
   );
 };
 

--- a/components/server/MegaMenuWrapper.tsx
+++ b/components/server/MegaMenuWrapper.tsx
@@ -3,19 +3,19 @@
 import classNames from "classnames";
 import { usePathname } from "next/navigation";
 import { MegaMenuLayout } from "ssw.megamenu";
-import { useHeaderAppearance } from "@/app/components/header-appearance";
 import { CustomLink } from "../customLink";
 
 export function MegaMenuWrapper(props) {
   const pathName = usePathname();
-  const { mobile } = useHeaderAppearance();
 
+  // Per-page hiding of the mobile flag/Contact button is handled by CSS reading a
+  // server-rendered marker (see header-appearance.tsx), so the header always renders
+  // both here and stays correct at SSR. Only the contact-us page (known at SSR from the
+  // pathname) hides the phone via the package itself.
   return (
     <MegaMenuLayout
-      hidePhone={
-        pathName === "/company/contact-us" || Boolean(mobile.hideContactButton)
-      }
-      isFlagVisible={!mobile.hideFlag}
+      hidePhone={pathName === "/company/contact-us"}
+      isFlagVisible={true}
       menuBarItems={props.menu}
       tagline="Enterprise Software Development"
       linkComponent={(props) => (

--- a/styles.css
+++ b/styles.css
@@ -288,6 +288,8 @@
  * marker; these rules hide the matching ssw.megamenu elements on first paint instead of
  * after hydration. Selectors target ssw.megamenu@4.13.8 internals — revisit on upgrade.
  * Left unlayered so they beat Tailwind's @layer utilities without !important.
+ * Degrades gracefully where :has() is unsupported (Firefox < 121): the flag/Contact
+ * button simply stay visible — no layout shift, just no opt-out.
  */
 body:has([data-mm-hide-flag]) header .xl\:hidden button:has(img[alt$="flag" i]),
 body:has([data-mm-hide-flag]) header .xl\:hidden .h-4.w-px {

--- a/styles.css
+++ b/styles.css
@@ -281,3 +281,18 @@
     }
   }
 }
+
+/*
+ * Mobile header appearance (CLS fix — see app/components/header-appearance.tsx).
+ * A page that opts out server-renders a hidden [data-mm-hide-flag] / [data-mm-hide-contact]
+ * marker; these rules hide the matching ssw.megamenu elements on first paint instead of
+ * after hydration. Selectors target ssw.megamenu@4.13.8 internals — revisit on upgrade.
+ * Left unlayered so they beat Tailwind's @layer utilities without !important.
+ */
+body:has([data-mm-hide-flag]) header .xl\:hidden button:has(img[alt$="flag" i]),
+body:has([data-mm-hide-flag]) header .xl\:hidden .h-4.w-px {
+  display: none;
+}
+body:has([data-mm-hide-contact]) header .gap-2.sm\:flex-grow-0 {
+  display: none;
+}


### PR DESCRIPTION
Closes #4906 (parent PBI #4894, item 12).

## Root cause

The header (`MegaMenuWrapper`) renders in the root layout, which has no access to the current page's data. So the per-page decision to hide the mobile country flag / Contact button ran in a client `useEffect` (`useMobileHeaderAppearance`) that pushed the page's `appearance` into React context **after hydration**. The header then removed those elements, reflowing itself and everything below it — CLS 0.133 on `/events/ai-for-business-leaders`, which sets both `hideFlag` and `hideContactButton`.

## Fix

Render the final state server-side and let CSS do the hiding, so the first paint is already correct:

- An opting-out page server-renders a hidden marker (`HeaderAppearanceMarker`) carrying `data-mm-hide-flag` / `data-mm-hide-contact`.
- Unlayered CSS in `styles.css` reads it with `body:has([data-mm-hide-flag]) …` and hides the matching `ssw.megamenu` elements. No header-side JS.
- `MegaMenuWrapper` now always renders the flag/Contact button (it only still hides the phone on `/company/contact-us`, which it already knows at SSR from the pathname).
- The client context/provider/hook are removed — CSS covers both SSR **and** client-side navigation (React swaps the marker in/out with the page).

## Why CSS, not the middleware path the comment documented

`header-appearance.tsx` previously suggested an `x-pathname` middleware header + server-side resolution in the layout. I did **not** take that route: reading `headers()` in the **root** layout opts every route out of static generation, and directly conflicts with `export const dynamic = "force-static"` on the events route — it would break the static build for a heavily-cached marketing site. The CSS approach keeps every route static and adds zero runtime cost.

Trade-off to be aware of: the CSS selectors target `ssw.megamenu@4.13.8` internals (the flag `img[alt$="flag"]`, the mobile divider, the `.gap-2.sm:flex-grow-0` phone-button wrapper). The version is pinned; there's a comment to revisit on upgrade. Cleaner long-term would be a stable `data-*` hook or className prop upstreamed into `ssw.megamenu`.

## Expected impact

CLS on `/events/ai-for-business-leaders` should drop from 0.133 toward ~0 for the header contribution, since the flag/Contact button no longer appear-then-disappear.

## Verified

- `pnpm lint` passes (only the pre-existing, unrelated `z-[2]` tailwind warning).
- Prettier clean on all changed files.
- CSS diff kept minimal (existing lines left untouched).

## Still needs manual verification

- `pnpm build` / typecheck could **not** be run here — Tina codegen requires TinaCloud creds (`clientId`/`token`/`branch`), so the generated client isn't present. Please run a full build in CI/locally with creds.
- Re-run mobile Lighthouse on `/events/ai-for-business-leaders` to confirm **CLS < 0.1**.
- Visually check mobile + desktop headers on: homepage, a consulting page, a normal event page (flag + Contact present), and `/events/ai-for-business-leaders` (both hidden, no post-hydration shift). Confirm client-side nav between a hiding page and a non-hiding page updates the header correctly, and no hydration-mismatch warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8genJyZboXaa4vgYhJF4P