### PR TITLE
🧹 Stop PR builds pushing throwaway images to ACR

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,6 +15,8 @@ jobs:
     uses: ./.github/workflows/template-build.yml
     with:
       tag: pr-${{ github.event.number }}
+      # Validate the build only - `/deploy` is what pushes a pr-<n> image to ACR.
+      push: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: ""
         description: "PR number for the slot URL; defaults to the event's PR number"
+      push:
+        type: boolean
+        required: false
+        default: true
+        description: "Push the image to ACR. Set false to validate the build only - the BuildKit cache is still exported either way."
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -115,7 +120,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
+          push: ${{ inputs.push }}
           build-args: |
             NODE_VERSION=${{ steps.node-version.outputs.version }}
             NODE_OPTIONS=--max_old_space_size=8192


### PR DESCRIPTION
## TL;DR

`pr-build.yml` runs on every `pull_request` and pushed a `pr-<n>` image to ACR, so the registry holds 11 `pr-*` tags right now even though staging slots are capped at 5 and gated behind `/deploy`. PR builds now validate the Docker build without pushing it.

## Why

The `MAX_PR_SLOTS=5` cap added in #4835 gates App Service *slots*, not registry images — nothing was ever capped on the ACR side. Images are only deleted when their PR closes, so every long-lived open PR keeps a few hundred MB of dormant image on the shelf indefinitely.

## Reviewer notes

- **`/deploy` is not slower.** BuildKit's `cache-to` export is independent of `push`, so PR builds keep warming the shared `buildcache` tag.
- **Default is `true`.** `main-build-and-deploy.yml` and `pr-deploy-command.yml` omit the input and still push.
- **Backlog is untouched.** The existing 11 tags belong to open PRs, so the Monday sweep skips them — draining those is a separate change.

## Links

- [#4767 — staging slots are a limited resource](https://github.com/SSWConsulting/SSW.Website/issues/4767)
- [#4835 — /deploy opt-in + slot cap](https://github.com/SSWConsulting/SSW.Website/pull/4835)