### PR TITLE
⚡ Alias @tinacms/mdx to keep its 2 MB markdown parser out of the client bundle

### DIFF
--- a/lib/tinacms-mdx-shim.js
+++ b/lib/tinacms-mdx-shim.js
@@ -1,0 +1,81 @@
+/**
+ * Stand-in for `@tinacms/mdx`, aliased in via `next.config.mjs`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `tinacms/dist/rich-text` — the module behind `<TinaMarkdown>`, imported by 65
+ * components in this repo — starts with:
+ *
+ *     import { sanitizeUrl } from "@tinacms/mdx";
+ *
+ * `@tinacms/mdx` publishes a single "." entry point built with `bundleDeps`, so
+ * that one import drags the whole remark / mdast / micromark / prettier parsing
+ * toolchain into the bundle: 1,973,803 bytes (@tinacms/mdx 2.1.9) to reach a
+ * 22-line URL sanitiser. It was ~1.14 MB minified on the deployed site and the
+ * single largest attributable slice of the page's JavaScript.
+ *
+ * Aliasing the package here keeps `sanitizeUrl` — the only export any browser
+ * code path actually needs — and drops the parser.
+ *
+ * HOW TO REMOVE THIS
+ * ------------------
+ * Upstream tinacms#7232 tracks the same problem and tinacms#7233 adds a
+ * dependency-free `@tinacms/mdx/sanitize-url` subpath. Once that ships in a
+ * release we consume, delete this file and its two aliases in `next.config.mjs`
+ * and bump `tinacms` / `@tinacms/mdx`. See SSW.Website#4896.
+ *
+ * KEEPING IT HONEST
+ * -----------------
+ * `sanitizeUrl` below is a verbatim copy from @tinacms/mdx@2.1.9 (byte-identical
+ * in both `dist/index.js` and `dist/index.browser.js`). If you bump the Tina
+ * packages, re-diff it against the new build before assuming it still matches.
+ */
+
+// Verbatim from @tinacms/mdx@2.1.9 — do not "improve" it; it must match upstream.
+export const sanitizeUrl = (url) => {
+  const allowedSchemes = ["http", "https", "mailto", "tel", "xref"];
+  if (!url) return "";
+  let parsedUrl = null;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    return url;
+  }
+  const scheme = parsedUrl.protocol.slice(0, -1);
+  if (allowedSchemes && !allowedSchemes.includes(scheme)) {
+    // eslint-disable-next-line no-console -- upstream behaviour, kept as-is
+    console.warn(`Invalid URL scheme detected ${scheme}`);
+    return "";
+  }
+  if (parsedUrl.pathname === "/") {
+    if (url.endsWith("/")) {
+      return parsedUrl.href;
+    }
+    return `${parsedUrl.origin}${parsedUrl.search}${parsedUrl.hash}`;
+  } else {
+    return parsedUrl.href;
+  }
+};
+
+/**
+ * The other two exports of `@tinacms/mdx`. Neither runs in a browser on a public
+ * page: `serializeMDX` is reached only from `tinacms/dist/index.js` on the
+ * editor's save path, and `parseMDX` only from the Tina GraphQL layer, which runs
+ * in the `@tinacms/cli` process and in `/admin` — both built outside this Next
+ * config, so both still get the real package.
+ *
+ * They throw rather than returning a plausible-looking value so that if that
+ * assumption is ever wrong we get a loud, traceable failure instead of silently
+ * mangled content.
+ */
+const unavailable = (name) => () => {
+  throw new Error(
+    `${name}() is not available: @tinacms/mdx is aliased to lib/tinacms-mdx-shim.js ` +
+      `to keep the ~2 MB markdown parser out of the browser bundle. If you genuinely ` +
+      `need ${name}() in the Next build, remove the alias in next.config.mjs and ` +
+      `re-measure the bundle. See SSW.Website#4896.`
+  );
+};
+
+export const parseMDX = unavailable("parseMDX");
+export const serializeMDX = unavailable("serializeMDX");

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,11 +4,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 const withNextPluginPreval = createNextPluginPreval();
 
-// Absolute so webpack and Turbopack resolve it identically regardless of cwd.
-const TINACMS_MDX_SHIM = path.join(
+// The two bundlers want this path in different forms, so don't unify them:
+// webpack's resolve.alias needs an absolute path, while Turbopack's resolveAlias
+// resolves values against the project root and prepends "./" to whatever it is
+// given — an absolute path there becomes "./Users/..." and fails to resolve,
+// 500ing every page that renders <TinaMarkdown> under `next dev`.
+const TINACMS_MDX_SHIM_ABS = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "lib/tinacms-mdx-shim.js"
 );
+const TINACMS_MDX_SHIM_REL = "./lib/tinacms-mdx-shim.js";
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -73,7 +78,7 @@ const config = {
     // Remove once tinacms#7233 lands a `@tinacms/mdx/sanitize-url` subpath.
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@tinacms/mdx$": TINACMS_MDX_SHIM,
+      "@tinacms/mdx$": TINACMS_MDX_SHIM_ABS,
     };
 
     return config;
@@ -101,7 +106,7 @@ const config = {
     // Mirrors the webpack alias above — `next dev` uses Turbopack, `next build`
     // uses webpack, so both need it or dev and prod diverge.
     resolveAlias: {
-      "@tinacms/mdx": TINACMS_MDX_SHIM,
+      "@tinacms/mdx": TINACMS_MDX_SHIM_REL,
     },
   },
   experimental: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,14 @@
 import bundleAnalyser from "@next/bundle-analyzer";
 import createNextPluginPreval from "next-plugin-preval/config.js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 const withNextPluginPreval = createNextPluginPreval();
+
+// Absolute so webpack and Turbopack resolve it identically regardless of cwd.
+const TINACMS_MDX_SHIM = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "lib/tinacms-mdx-shim.js"
+);
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -58,6 +66,16 @@ const config = {
       use: ["@svgr/webpack"],
     });
 
+    // `tinacms/dist/rich-text` imports `sanitizeUrl` from `@tinacms/mdx`, whose
+    // single entry point bundles the entire markdown parser (~1.97 MB) to supply
+    // a 22-line function. Swap in a shim that keeps sanitizeUrl and drops the
+    // parser. Exact match ("$") — the package publishes no subpaths.
+    // Remove once tinacms#7233 lands a `@tinacms/mdx/sanitize-url` subpath.
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@tinacms/mdx$": TINACMS_MDX_SHIM,
+    };
+
     return config;
   },
   async rewrites() {
@@ -80,6 +98,11 @@ const config = {
   serverExternalPackages: ["applicationinsights"],
   turbopack: {
     resolveExtensions: [".mdx", ".tsx", ".ts", ".jsx", ".js", ".mjs", ".json"],
+    // Mirrors the webpack alias above — `next dev` uses Turbopack, `next build`
+    // uses webpack, so both need it or dev and prod diverge.
+    resolveAlias: {
+      "@tinacms/mdx": TINACMS_MDX_SHIM,
+    },
   },
   experimental: {
     optimizePackageImports: ["tinacms", "@fortawesome/fontawesome-svg-core"],


### PR DESCRIPTION
- Affected routes: all routes rendering rich text (every page importing `TinaMarkdown` — 65 components), verified on `/events/ai-for-business-leaders`

- Fixed #4896

## TL;DR

`tinacms/dist/rich-text` — the module behind `<TinaMarkdown>` — opens with `import { sanitizeUrl } from "@tinacms/mdx"`, and that package ships a single `bundleDeps` entry point of **1,973,803 bytes** to supply a **22-line** URL sanitiser. This aliases the package to a shim that keeps `sanitizeUrl` and drops the parser; no application code changes.

## Why

On the deployed site, `/events/ai-for-business-leaders` references **5,966,858 bytes of JS across 60 chunks**. `dd3583a7-*.js` — the `@tinacms/mdx` bundle — is **1,142,097** of them, making it the largest single attributable slice of the page's JavaScript and the bulk of Lighthouse's "Reduce unused JavaScript — Est savings of 1,064 KiB".

Reproduce the page total:

```bash
curl -s https://www.ssw.com.au/events/ai-for-business-leaders \
  | grep -o '/_next/static/chunks/[A-Za-z0-9_.-]*\.js' | sort -u \
  | while read c; do curl -s -o /dev/null -w "%{size_download}\n" \
      -H 'Accept-Encoding: identity' "https://www.ssw.com.au$c"; done \
  | awk '{s+=$1} END {print s" bytes"}'
```

Local before/after build figures to follow in a comment.

## Reviewer notes

- **`sanitizeUrl` is copied, not reimplemented.** Verbatim from `@tinacms/mdx@2.1.9` and byte-identical across that package's node and browser builds. If you bump the Tina packages, re-diff it.
- **`parseMDX` / `serializeMDX` throw.** Neither runs in a browser on a public page — `serializeMDX` is reached only from the editor's save path, `parseMDX` only from the Tina GraphQL layer, and both `/admin` and `@tinacms/cli` are built outside this Next config, so both still get the real package. They throw rather than returning a plausible value so a wrong assumption fails loudly instead of silently mangling content.
- **Aliased for both bundlers.** `next dev` uses Turbopack and `next build` uses webpack; wiring only one would let dev and prod diverge silently.
- **This is a stopgap.** tinacms/tinacms#7233 adds a dependency-free `@tinacms/mdx/sanitize-url` subpath that makes the shim unnecessary — delete the file and the two aliases once it ships in a release we consume.

## Tests

- Existing suite green (13/13).
- Differential test of the shim's `sanitizeUrl` against the real export across 31 inputs — allowed and blocked schemes (`javascript:`, `data:`, `vbscript:`, `file:`, `ftp:`), relative paths, anchors, userinfo, explicit ports, and query/hash/trailing-slash combinations: **0 mismatches**, and an identical export surface.

## Links

- Closes #4896
- Parent PBI #4894
- Upstream issue: tinacms/tinacms#7232
- Upstream fix: tinacms/tinacms#7233
- Related, same payload via a different import chain: #4892