### PR TITLE
💸 Raise image minimumCacheTTL so optimised images stay cached

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const config = {
   },
   images: {
     deviceSizes: [384, 640, 750, 828, 1080, 1200, 1440, 1920, 2048, 3840],
-    minimumCacheTTL: 60,
+    minimumCacheTTL: 31536000,
 
     remotePatterns: [
       {


### PR DESCRIPTION
Closes #4902

`next.config.mjs` set `images.minimumCacheTTL: 60`, so every `/_next/image` response carried a 60-second cache lifetime — repeat visitors and multi-page sessions re-downloaded (and the server re-optimised) every image. This is Lighthouse's "Use efficient cache lifetimes" finding.

Raised it to a year (`31536000`), the usual choice. Optimised image URLs are keyed on source path + width + quality, so changing an image in Tina produces a new upload path and therefore a new URL — the long TTL is safe and doesn't require a manual purge.

One-line change; the rest of the `images` block is untouched to avoid conflicts with the other open PRs on this file.

**Note:** the acceptance criteria also ask to confirm the CDN/host in front of the app isn't overriding the `Cache-Control` header and to re-run Lighthouse — those verifications need a deploy and should be checked on the preview/staging slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8genJyZboXaa4vgYhJF4P