### PR TITLE
Content: remove duplicate Jack Bear biography

### DIFF
--- a/content/events-calendar/2026/September-User-Group---Getting-Found-in-the-Age-of-AI.json
+++ b/content/events-calendar/2026/September-User-Group---Getting-Found-in-the-Age-of-AI.json
@@ -18,7 +18,7 @@
   "city": "Sydney",
   "category": "Artificial Intelligence",
   "abstract": "How AI is rewriting the way businesses get discovered online. From traditional SEO to AI-powered search, and what it means for your brand's visibility.",
-  "description": "How AI is rewriting the way businesses get discovered online. From traditional SEO to AI-powered search, and what it means for your brand's visibility.\n\n**About Jack:**\n\nJack Bear is an Australian technology founder and consultant specialising in AI infrastructure and the \"answer economy.\" He is the founder and CEO of Norg AI, a platform building operating systems for AI agents.\n\n[Connect with Jack on LinkedIn](https://www.linkedin.com/in/jack-bear-726578226/)\n",
+  "description": "How AI is rewriting the way businesses get discovered online. From traditional SEO to AI-powered search, and what it means for your brand's visibility.\n\n[Connect with Jack on LinkedIn](https://www.linkedin.com/in/jack-bear-726578226/)\n",
   "liveStreamDelayMinutes": 30,
   "hostedAtSsw": true,
   "enabled": true


### PR DESCRIPTION
## What changed

- Removed the duplicated **About Jack** heading and biography from the event description.
- Kept the talk summary and Jack's LinkedIn link in the event description.
- Left Jack's biography in the dedicated presenter profile, where it appears under **About the speaker**.

## Why

Jack's biography appeared in both **About the event** and **About the speaker** on `/events/2026/getting-found-in-the-age-of-ai`.

## User impact

The event page will show the speaker biography once, in the speaker section, while preserving the event summary and LinkedIn link.

- Affected route: `/events/2026/getting-found-in-the-age-of-ai`

## Validation

- Parsed the event JSON successfully.
- Verified the duplicated heading and biography are absent from `description`.
- Verified the LinkedIn link remains.
- Verified the event still references `content/presenters/jack-bear.mdx`.
- Ran `git diff --check` successfully.