### PR TITLE
🩹 Add redirects for /consulting/web-application-development and product pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -101,6 +101,26 @@ const config = {
         destination: "/admin/index.html",
         permanent: true,
       },
+      {
+        source: "/consulting/web-application-development",
+        destination: "/consulting/web-applications",
+        permanent: true,
+      },
+      {
+        source: "/eagle-eye",
+        destination: "https://ssweagleeye.com",
+        permanent: true,
+      },
+      {
+        source: "/eagleeye",
+        destination: "https://ssweagleeye.com",
+        permanent: true,
+      },
+      {
+        source: "/yakshaver",
+        destination: "https://yakshaver.ai",
+        permanent: true,
+      },
     ];
   },
   serverExternalPackages: ["applicationinsights"],


### PR DESCRIPTION
## TL;DR

A client hit `/consulting/web-application-development` and `/eagle-eye` and saw the site chrome with no page content — unknown paths fall through to the `[filename]` catch-all, which renders `ClientFallback` instead of a 404. This adds 308 redirects for the four reported paths.

| From | To |
|---|---|
| `/consulting/web-application-development` | `/consulting/web-applications` |
| `/eagle-eye`, `/eagleeye` | https://ssweagleeye.com |
| `/yakshaver` | https://yakshaver.ai |

## Reviewer notes

- **308, not 307.** These are permanent moves; browsers will hard-cache them.
- **Wins over the catch-alls.** Next runs `redirects()` ahead of dynamic routes, so `/[filename]` and `/consulting/[filename]` never see these paths.
- **Root cause untouched.** The empty-shell fallback for unknown paths is still there — the next mistyped link will look identical.

## Links

- Closes #4877