### PR TITLE
⚡ Load Application Insights on demand instead of in every page bundle

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,8 +1,6 @@
 "use client";
 import { MegaMenuWrapper } from "@/components/server/MegaMenuWrapper";
 import { ErrorPage } from "@/components/util/error-page";
-import { ReactPlugin } from "@microsoft/applicationinsights-react-js";
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import { inter } from "@/lib/fonts";
 import { useEffect } from "react";
 import "styles.css";
@@ -14,42 +12,50 @@ import PageLayout from "./components/page-layout";
 
 export default function GlobalError({ error }: { error: Error }) {
   useEffect(() => {
-    const reactPlugin = new ReactPlugin();
-    const appInsights = new ApplicationInsights({
-      config: {
-        connectionString: process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
-        extensions: [reactPlugin],
-        autoExceptionInstrumented: true,
-        autoTrackPageVisitTime: true,
-        enableRequestHeaderTracking: true,
-        enableResponseHeaderTracking: true,
-        enableAjaxErrorStatusText: true,
-        distributedTracingMode: 0,
-        loggingLevelTelemetry: 1,
-        loggingLevelConsole: 1,
-        extensionConfig: {
-          [reactPlugin.identifier]: {},
-        },
-        disablePageUnloadEvents: ["unload"],
-      },
-    });
-
-    if (appInsights.config.connectionString) {
-      appInsights.loadAppInsights();
-      appInsights.trackException({
-        exception: error,
-        properties: {
-          Request: `GET /${window?.location?.pathname || "unknown"}`,
-          Type: "ErrorBoundary",
-          ErrorInfo: error.stack || error.message,
+    // Loaded on demand so the SDK stays out of the bundle every page ships —
+    // this boundary only renders when the root layout throws.
+    void Promise.all([
+      import("@microsoft/applicationinsights-react-js"),
+      import("@microsoft/applicationinsights-web"),
+    ]).then(([{ ReactPlugin }, { ApplicationInsights }]) => {
+      const reactPlugin = new ReactPlugin();
+      const appInsights = new ApplicationInsights({
+        config: {
+          connectionString:
+            process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
+          extensions: [reactPlugin],
+          autoExceptionInstrumented: true,
+          autoTrackPageVisitTime: true,
+          enableRequestHeaderTracking: true,
+          enableResponseHeaderTracking: true,
+          enableAjaxErrorStatusText: true,
+          distributedTracingMode: 0,
+          loggingLevelTelemetry: 1,
+          loggingLevelConsole: 1,
+          extensionConfig: {
+            [reactPlugin.identifier]: {},
+          },
+          disablePageUnloadEvents: ["unload"],
         },
       });
-    } else {
-      // eslint-disable-next-line no-console
-      console.error(
-        "Failed to log root layout exception to Application Insights!"
-      );
-    }
+
+      if (appInsights.config.connectionString) {
+        appInsights.loadAppInsights();
+        appInsights.trackException({
+          exception: error,
+          properties: {
+            Request: `GET /${window?.location?.pathname || "unknown"}`,
+            Type: "ErrorBoundary",
+            ErrorInfo: error.stack || error.message,
+          },
+        });
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(
+          "Failed to log root layout exception to Application Insights!"
+        );
+      }
+    });
   }, [error]);
 
   const errorDetails = error.stack || error.message;

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { MegaMenuWrapper } from "@/components/server/MegaMenuWrapper";
 import { ErrorPage } from "@/components/util/error-page";
+import { loadAppInsights } from "@/lib/app-insights";
 import { inter } from "@/lib/fonts";
 import { useEffect } from "react";
 import "styles.css";
@@ -12,35 +13,21 @@ import PageLayout from "./components/page-layout";
 
 export default function GlobalError({ error }: { error: Error }) {
   useEffect(() => {
-    // Loaded on demand so the SDK stays out of the bundle every page ships —
-    // this boundary only renders when the root layout throws.
-    void Promise.all([
-      import("@microsoft/applicationinsights-react-js"),
-      import("@microsoft/applicationinsights-web"),
-    ]).then(([{ ReactPlugin }, { ApplicationInsights }]) => {
-      const reactPlugin = new ReactPlugin();
-      const appInsights = new ApplicationInsights({
-        config: {
-          connectionString:
-            process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
-          extensions: [reactPlugin],
-          autoExceptionInstrumented: true,
-          autoTrackPageVisitTime: true,
-          enableRequestHeaderTracking: true,
-          enableResponseHeaderTracking: true,
-          enableAjaxErrorStatusText: true,
-          distributedTracingMode: 0,
-          loggingLevelTelemetry: 1,
-          loggingLevelConsole: 1,
-          extensionConfig: {
-            [reactPlugin.identifier]: {},
-          },
-          disablePageUnloadEvents: ["unload"],
-        },
-      });
-
-      if (appInsights.config.connectionString) {
-        appInsights.loadAppInsights();
+    // This boundary replaces the root layout, so AppInsightsProvider is not in
+    // the tree — it needs its own plugin and instance. No samplingPercentage:
+    // every root-layout crash should be reported.
+    void import("@microsoft/applicationinsights-react-js")
+      .then(({ ReactPlugin }) =>
+        loadAppInsights({ reactPlugin: new ReactPlugin() })
+      )
+      .then((appInsights) => {
+        if (!appInsights) {
+          // eslint-disable-next-line no-console
+          console.error(
+            "Failed to log root layout exception to Application Insights!"
+          );
+          return;
+        }
         appInsights.trackException({
           exception: error,
           properties: {
@@ -49,13 +36,7 @@ export default function GlobalError({ error }: { error: Error }) {
             ErrorInfo: error.stack || error.message,
           },
         });
-      } else {
-        // eslint-disable-next-line no-console
-        console.error(
-          "Failed to log root layout exception to Application Insights!"
-        );
-      }
-    });
+      });
   }, [error]);
 
   const errorDetails = error.stack || error.message;

--- a/context/app-insight-client.tsx
+++ b/context/app-insight-client.tsx
@@ -4,7 +4,6 @@ import {
   AppInsightsContext,
   ReactPlugin,
 } from "@microsoft/applicationinsights-react-js";
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import React, { ReactNode, useEffect, useMemo } from "react";
 
 export function AppInsightsProvider({ children }: { children: ReactNode }) {
@@ -22,39 +21,54 @@ export function AppInsightsProvider({ children }: { children: ReactNode }) {
         ? clientSamplingPercentageRaw
         : 20;
 
-    const appInsights = new ApplicationInsights({
-      config: {
-        connectionString: process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
-        extensions: [reactPlugin],
-        samplingPercentage: clientSamplingPercentage, // Apply client-side sampling
-        autoExceptionInstrumented: true, // Always track exceptions
-        autoTrackPageVisitTime: true,
-        enableRequestHeaderTracking: true,
-        enableResponseHeaderTracking: true,
-        enableAjaxErrorStatusText: true,
-        distributedTracingMode: 0,
-        loggingLevelTelemetry: 1,
-        loggingLevelConsole: 1,
-        extensionConfig: {
-          [reactPlugin.identifier]: {},
-        },
-        disablePageUnloadEvents: ["unload"],
-      },
-    });
+    let loaded: { unload: () => void } | undefined;
+    let unmounted = false;
 
-    if (appInsights.config.connectionString) {
-      appInsights.loadAppInsights();
-      // eslint-disable-next-line no-console
-      console.log("✅ App Insights - Client Side logging is turned on!");
-      // eslint-disable-next-line no-console
-      console.log(`   📊 Client Sampling: ${clientSamplingPercentage}%`);
-    } else {
-      // eslint-disable-next-line no-console
-      console.log("Client side logging is not turned on!");
-    }
+    // applicationinsights-web is ~271 KB and nothing renders from it, so it is
+    // imported here rather than at module scope to keep it out of the bundle
+    // every page loads up front.
+    void import("@microsoft/applicationinsights-web").then(
+      ({ ApplicationInsights }) => {
+        if (unmounted) return;
+
+        const appInsights = new ApplicationInsights({
+          config: {
+            connectionString:
+              process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
+            extensions: [reactPlugin],
+            samplingPercentage: clientSamplingPercentage, // Apply client-side sampling
+            autoExceptionInstrumented: true, // Always track exceptions
+            autoTrackPageVisitTime: true,
+            enableRequestHeaderTracking: true,
+            enableResponseHeaderTracking: true,
+            enableAjaxErrorStatusText: true,
+            distributedTracingMode: 0,
+            loggingLevelTelemetry: 1,
+            loggingLevelConsole: 1,
+            extensionConfig: {
+              [reactPlugin.identifier]: {},
+            },
+            disablePageUnloadEvents: ["unload"],
+          },
+        });
+
+        if (appInsights.config.connectionString) {
+          appInsights.loadAppInsights();
+          loaded = appInsights;
+          // eslint-disable-next-line no-console
+          console.log("✅ App Insights - Client Side logging is turned on!");
+          // eslint-disable-next-line no-console
+          console.log(`   📊 Client Sampling: ${clientSamplingPercentage}%`);
+        } else {
+          // eslint-disable-next-line no-console
+          console.log("Client side logging is not turned on!");
+        }
+      }
+    );
 
     return () => {
-      appInsights.unload();
+      unmounted = true;
+      loaded?.unload();
     };
   }, [reactPlugin]);
 

--- a/context/app-insight-client.tsx
+++ b/context/app-insight-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { loadAppInsights } from "@/lib/app-insights";
 import {
   AppInsightsContext,
   ReactPlugin,
@@ -21,50 +22,29 @@ export function AppInsightsProvider({ children }: { children: ReactNode }) {
         ? clientSamplingPercentageRaw
         : 20;
 
-    let loaded: { unload: () => void } | undefined;
+    let loaded: { unload: () => void } | null = null;
     let unmounted = false;
 
-    // applicationinsights-web is ~271 KB and nothing renders from it, so it is
-    // imported here rather than at module scope to keep it out of the bundle
-    // every page loads up front.
-    void import("@microsoft/applicationinsights-web").then(
-      ({ ApplicationInsights }) => {
-        if (unmounted) return;
-
-        const appInsights = new ApplicationInsights({
-          config: {
-            connectionString:
-              process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING,
-            extensions: [reactPlugin],
-            samplingPercentage: clientSamplingPercentage, // Apply client-side sampling
-            autoExceptionInstrumented: true, // Always track exceptions
-            autoTrackPageVisitTime: true,
-            enableRequestHeaderTracking: true,
-            enableResponseHeaderTracking: true,
-            enableAjaxErrorStatusText: true,
-            distributedTracingMode: 0,
-            loggingLevelTelemetry: 1,
-            loggingLevelConsole: 1,
-            extensionConfig: {
-              [reactPlugin.identifier]: {},
-            },
-            disablePageUnloadEvents: ["unload"],
-          },
-        });
-
-        if (appInsights.config.connectionString) {
-          appInsights.loadAppInsights();
-          loaded = appInsights;
-          // eslint-disable-next-line no-console
-          console.log("✅ App Insights - Client Side logging is turned on!");
-          // eslint-disable-next-line no-console
-          console.log(`   📊 Client Sampling: ${clientSamplingPercentage}%`);
-        } else {
-          // eslint-disable-next-line no-console
-          console.log("Client side logging is not turned on!");
-        }
+    void loadAppInsights({
+      reactPlugin,
+      samplingPercentage: clientSamplingPercentage,
+    }).then((appInsights) => {
+      if (unmounted) {
+        appInsights?.unload();
+        return;
       }
-    );
+
+      loaded = appInsights;
+      if (appInsights) {
+        // eslint-disable-next-line no-console
+        console.log("✅ App Insights - Client Side logging is turned on!");
+        // eslint-disable-next-line no-console
+        console.log(`   📊 Client Sampling: ${clientSamplingPercentage}%`);
+      } else {
+        // eslint-disable-next-line no-console
+        console.log("Client side logging is not turned on!");
+      }
+    });
 
     return () => {
       unmounted = true;

--- a/lib/app-insights.ts
+++ b/lib/app-insights.ts
@@ -1,0 +1,52 @@
+import type { ReactPlugin } from "@microsoft/applicationinsights-react-js";
+
+type LoadOptions = {
+  reactPlugin: ReactPlugin;
+  /**
+   * Omitted by the global error boundary — sampling away four in five fatal
+   * errors would defeat the point of a crash reporter.
+   */
+  samplingPercentage?: number;
+};
+
+/**
+ * Resolves to null when no connection string is configured, so callers can log
+ * their own message. applicationinsights-web is ~271 KB and nothing renders
+ * from it, so it is imported here rather than at module scope to keep it out of
+ * the bundle every page loads up front.
+ */
+export async function loadAppInsights({
+  reactPlugin,
+  samplingPercentage,
+}: LoadOptions) {
+  const connectionString =
+    process.env.NEXT_PUBLIC_APP_INSIGHT_CONNECTION_STRING;
+  if (!connectionString) return null;
+
+  const { ApplicationInsights } = await import(
+    "@microsoft/applicationinsights-web"
+  );
+
+  const appInsights = new ApplicationInsights({
+    config: {
+      connectionString,
+      extensions: [reactPlugin],
+      ...(samplingPercentage !== undefined && { samplingPercentage }),
+      autoExceptionInstrumented: true,
+      autoTrackPageVisitTime: true,
+      enableRequestHeaderTracking: true,
+      enableResponseHeaderTracking: true,
+      enableAjaxErrorStatusText: true,
+      distributedTracingMode: 0,
+      loggingLevelTelemetry: 1,
+      loggingLevelConsole: 1,
+      extensionConfig: {
+        [reactPlugin.identifier]: {},
+      },
+      disablePageUnloadEvents: ["unload"],
+    },
+  });
+
+  appInsights.loadAppInsights();
+  return appInsights;
+}


### PR DESCRIPTION
## TL;DR

`@microsoft/applicationinsights-web` was imported at module scope by two client components in the root layout, so every page on the site downloaded and parsed ~138 KB of telemetry SDK before hydration. Neither renders anything from it — both construct the SDK inside `useEffect` — so both now import it dynamically.

**Eager JS on `/events/ai-for-business-leaders`: 1,202,372 → 1,063,976 bytes**, one fewer eager chunk, and the SDK moves to an async chunk that no longer blocks hydration.

## Why

That page is 85% JavaScript by transfer size — 1,327 KiB across 77 script requests, against 42 KiB of images and 4 KiB of CSS. Mobile LCP is 89% "render delay" with zero resource load time, i.e. the paint is waiting on the main thread rather than on any download. Telemetry that only runs after mount has no business being in that critical path.

<img width="810" height="978" alt="Screenshot 2026-07-27 at 5 30 17 pm" src="https://github.com/user-attachments/assets/efb604ec-96a0-476b-9544-078c07e75a90" />

**Figure: Tested lighthouse speed**

## Links

- Closes #4903 — Defer Application Insights init out of the critical window
- Parent: #4894 — Perf: AI for Business Leaders event page