### PR TITLE
content: add September Sydney user group

### DIFF
--- a/content/events-calendar/2026/September-User-Group---Getting-Found-in-the-Age-of-AI.json
+++ b/content/events-calendar/2026/September-User-Group---Getting-Found-in-the-Age-of-AI.json
@@ -1,0 +1,21 @@
+{
+  "title": "September User Group - Getting Found in the Age of AI",
+  "slug": "getting-found-in-the-age-of-ai",
+  "url": "https://www.meetup.com/sydney-net-user-group/",
+  "thumbnail": "/images/events/sydney-ug-thumb.jpg",
+  "thumbnailDescription": "Sydney .NET User Group",
+  "presenterName": "Jack Bear",
+  "headerLayout": "avatars",
+  "startDateTime": "2026-09-16T08:00:00.000Z",
+  "endDateTime": "2026-09-16T11:00:00.000Z",
+  "startShowBannerDateTime": "2026-09-15T14:00:00.000Z",
+  "endShowBannerDateTime": "2026-09-16T12:00:00.000Z",
+  "calendarType": "User Groups",
+  "city": "Sydney",
+  "category": "Artificial Intelligence",
+  "abstract": "How AI is rewriting the way businesses get discovered online. From traditional SEO to AI-powered search, and what it means for your brand's visibility.",
+  "description": "How AI is rewriting the way businesses get discovered online. From traditional SEO to AI-powered search, and what it means for your brand's visibility.\n\n**About Jack:**\n\nJack Bear is an Australian technology founder and consultant specialising in AI infrastructure and the \"answer economy.\" He is the founder and CEO of Norg AI, a platform building operating systems for AI agents.\n\n[Connect with Jack on LinkedIn](https://www.linkedin.com/in/jack-bear-726578226/)\n",
+  "liveStreamDelayMinutes": 30,
+  "hostedAtSsw": true,
+  "enabled": true
+}


### PR DESCRIPTION
## Summary

- adds the 16 September 2026 Sydney .NET User Group listing
- features Jack Bear presenting “Getting Found in the Age of AI”
- uses the current Sydney user-group event structure, thumbnail, banner window, and Artificial Intelligence category

## Event details

- **Local time:** Wednesday 16 September 2026, 6:00–9:00 pm AEST (`Australia/Sydney`)
- **UTC:** 08:00–11:00 UTC
- **Venue:** SSW Sydney office
- **Presenter:** `presenterName` fallback because no `content/presenters/jack-bear.mdx` profile exists
- **Registration URL:** Sydney Meetup group URL; the event-specific Meetup URL was still a draft when this website record was prepared

## Validation

- JSON parses successfully
- `public/images/events/sydney-ug-thumb.jpg` exists
- `/netug/sydney` content exists
- `Artificial Intelligence` is an allowed category
- date resolves to Wednesday with UTC+10 for `Australia/Sydney`