### PR TITLE
⚡ Stop the fade-in wrapper hiding content that has already painted

### DIFF
--- a/components/layout/v2ComponentWrapper.tsx
+++ b/components/layout/v2ComponentWrapper.tsx
@@ -1,10 +1,8 @@
 "use client";
 import classNames from "classnames";
-import { useInView } from "framer-motion";
 import Image from "next/image";
 
-import { UseInViewOptions } from "framer-motion";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { backgroundOptions } from "../blocksSubtemplates/tinaFormElements/colourOptions/blockBackgroundOptions";
 
 type BackgroundData = {
@@ -18,6 +16,38 @@ type BackgroundData = {
   };
 };
 
+// "pending" until the observer's first report, so a block never goes
+// visible→hidden after paint — hiding painted content disqualifies it as an
+// LCP candidate.
+const useFadeIn = (rootMargin: string) => {
+  const ref = useRef<HTMLElement>(null);
+  const [state, setState] = useState<"pending" | "hidden" | "visible">(
+    "pending"
+  );
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setState("visible");
+          observer.disconnect();
+        } else {
+          setState((current) => (current === "pending" ? "hidden" : current));
+        }
+      },
+      { rootMargin }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  return [ref, state] as const;
+};
+
 const V2ComponentWrapper = ({
   data,
   children,
@@ -26,7 +56,7 @@ const V2ComponentWrapper = ({
 }: {
   data: BackgroundData;
   children: React.ReactNode;
-  fadeInMargin?: UseInViewOptions["margin"];
+  fadeInMargin?: string;
   className?: string;
 }) => {
   //Bleed effect setup
@@ -47,13 +77,7 @@ const V2ComponentWrapper = ({
     };
   }, []);
 
-  //Fade-in effect setup
-  const ref = useRef(null);
-  const isInView = useInView(ref, { once: true, margin: fadeInMargin });
-  useEffect(() => {
-    setIsInInitialViewport(isInView);
-  }, [isInView]);
-  const [isInInitialViewport, setIsInInitialViewport] = React.useState(null);
+  const [ref, fadeState] = useFadeIn(fadeInMargin);
 
   return (
     <section
@@ -114,8 +138,8 @@ const V2ComponentWrapper = ({
         ref={ref}
         className={classNames(
           "relative z-30 transition-opacity duration-300",
-          isInInitialViewport === false && "opacity-0",
-          !isInInitialViewport && isInView && "opacity-100"
+          fadeState === "hidden" && "opacity-0",
+          fadeState === "visible" && "opacity-100"
         )}
         // Only emit a background-image when there actually is one. Interpolating a
         // missing value produced `url(null)` / `url()`, and the browser resolved


### PR DESCRIPTION
## TL;DR

On hydration every `V2ComponentWrapper` flipped to `opacity-0` and faded back over 300ms — 39 of them on `/events/ai-for-business-leaders`, including the one wrapping the LCP element. Chrome will not accept an `opacity: 0` element as an LCP candidate, so the LCP element stayed disqualified until the fade finished.

## Why

`useInView` returns `false` on the first client render, before its IntersectionObserver has reported. The old effect wrote that `false` straight into state, which retroactively hid content that had already painted from SSR.

PageSpeed on that page shows FCP 1.3s against LCP 2.9s, with Speed Index 1.7s and CLS 0 — the viewport is visually settled more than a second before Chrome records the LCP, which is the signature of an element that is on screen but ineligible.

## How

`useFadeIn` replaces the `useInView` + effect + `useState` trio with a three-state machine. A block stays `"pending"` (no opacity class) until the observer's first report, so it can only ever go hidden → visible, never visible → hidden.

## Reviewer notes

- **Above-the-fold blocks never hide.** They stay `"pending"` and get no opacity class at all, which is the fix.
- **Below-the-fold blocks still fade.** The observer reports them off-screen, they go `"hidden"`, and fade in on scroll. The user cannot see that transition and it cannot affect LCP.
- **Opacity, not `display`.** Deliberately kept — `display: none` would disqualify the LCP element just the same, and would drop blocks out of layout and break the current CLS of 0.
- **`framer-motion` dropped from this component.** Negative `rootMargin` on a raw `IntersectionObserver` matches what its `margin` option did. `fadeInMargin` is retyped `string`; no caller passes it, so every block keeps the `-100px` default.

## Verify

LCP is the metric to watch, not the overall score. Single PageSpeed runs on this page fluctuate heavily — `.lighthouserc.json` is still `"numberOfRuns": 1` on the desktop preset, so compare medians over ~5 mobile runs before and after.