### PR TITLE
🐛 Stop fetching 631 KiB of HTML as an image on every page load

### DIFF
--- a/__tests__/components/v2ComponentWrapper.test.tsx
+++ b/__tests__/components/v2ComponentWrapper.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { render } from "@testing-library/react";
+import React from "react";
+
+// useInView needs IntersectionObserver, which jsdom doesn't implement. The
+// fade-in isn't what's under test here, so report "in view" and move on.
+jest.mock("framer-motion", () => ({
+  useInView: () => true,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- must load after the mock above
+const V2ComponentWrapper = require("@/components/layout/v2ComponentWrapper")
+  .default as React.ComponentType<{
+  data: object;
+  children?: React.ReactNode;
+}>;
+
+const renderWrapper = (background: unknown) =>
+  render(
+    <V2ComponentWrapper data={{ background }}>
+      <p>content</p>
+    </V2ComponentWrapper>
+  );
+
+/**
+ * Regression guard for the `url(null)` bug.
+ *
+ * The wrapper used to build `backgroundImage: url(${...})` unconditionally, so a
+ * block with no background produced `background-image: url(null)` or `url()`.
+ * Browsers resolve those against the current path, so on /events/* it fetched
+ * /events/null — answered by the catch-all route with 200 and ~631 KiB of HTML,
+ * at high priority, on every page load. 39 blocks on one page emitted it.
+ */
+describe("V2ComponentWrapper background-image", () => {
+  it.each([
+    ["the key is absent", { backgroundColour: 0 }],
+    ["it is null", { backgroundColour: 0, backgroundImage: null }],
+    ["it is an empty string", { backgroundColour: 0, backgroundImage: "" }],
+    ["there is no background at all", undefined],
+  ])("emits no background-image when %s", (_case, background) => {
+    const { container } = renderWrapper(background);
+    expect(container.innerHTML).not.toContain("background-image");
+  });
+
+  it("still renders a real background image", () => {
+    const { container } = renderWrapper({
+      backgroundColour: 0,
+      backgroundImage: "/images/background/waveBackground.svg",
+    });
+    const section = container.querySelector<HTMLElement>("section section");
+    // jsdom normalises the value to url("…"), so match on the path itself.
+    expect(section?.style.backgroundImage).toContain(
+      "/images/background/waveBackground.svg"
+    );
+    expect(section?.style.backgroundSize).toBe("cover");
+  });
+
+  it("leaves the inline style off when the image is bleeding", () => {
+    // Bleed renders the image as an <Image> instead of an inline background.
+    const { container } = renderWrapper({
+      backgroundColour: 0,
+      backgroundImage: "/images/background/waveBackground.svg",
+      bleed: true,
+    });
+    const section = container.querySelector<HTMLElement>("section section");
+    expect(section?.style.backgroundImage).toBe("");
+  });
+});

--- a/components/layout/v2ComponentWrapper.tsx
+++ b/components/layout/v2ComponentWrapper.tsx
@@ -117,15 +117,20 @@ const V2ComponentWrapper = ({
           isInInitialViewport === false && "opacity-0",
           !isInInitialViewport && isInView && "opacity-100"
         )}
+        // Only emit a background-image when there actually is one. Interpolating a
+        // missing value produced `url(null)` / `url()`, and the browser resolved
+        // those against the current path — on /events/* that fetched /events/null,
+        // which the catch-all route answered with 200 and ~631 KiB of HTML, at high
+        // priority, on every page load.
         style={
-          data.background?.bleed
-            ? {}
-            : {
-                backgroundImage: `url(${data.background?.backgroundImage})`,
+          !data.background?.bleed && data.background?.backgroundImage
+            ? {
+                backgroundImage: `url(${data.background.backgroundImage})`,
                 backgroundSize: "cover",
                 backgroundRepeat: "no-repeat",
                 backgroundPosition: "center",
               }
+            : undefined
         }
       >
         {children}


### PR DESCRIPTION
- Affected routes: every page built from v2/v3 blocks — `eventsv2`, `consultingv2`, v3. Verified on `/events/ai-for-business-leaders`

- Fixed #4898

## TL;DR

`V2ComponentWrapper` built its `background-image` style unconditionally, so blocks with no background emitted `background-image: url(null)`. The browser resolves that against the current path, requests `/events/null`, and the catch-all route answers with **200 and 646,090 bytes of HTML** — downloaded at **High** priority and discarded on every page load. One condition fixes it.

## Why

From a Lighthouse 13.4 run against the deployed page:

```
GET https://www.ssw.com.au/events/null
  resourceType:  Image          priority:      High
  statusCode:    200            transferSize:  646,090 bytes
  mimeType:      text/html
```

**631 KiB — 18.4% of the page's 3,438 KiB total transfer**, second only to the JavaScript, competing for bandwidth during the critical window.

`/events/ai-for-business-leaders` emits 39 bogus styles, one per block:

| Emitted | Count | Effect |
|---|---:|---|
| `background-image:url(null)` | 15 | fetches `/events/null` |
| `background-image:url()` | 24 | empty URL resolves to the document URL |

## Verified

Rendered page, before and after:

| | `url(null)` | `url()` |
|---|---:|---:|
| Production today | 15 | 24 |
| This branch | **0** | **0** |

## Reviewer notes

- **`undefined`, not `{}`.** React omits the attribute entirely rather than emitting an empty `style`.
- **Bleed path untouched.** When `bleed` is set the background renders as an `<Image>`; that branch is unchanged and covered by a test.
- **Scoped deliberately.** #4898 also covers the per-block forced reflow and the framer-motion `useInView` work. Those change visible fade-in behaviour and need their own before/after, so they're left for a follow-up — this PR is just "stop downloading 631 KiB of HTML as an image".

## Tests

6 new cases in `__tests__/components/v2ComponentWrapper.test.tsx`. Four cover the regression — key absent, `null`, `""`, and no `background` object — asserting no `background-image` reaches the DOM. Two cover what must keep working: a real image still renders with `background-size: cover`, and bleed mode still delegates to `<Image>`.

Suite: 19 passing, up from 13.

`useInView` needs `IntersectionObserver`, which jsdom lacks, so the test mocks `framer-motion` — the fade-in isn't what's under test.

Being the repo's first component-rendering test, it surfaces a pre-existing warning about the classic JSX transform in the Jest Babel config. Unrelated to this change; worth fixing separately.

## Follow-up

`/events/null` returning **200 rather than 404** is a separate bug — `page.tsx` does guard `filename === "null"` with `notFound()`, yet the response still carries a 200 and a full body. That's what makes this cost 631 KiB rather than a cheap error. Worth its own issue.

## Links

- Closes #4898
- Parent PBI #4894