### PR TITLE
💸 Perf - Mount the Eventbrite Popup only when it opens

### DIFF
--- a/components/eventbrite/eventbriteModalButton.tsx
+++ b/components/eventbrite/eventbriteModalButton.tsx
@@ -58,6 +58,8 @@ export const EventbriteModalButton = ({
   const reactId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
   const containerId = `eventbrite-checkout-${eventId}-${reactId}`;
   const [open, setOpen] = useState(false);
+  // Gate the Popup on first open so a closed CTA mounts no react-responsive-modal; once opened it stays mounted for the close animation.
+  const [hasOpened, setHasOpened] = useState(false);
   const [scriptLoaded, setScriptLoaded] = useState(false);
   const [scriptFailed, setScriptFailed] = useState(false);
   // The popup portals its content, so bind via the callback ref once the node mounts, not when `open` flips.
@@ -120,49 +122,54 @@ export const EventbriteModalButton = ({
         variant={variant}
         className={className}
         textTinaField={textTinaField}
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          setHasOpened(true);
+          setOpen(true);
+        }}
       >
         {children}
       </RippleButton>
-      {/* Always mounted (for the close animation); the library unmounts contents while closed, resetting the widget. */}
-      <Popup
-        isVisible={open}
-        showCloseIcon
-        onClose={() => setOpen(false)}
-        modalStyle={{
-          maxWidth: CHECKOUT_WIDTH_PX,
-          padding: 0, // padding reads as a white border around the checkout
-          borderRadius: "0.375rem", // rounded-md, matching the site cards
-          overflow: "hidden",
-          background: THEME_SETTINGS.background,
-        }}
-      >
-        {scriptFailed && !scriptLoaded ? (
-          <div className="flex flex-col items-center justify-center gap-4 p-12 text-center">
-            <p>The booking form could not be loaded.</p>
-            <a
-              href={`${EVENTBRITE_DOMAIN}/e/${eventId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-semibold text-sswRed underline"
-            >
-              Register on the Eventbrite event page instead
-            </a>
-          </div>
-        ) : (
-          <div
-            ref={setContainerEl}
-            id={containerId}
-            className="w-full"
-            // Capped height with scroll: Eventbrite sizes the iframe to full height, clipping the pay button in short viewports.
-            style={{
-              height: `min(${CHECKOUT_HEIGHT_PX}px, 85vh)`,
-              overflowY: "auto",
-              backgroundColor: THEME_SETTINGS.background,
-            }}
-          />
-        )}
-      </Popup>
+      {/* Mounted only after the first open; stays mounted thereafter so the close animation plays. The library unmounts contents while closed, resetting the widget. */}
+      {hasOpened && (
+        <Popup
+          isVisible={open}
+          showCloseIcon
+          onClose={() => setOpen(false)}
+          modalStyle={{
+            maxWidth: CHECKOUT_WIDTH_PX,
+            padding: 0, // padding reads as a white border around the checkout
+            borderRadius: "0.375rem", // rounded-md, matching the site cards
+            overflow: "hidden",
+            background: THEME_SETTINGS.background,
+          }}
+        >
+          {scriptFailed && !scriptLoaded ? (
+            <div className="flex flex-col items-center justify-center gap-4 p-12 text-center">
+              <p>The booking form could not be loaded.</p>
+              <a
+                href={`${EVENTBRITE_DOMAIN}/e/${eventId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-sswRed underline"
+              >
+                Register on the Eventbrite event page instead
+              </a>
+            </div>
+          ) : (
+            <div
+              ref={setContainerEl}
+              id={containerId}
+              className="w-full"
+              // Capped height with scroll: Eventbrite sizes the iframe to full height, clipping the pay button in short viewports.
+              style={{
+                height: `min(${CHECKOUT_HEIGHT_PX}px, 85vh)`,
+                overflowY: "auto",
+                backgroundColor: THEME_SETTINGS.background,
+              }}
+            />
+          )}
+        </Popup>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Closes #4904

Each Eventbrite CTA mounted a `react-responsive-modal` `Popup` unconditionally — the old comment kept it always-mounted so the close animation could play. On the AI for Business Leaders page (blocks 5 and 37, eight `EmbeddedCardButton`s) that means eight live modal instances at first paint.

## Change

`components/eventbrite/eventbriteModalButton.tsx` now gates the `Popup` behind a `hasOpened` flag:

- On initial paint `hasOpened` is `false`, so `{hasOpened && <Popup />}` renders nothing — no `react-responsive-modal` instance, no portal, no iframe.
- Clicking a CTA sets `hasOpened` (and `open`) `true`, mounting the Popup and playing the enter animation.
- Once opened it stays mounted, so the close transition still runs; the library unmounts the Popup's children while closed, which already resets the widget.

The deferred script load, the "don't stack a second iframe" guard, the script-timeout fallback link, and the `eventbrite_order_complete` conversion tracking (`sendGTMEvent`) are all untouched.

This is option 1 from the issue (a "has ever opened" flag), the smallest of the three proposed approaches — no page-level refactor, no dep changes.

## Verified

- `pnpm lint` clean (only the pre-existing `z-[2]` Tailwind warning).
- `npx prettier --check` on the changed file clean.
- `npx tsc --noEmit` reports no errors for this file (remaining project errors are the pre-existing `@/tina/client` re-export that only the full dev server emits).
- Code trace: with `hasOpened` false the Popup subtree is not rendered, so no modal DOM or iframe exists until a CTA is clicked; reopening after close re-runs the same open path.

## Left for a human

- A quick manual smoke test in a running dev server (open a CTA, complete/close, open a second card) to confirm the animation feel — the full `pnpm dev` build is memory-heavy in this environment so I verified by code trace and static checks rather than a live click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8genJyZboXaa4vgYhJF4P
