### PR TITLE
⚡ Defer Google Tag Manager to lazyOnload

### DIFF
--- a/app/components/google-tag-manager-lazy.tsx
+++ b/app/components/google-tag-manager-lazy.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Script from "next/script";
+
+// GTM injects every marketing/analytics tag on the site (GA4, Google Ads,
+// Facebook, Hotjar, LinkedIn, Bing, Clarity, Plausible). @next/third-parties'
+// <GoogleTagManager> hardcodes strategy="afterInteractive", loading all of that
+// during hydration and contending with first paint. lazyOnload defers the whole
+// stack to browser idle after the load event. sendGTMEvent still queues into
+// dataLayer before GTM boots, so no events are lost.
+export function GoogleTagManagerLazy({ gtmId }: { gtmId?: string }) {
+  if (!gtmId) return null;
+  return (
+    <Script id="gtm-lazy" strategy="lazyOnload">
+      {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${gtmId}');`}
+    </Script>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { HomeThemeBoundary } from "@/components/layout/homeTheme";
 import { MegaMenuWrapper } from "@/components/server/MegaMenuWrapper";
 import { AppInsightsProvider } from "@/context/app-insight-client";
 import { EventInfoStatic } from "@/services/server/events-types";
-import { GoogleTagManager } from "@next/third-parties/google";
+import { GoogleTagManagerLazy } from "./components/google-tag-manager-lazy";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import isBetween from "dayjs/plugin/isBetween";
@@ -77,7 +77,7 @@ export default async function RootLayout({
             </PageLayout>
           </HomeThemeBoundary>
 
-          <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GOOGLE_GTM_ID} />
+          <GoogleTagManagerLazy gtmId={process.env.NEXT_PUBLIC_GOOGLE_GTM_ID} />
           <ChatBaseBot />
         </QueryProvider>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -76,10 +76,9 @@ export default async function RootLayout({
               {/* </Theme> */}
             </PageLayout>
           </HomeThemeBoundary>
-
-          <GoogleTagManagerLazy gtmId={process.env.NEXT_PUBLIC_GOOGLE_GTM_ID} />
-          <ChatBaseBot />
         </QueryProvider>
+        <GoogleTagManagerLazy gtmId={process.env.NEXT_PUBLIC_GOOGLE_GTM_ID} />
+        <ChatBaseBot />
       </body>
     </html>
   );


### PR DESCRIPTION
## TL;DR

GTM injects every marketing/analytics tag on the site (GA4, Google Ads, Facebook, Hotjar, LinkedIn, Bing, Clarity, Plausible) — ~820 KiB across ~19 requests — and `@next/third-parties` loads it `afterInteractive`, i.e. during hydration where it contends with first paint. This switches GTM to `lazyOnload` so the whole tracker stack fires at browser idle after the load event, moving its main-thread work out of the TBT window.

## Why

On `/events/ai-for-business-leaders`, the ~19 third-party requests all fire from ~825ms and execute on the main thread through the critical window — the dominant contributor to TBT (690ms lab) and the reason the mobile PageSpeed score swings 50↔90 between runs. All of them come from this one GTM container.

## How

`@next/third-parties`' `<GoogleTagManager>` hardcodes `strategy="afterInteractive"` with no override. Replaced it with a small client component that renders the canonical GTM install snippet via `next/script` at `strategy="lazyOnload"`. `sendGTMEvent` (one caller, the Eventbrite modal) self-initialises `dataLayer`, so events fired before GTM boots still queue and flush on load — no lost events.

## Reviewer notes

- **Marketing sign-off needed.** Tags fire later, so very-early pageviews / first-second clicks may be undercounted. Whoever owns GA4/Ads attribution should OK this before merge.
- **Package stays.** `@next/third-parties` is still a dep for `sendGTMEvent`; only the loader component changed.

## Tests

The real TBT delta only appears where the GTM container is configured (preview/prod env), so it needs measuring on the preview deploy — locally `NEXT_PUBLIC_GOOGLE_GTM_ID` is unset and GTM doesn't load at all. Verify on preview: GTM/tags fire after the load event (not during hydration), and TBT drops versus production.

## Links

Closes #4891
Closes #4908

🤖 Generated with [Claude Code](https://claude.com/claude-code)