### PR TITLE
⚡ Stop rendering empty spacers as client components

### DIFF
--- a/components/blocks/spacer/spacer.tsx
+++ b/components/blocks/spacer/spacer.tsx
@@ -1,10 +1,22 @@
+import { backgroundOptions } from "@/components/blocksSubtemplates/tinaFormElements/colourOptions/blockBackgroundOptions";
 import V2ComponentWrapper from "@/components/layout/v2ComponentWrapper";
 import { hideOnClasses } from "@/components/util/hideOn";
 import { Consultingv2BlocksSpacer } from "@/tina/types";
+import classNames from "classnames";
 
 export function Spacer({ data }: { data: Consultingv2BlocksSpacer }) {
   const hideClasses = hideOnClasses(data?.hideOn);
-  const spacer = (
+
+  // A spacer renders nothing, so the wrapper's fade-in observer, bleed image,
+  // glow and grid overlay have nothing to act on — only pay for the client
+  // component when one of them is actually configured.
+  const isDecorated = Boolean(
+    data?.background?.backgroundImage ||
+      data?.background?.redGlow ||
+      data?.background?.gridOverlay
+  );
+
+  const spacer = isDecorated ? (
     <V2ComponentWrapper data={data}>
       <div
         style={{
@@ -13,6 +25,18 @@ export function Spacer({ data }: { data: Consultingv2BlocksSpacer }) {
         }}
       />
     </V2ComponentWrapper>
+  ) : (
+    <section
+      aria-hidden="true"
+      className={classNames(
+        backgroundOptions.find(
+          (value) => value.reference === data?.background?.backgroundColour
+        )?.classes,
+        "relative w-full overflow-visible"
+      )}
+      style={{ height: data?.spacerHeight }}
+    />
   );
+
   return hideClasses ? <div className={hideClasses}>{spacer}</div> : spacer;
 }


### PR DESCRIPTION
## TL;DR

24 of the 39 blocks on `/events/ai-for-business-leaders` are spacers, and **none of them** configure a background image, glow or grid overlay — yet each was paying for `V2ComponentWrapper`'s IntersectionObserver, two effects and a hydration boundary in order to render an empty div. Spacers now render as a plain server-side `<section>`, keeping the wrapper only when decoration is actually configured.

**Fade wrappers on the page: 39 → 15. DOM tags: 991 → 943.**

## Why

Lighthouse mobile on this page reports 1.5 s of JavaScript execution and 2.3 s of main-thread work, and LCP is 89% *render delay* with zero resource load time — the paint is waiting on the main thread, not on a download. 24 client components that render nothing are pure main-thread cost with no user-visible return.

## Reviewer notes

- **Rendered output is equivalent.** Before: outer `<section>` with the background classes, inner `<section class="relative z-30 transition-opacity duration-300">`, then `<div style="height:45px;width:100%">`. After: one `<section>` with the same background classes and `style="height:45px"`. Same `hideOn` wrapper, same colour, same height — 1 element instead of 3.
- **Decorated spacers still use the wrapper.** If an editor sets `backgroundImage`, `redGlow` or `gridOverlay`, the old path is taken unchanged. Only the undecorated case is simplified.
- **`backgroundColour` is preserved** by resolving `backgroundOptions` directly, so a spacer used to create a coloured gap still works.
- **`aria-hidden="true"`** added — it is a presentational gap with no content, and it previously sat inside a wrapper that screen readers had to walk.
- **No bundle change expected.** `V2ComponentWrapper` is still used by the other 15 blocks. The win is runtime: 24 fewer observers, 48 fewer effects, 24 fewer hydration boundaries.

## Verify

`tsc --noEmit` passes and the production build succeeds. Counts above are from the served HTML of two local production builds, compared identically.

LCP/TBT have **not** been re-measured against this. Localhost Lighthouse numbers mapped poorly to PSI during this investigation, so that is worth doing on a preview deploy with 5 mobile runs compared on median — single runs on this page swing 11–18 points.

## Links

- Closes #4899
- Parent: #4894