### PR TITLE
⚡ Perf - Defer Application Insights init out of the critical window

### DIFF
--- a/app/components/web-vitals.tsx
+++ b/app/components/web-vitals.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useAppInsightsContext } from "@microsoft/applicationinsights-react-js";
+import { trackWebVital } from "@/context/app-insights-web-vitals-buffer";
 import { usePathname } from "next/navigation";
 import { useReportWebVitals } from "next/web-vitals";
 
 export const WebVitals = () => {
-  const appInsights = useAppInsightsContext();
   const pathname = usePathname();
 
   // Check if Web Vitals tracking is enabled (default: true)
@@ -23,7 +22,9 @@ export const WebVitals = () => {
       case "FID":
       case "CLS":
       case "INP":
-        appInsights?.trackMetric(
+        // Buffered until App Insights loads (init is deferred), then flushed —
+        // so metrics measured before init are not lost.
+        trackWebVital(
           { name: metric.name, average: metric.value },
           { page: `${pathname}` }
         );

--- a/context/app-insight-client.tsx
+++ b/context/app-insight-client.tsx
@@ -4,57 +4,97 @@ import {
   AppInsightsContext,
   ReactPlugin,
 } from "@microsoft/applicationinsights-react-js";
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import React, { ReactNode, useEffect, useMemo } from "react";
+import {
+  flushWebVitals,
+  resetWebVitalsSink,
+} from "./app-insights-web-vitals-buffer";
+
+// Run the callback once the page is idle so App Insights init stays out of the
+// critical/hydration window. Falls back to a timer where requestIdleCallback is
+// unavailable (Safari < 17).
+function whenIdle(cb: () => void): () => void {
+  if (typeof window.requestIdleCallback === "function") {
+    const id = window.requestIdleCallback(cb, { timeout: 5000 });
+    return () => window.cancelIdleCallback(id);
+  }
+  const id = window.setTimeout(cb, 1000);
+  return () => window.clearTimeout(id);
+}
 
 export function AppInsightsProvider({ children }: { children: ReactNode }) {
   const reactPlugin = useMemo(() => new ReactPlugin(), []);
-  useEffect(() => {
-    // Configuration options with defaults for cost optimization
-    const clientSamplingPercentageRaw = parseFloat(
-      process.env.NEXT_PUBLIC_APPINSIGHTS_CLIENT_SAMPLING_PERCENTAGE || "20"
-    );
-    // Validate sampling percentage is between 1 and 100, default to 20 if invalid
-    const clientSamplingPercentage =
-      !isNaN(clientSamplingPercentageRaw) &&
-      clientSamplingPercentageRaw >= 1 &&
-      clientSamplingPercentageRaw <= 100
-        ? clientSamplingPercentageRaw
-        : 20;
 
-    const appInsights = new ApplicationInsights({
-      config: {
-        connectionString: process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
-        extensions: [reactPlugin],
-        samplingPercentage: clientSamplingPercentage, // Apply client-side sampling
-        autoExceptionInstrumented: true, // Always track exceptions
-        autoTrackPageVisitTime: true,
-        enableRequestHeaderTracking: true,
-        enableResponseHeaderTracking: true,
-        enableAjaxErrorStatusText: true,
-        distributedTracingMode: 0,
-        loggingLevelTelemetry: 1,
-        loggingLevelConsole: 1,
-        extensionConfig: {
-          [reactPlugin.identifier]: {},
+  useEffect(() => {
+    let cancelled = false;
+    let appInsights: { unload: () => void } | undefined;
+
+    const init = async () => {
+      // Configuration options with defaults for cost optimization
+      const clientSamplingPercentageRaw = parseFloat(
+        process.env.NEXT_PUBLIC_APPINSIGHTS_CLIENT_SAMPLING_PERCENTAGE || "20"
+      );
+      // Validate sampling percentage is between 1 and 100, default to 20 if invalid
+      const clientSamplingPercentage =
+        !isNaN(clientSamplingPercentageRaw) &&
+        clientSamplingPercentageRaw >= 1 &&
+        clientSamplingPercentageRaw <= 100
+          ? clientSamplingPercentageRaw
+          : 20;
+
+      // Dynamic import keeps the ~ES5 SDK out of the route's initial chunk graph.
+      const { ApplicationInsights } = await import(
+        "@microsoft/applicationinsights-web"
+      );
+      if (cancelled) return;
+
+      const ai = new ApplicationInsights({
+        config: {
+          connectionString:
+            process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
+          extensions: [reactPlugin],
+          samplingPercentage: clientSamplingPercentage, // Apply client-side sampling
+          autoExceptionInstrumented: true, // Always track exceptions
+          autoTrackPageVisitTime: true,
+          enableRequestHeaderTracking: true,
+          enableResponseHeaderTracking: true,
+          enableAjaxErrorStatusText: true,
+          distributedTracingMode: 0,
+          loggingLevelTelemetry: 1,
+          loggingLevelConsole: 1,
+          extensionConfig: {
+            [reactPlugin.identifier]: {},
+          },
+          disablePageUnloadEvents: ["unload"],
         },
-        disablePageUnloadEvents: ["unload"],
-      },
+      });
+
+      if (ai.config.connectionString) {
+        ai.loadAppInsights();
+        appInsights = ai;
+        // Replay any web-vitals measured before the SDK was ready.
+        flushWebVitals((metric, properties) =>
+          reactPlugin.trackMetric(metric, properties)
+        );
+        // eslint-disable-next-line no-console
+        console.log("✅ App Insights - Client Side logging is turned on!");
+        // eslint-disable-next-line no-console
+        console.log(`   📊 Client Sampling: ${clientSamplingPercentage}%`);
+      } else {
+        // eslint-disable-next-line no-console
+        console.log("Client side logging is not turned on!");
+      }
+    };
+
+    const cancelIdle = whenIdle(() => {
+      void init();
     });
 
-    if (appInsights.config.connectionString) {
-      appInsights.loadAppInsights();
-      // eslint-disable-next-line no-console
-      console.log("✅ App Insights - Client Side logging is turned on!");
-      // eslint-disable-next-line no-console
-      console.log(`   📊 Client Sampling: ${clientSamplingPercentage}%`);
-    } else {
-      // eslint-disable-next-line no-console
-      console.log("Client side logging is not turned on!");
-    }
-
     return () => {
-      appInsights.unload();
+      cancelled = true;
+      cancelIdle();
+      resetWebVitalsSink();
+      appInsights?.unload();
     };
   }, [reactPlugin]);
 

--- a/context/app-insights-web-vitals-buffer.test.ts
+++ b/context/app-insights-web-vitals-buffer.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  flushWebVitals,
+  resetWebVitalsSink,
+  trackWebVital,
+} from "./app-insights-web-vitals-buffer";
+
+describe("web-vitals buffer", () => {
+  beforeEach(() => resetWebVitalsSink());
+
+  it("buffers metrics reported before flush, replays them in order, then passes through", () => {
+    const sink = jest.fn();
+
+    // Reported before the SDK is ready -> buffered, not sent yet.
+    trackWebVital({ name: "LCP", average: 1 }, { page: "/a" });
+    trackWebVital({ name: "CLS", average: 2 }, { page: "/a" });
+    expect(sink).not.toHaveBeenCalled();
+
+    // SDK ready -> buffered metrics replay in order.
+    flushWebVitals(sink);
+    expect(sink).toHaveBeenCalledTimes(2);
+    expect(sink).toHaveBeenNthCalledWith(
+      1,
+      { name: "LCP", average: 1 },
+      { page: "/a" }
+    );
+    expect(sink).toHaveBeenNthCalledWith(
+      2,
+      { name: "CLS", average: 2 },
+      { page: "/a" }
+    );
+
+    // Reported after flush -> straight through, no double-send of the buffer.
+    trackWebVital({ name: "INP", average: 3 }, { page: "/b" });
+    expect(sink).toHaveBeenCalledTimes(3);
+    expect(sink).toHaveBeenNthCalledWith(
+      3,
+      { name: "INP", average: 3 },
+      { page: "/b" }
+    );
+  });
+});

--- a/context/app-insights-web-vitals-buffer.test.ts
+++ b/context/app-insights-web-vitals-buffer.test.ts
@@ -39,4 +39,27 @@ describe("web-vitals buffer", () => {
       { page: "/b" }
     );
   });
+
+  it("re-buffers after reset and replays to a fresh sink without double-sending the old one (StrictMode/remount)", () => {
+    const firstSink = jest.fn();
+    trackWebVital({ name: "LCP", average: 1 }, { page: "/a" });
+    flushWebVitals(firstSink);
+    expect(firstSink).toHaveBeenCalledTimes(1);
+
+    // Provider unmounts -> sink cleared, later metrics buffer again.
+    resetWebVitalsSink();
+    trackWebVital({ name: "INP", average: 2 }, { page: "/b" });
+    expect(firstSink).toHaveBeenCalledTimes(1); // no send to the unloaded sink
+
+    // Fresh SDK on remount -> only the post-reset metric replays, once.
+    const secondSink = jest.fn();
+    flushWebVitals(secondSink);
+    expect(secondSink).toHaveBeenCalledTimes(1);
+    expect(secondSink).toHaveBeenNthCalledWith(
+      1,
+      { name: "INP", average: 2 },
+      { page: "/b" }
+    );
+    expect(firstSink).toHaveBeenCalledTimes(1); // old sink never re-fired
+  });
 });

--- a/context/app-insights-web-vitals-buffer.ts
+++ b/context/app-insights-web-vitals-buffer.ts
@@ -1,0 +1,45 @@
+// Buffers web-vitals metrics reported before App Insights finishes loading.
+// Init is deferred out of the critical window (see app-insight-client.tsx), so
+// early metrics (LCP/FCP/TTFB fired during hydration) would otherwise be lost.
+// They queue here and replay on flush once the SDK is ready.
+
+type WebVitalMetric = { name: string; average: number };
+type WebVitalProperties = { page: string };
+
+type MetricSink = (
+  metric: WebVitalMetric,
+  properties: WebVitalProperties
+) => void;
+
+let sink: MetricSink | null = null;
+const buffer: Array<{
+  metric: WebVitalMetric;
+  properties: WebVitalProperties;
+}> = [];
+
+export function trackWebVital(
+  metric: WebVitalMetric,
+  properties: WebVitalProperties
+) {
+  if (sink) {
+    sink(metric, properties);
+  } else {
+    buffer.push({ metric, properties });
+  }
+}
+
+// Called once App Insights has loaded: drains the buffer in order and routes
+// all subsequent metrics straight through.
+export function flushWebVitals(nextSink: MetricSink) {
+  sink = nextSink;
+  for (const { metric, properties } of buffer) {
+    nextSink(metric, properties);
+  }
+  buffer.length = 0;
+}
+
+// Called on provider unmount so metrics buffer again against a fresh SDK
+// (e.g. React StrictMode's mount/unmount/mount in dev).
+export function resetWebVitalsSink() {
+  sink = null;
+}


### PR DESCRIPTION
Closes #4903

## What

`context/app-insight-client.tsx` built the full `@microsoft/applicationinsights-web` SDK and called `loadAppInsights()` synchronously in a mount effect on every page, landing in the hydration window (contributes to TBT / long tasks), and the SDK shipped in the route's initial chunk.

- Defer init to idle time: `requestIdleCallback` with a 5s `timeout`, falling back to `setTimeout` for Safari (< 17) that lacks it. Effect cleanup cancels the scheduled callback and unloads the SDK.
- Dynamically `import("@microsoft/applicationinsights-web")` inside the deferred callback, so the SDK is no longer in the route's initial JS entry.
- Buffer web-vitals metrics reported before the SDK is ready, and flush them in order on init, so telemetry measured during hydration (LCP/FCP/TTFB) is not lost.

The `ReactPlugin` (from the lightweight `applicationinsights-react-js`, already in the graph via the error handlers) is still created eagerly and provided via context, so `error-boundary` / `global-error-handler` keep working; only the heavy `-web` SDK is deferred. Server-side telemetry (`serverExternalPackages: ["applicationinsights"]`) is untouched.

## Files

- `context/app-insight-client.tsx` — defer + dynamic import + flush on load.
- `context/app-insights-web-vitals-buffer.ts` — small shared buffer (`trackWebVital` / `flushWebVitals` / `resetWebVitalsSink`).
- `app/components/web-vitals.tsx` — route metrics through the buffer instead of the context plugin directly.
- `context/app-insights-web-vitals-buffer.test.ts` — jest test asserting buffered metrics replay in order once, then pass straight through.

## Verified

- `npx jest` on the buffer test — passes.
- `npx tsc --noEmit -p tsconfig.json` — no new type errors (Tina client generated locally via `tinacms dev`).
- `npx prettier --check` and `npx eslint` on the changed files — clean.
- `pnpm dev` serves the homepage 200. Note: `NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING` is unset locally, so client telemetry no-ops here — the actual arrival of page views / exceptions / web vitals in App Insights needs confirming against a deployed environment with the connection string set, and TBT improvement confirmed with a fresh Lighthouse run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8genJyZboXaa4vgYhJF4P