### PR TITLE
💸 Perf - Early-return ButtonRow before its layout-measuring hooks

### DIFF
--- a/components/blocksSubtemplates/buttonRow.tsx
+++ b/components/blocksSubtemplates/buttonRow.tsx
@@ -8,7 +8,16 @@ import React, { useCallback, useRef, useState } from "react";
 import { useResizeObserver } from "usehooks-ts";
 import { Button } from "../button/templateButton";
 
+// Outer guard: bail out before any hooks when there's nothing to render, so the
+// 13-of-14 button rows on a page that carry no buttons don't create a
+// ResizeObserver or read layout. All layout-measuring hooks live in the inner
+// component, which only mounts when buttons exist.
 const ButtonRow = ({ className, data }) => {
+  if (!(data.buttons?.length > 0)) return null;
+  return <ButtonRowInner className={className} data={data} />;
+};
+
+const ButtonRowInner = ({ className, data }) => {
   const buttonContainer = useRef<HTMLDivElement>(null);
   const buttonRefs = useRef<HTMLButtonElement[]>([]);
   const [buttonIsFullWidth, setButtonIsFullWidth] = useState(false);
@@ -51,72 +60,68 @@ const ButtonRow = ({ className, data }) => {
 
   useResizeObserver({ ref: buttonContainer, onResize: measure });
   return (
-    <>
-      {data.buttons?.length > 0 && (
-        <div
-          ref={buttonContainer}
-          className={classNames("mt-5 flex flex-wrap gap-3", className)}
-        >
-          {data.buttons?.map((button, index) => {
-            const buttonElement = (
-              <Button
-                ref={(node) => {
-                  buttonRefs.current[index] = node;
-                  return () => {
-                    if (fullWidthButtonIndex.current === index) {
-                      fullWidthButtonIndex.current = null;
-                    }
-                    delete buttonRefs.current[index];
-                  };
-                }}
-                className={cn(
-                  "text-base font-semibold",
-                  index !== fullWidthButtonIndex.current &&
-                    buttonIsFullWidth &&
-                    "w-full sm:w-auto"
-                )}
-                key={`image-text-button-${index}`}
-                data={button}
-              />
-            );
+    <div
+      ref={buttonContainer}
+      className={classNames("mt-5 flex flex-wrap gap-3", className)}
+    >
+      {data.buttons?.map((button, index) => {
+        const buttonElement = (
+          <Button
+            ref={(node) => {
+              buttonRefs.current[index] = node;
+              return () => {
+                if (fullWidthButtonIndex.current === index) {
+                  fullWidthButtonIndex.current = null;
+                }
+                delete buttonRefs.current[index];
+              };
+            }}
+            className={cn(
+              "text-base font-semibold",
+              index !== fullWidthButtonIndex.current &&
+                buttonIsFullWidth &&
+                "w-full sm:w-auto"
+            )}
+            key={`image-text-button-${index}`}
+            data={button}
+          />
+        );
 
-            const isInPageAnchor = button.buttonLink?.startsWith("#");
+        const isInPageAnchor = button.buttonLink?.startsWith("#");
 
-            return button.buttonLink && !button.leadCaptureFormOption ? (
-              isInPageAnchor ? (
-                <a
-                  className={cn(buttonIsFullWidth && "w-full sm:w-auto")}
-                  href={button.buttonLink}
-                  key={`link-wrapper-${index}`}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    const target = document.getElementById(
-                      button.buttonLink.slice(1)
-                    );
-                    target?.scrollIntoView({ behavior: "smooth" });
-                    history.replaceState(null, "", button.buttonLink);
-                  }}
-                >
-                  {buttonElement}
-                </a>
-              ) : (
-                <Link
-                  className={cn(buttonIsFullWidth && "w-full sm:w-auto")}
-                  href={button.buttonLink}
-                  key={`link-wrapper-${index}`}
-                >
-                  {buttonElement}
-                </Link>
-              )
-            ) : (
-              <React.Fragment key={`button-fragment-${index}`}>
-                {buttonElement}
-              </React.Fragment>
-            );
-          })}
-        </div>
-      )}
-    </>
+        return button.buttonLink && !button.leadCaptureFormOption ? (
+          isInPageAnchor ? (
+            <a
+              className={cn(buttonIsFullWidth && "w-full sm:w-auto")}
+              href={button.buttonLink}
+              key={`link-wrapper-${index}`}
+              onClick={(e) => {
+                e.preventDefault();
+                const target = document.getElementById(
+                  button.buttonLink.slice(1)
+                );
+                target?.scrollIntoView({ behavior: "smooth" });
+                history.replaceState(null, "", button.buttonLink);
+              }}
+            >
+              {buttonElement}
+            </a>
+          ) : (
+            <Link
+              className={cn(buttonIsFullWidth && "w-full sm:w-auto")}
+              href={button.buttonLink}
+              key={`link-wrapper-${index}`}
+            >
+              {buttonElement}
+            </Link>
+          )
+        ) : (
+          <React.Fragment key={`button-fragment-${index}`}>
+            {buttonElement}
+          </React.Fragment>
+        );
+      })}
+    </div>
   );
 };
 


### PR DESCRIPTION
Closes #4900

`ButtonRow` called `useResizeObserver` and read `clientWidth` on every mount because the `data.buttons?.length > 0` check lived in the returned JSX, after the hooks. On the AI for Business Leaders page, 13 of the 14 button rows carry no buttons yet each still spun up a ResizeObserver and performed layout reads for a row that renders nothing.

## Change

Split the component in two, keeping hooks unconditional (Rules of Hooks):

- Outer `ButtonRow` does the cheap empty check and returns `null` before any hooks when `data.buttons` is empty.
- New `ButtonRowInner` owns all the layout-measuring hooks (`useResizeObserver`, the refs, `measure`) and only mounts when there are buttons — so its hooks always run in the same order.

The full-width-button measuring logic is unchanged; the redundant `data.buttons?.length > 0 &&` JSX guard was dropped since the outer guard already guarantees a non-empty array.

## Verification

- `npx eslint` on the changed file — clean (react-hooks/rules-of-hooks and exhaustive-deps both pass).
- `npx prettier --check` — clean.
- `npx tsc --noEmit` (with the Tina client generated locally) — no new errors.

Acceptance criteria: no ResizeObserver/layout reads when there are no buttons ✅; full-width behaviour preserved where buttons exist ✅; no hooks-order warnings ✅. The full-width behaviour on the hero block at mobile/desktop widths is worth a quick human eyeball since it wasn't runtime-tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8genJyZboXaa4vgYhJF4P