### PR TITLE
💄 Migrate six AI consulting pages to the v3 block set

### DIFF
--- a/components/blocks-renderer.tsx
+++ b/components/blocks-renderer.tsx
@@ -254,6 +254,10 @@ const V3CardCarousel = dynamic(() =>
   )
 );
 
+const V3Pills = dynamic(() =>
+  import("./blocks/v3/pills/pills").then((mod) => mod.V3Pills)
+);
+
 const componentMap = {
   AboutUs,
   Carousel,
@@ -307,6 +311,7 @@ const componentMap = {
   V3Cta,
   V3Testimonials,
   V3StackCards,
+  V3Pills,
   V3Faq,
   V3LeadCapture,
   V3VideoHighlights,

--- a/components/blocks/index.ts
+++ b/components/blocks/index.ts
@@ -69,6 +69,7 @@ import { V3CtaSchema } from "./v3/cta/cta.schema";
 import { V3LogoCarouselSchema } from "./v3/logoCarousel/logoCarousel.schema";
 import { V3TestimonialsSchema } from "./v3/testimonials/testimonials.schema";
 import { V3StackCardsSchema } from "./v3/stackCards/stackCards.schema";
+import { V3PillsSchema } from "./v3/pills/pills.schema";
 import { V3FaqSchema } from "./v3/faq/faq.schema";
 import { V3LeadCaptureSchema } from "./v3/leadCapture/leadCapture.template";
 import { V3VideoHighlightsSchema } from "./v3/videoHighlights/videoHighlights.schema";
@@ -95,6 +96,7 @@ export const pageBlocks: Template[] = [
   V3CtaSchema,
   V3TestimonialsSchema,
   V3StackCardsSchema,
+  V3PillsSchema,
   V3FaqSchema,
   V3LeadCaptureSchema,
   V3VideoHighlightsSchema,

--- a/components/blocks/v3/hero/hero.schema.tsx
+++ b/components/blocks/v3/hero/hero.schema.tsx
@@ -63,6 +63,10 @@ export const V3HeroSchema: Template = {
           value: "reactConsultingSvg",
           label: "React Consulting Atom (animated)",
         },
+        {
+          value: "aiConsultingSvg",
+          label: "AI Consulting Neural Network (animated)",
+        },
       ],
     },
     {

--- a/components/blocks/v3/hero/media/AiConsultingHeroMedia.tsx
+++ b/components/blocks/v3/hero/media/AiConsultingHeroMedia.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useReducedMotion } from "framer-motion";
+
+/**
+ * Neural-network composition for the AI Consulting v3 hero RHS.
+ *
+ * Layers of nodes are fully connected; a handful of the resulting edges carry a
+ * pulse that travels along the real path (via <animateMotion><mpath/>), so the
+ * signal always tracks the line it belongs to.
+ */
+
+const LAYERS = [
+  { x: 46, ys: [78, 150, 222] },
+  { x: 169, ys: [50, 117, 183, 250] },
+  { x: 292, ys: [110, 190] },
+];
+
+const EDGES = LAYERS.slice(0, -1).flatMap((layer, layerIndex) =>
+  layer.ys.flatMap((y1) =>
+    LAYERS[layerIndex + 1].ys.map((y2) => ({
+      x1: layer.x,
+      y1,
+      x2: LAYERS[layerIndex + 1].x,
+      y2,
+    }))
+  )
+);
+
+// Every third edge carries a pulse — enough movement to read as a live network
+// without turning the whole graph into noise.
+const PULSE_EDGES = EDGES.map((_, i) => i).filter((i) => i % 3 === 0);
+
+const NODE_COLOUR = "#CC4141";
+const PULSE_COLOUR = "#DA7373";
+
+const glow = (colour: string) => ({ filter: `drop-shadow(0 0 8px ${colour})` });
+
+export default function AiConsultingHeroMedia() {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <svg
+      viewBox="0 0 338 300"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Animated neural network illustrating custom AI models"
+      className="h-auto w-full max-w-media overflow-visible"
+    >
+      {EDGES.map((edge, i) => (
+        <path
+          key={i}
+          id={`hero-ai-edge-${i}`}
+          d={`M${edge.x1} ${edge.y1}L${edge.x2} ${edge.y2}`}
+          stroke={NODE_COLOUR}
+          strokeOpacity={0.35}
+          strokeWidth={1.5}
+        />
+      ))}
+
+      {PULSE_EDGES.map((edgeIndex, i) =>
+        reduceMotion ? null : (
+          <circle
+            key={edgeIndex}
+            r={4}
+            fill={PULSE_COLOUR}
+            style={glow(PULSE_COLOUR)}
+          >
+            <animateMotion
+              dur="2.8s"
+              begin={`-${i * 0.45}s`}
+              repeatCount="indefinite"
+            >
+              <mpath href={`#hero-ai-edge-${edgeIndex}`} />
+            </animateMotion>
+          </circle>
+        )
+      )}
+
+      {LAYERS.map((layer, layerIndex) =>
+        layer.ys.map((y, i) => {
+          const radius = layerIndex === LAYERS.length - 1 ? 16 : 9;
+          return (
+            <circle
+              key={`${layerIndex}-${i}`}
+              cx={layer.x}
+              cy={y}
+              r={radius}
+              fill={NODE_COLOUR}
+              style={glow(NODE_COLOUR)}
+            >
+              {!reduceMotion && (
+                <animate
+                  attributeName="r"
+                  values={`${radius};${radius + 2.5};${radius}`}
+                  dur="3s"
+                  begin={`-${(layerIndex + i) * 0.4}s`}
+                  repeatCount="indefinite"
+                  calcMode="spline"
+                  keyTimes="0;0.5;1"
+                  keySplines="0.4 0 0.6 1;0.4 0 0.6 1"
+                />
+              )}
+            </circle>
+          );
+        })
+      )}
+    </svg>
+  );
+}

--- a/components/blocks/v3/hero/media/registry.tsx
+++ b/components/blocks/v3/hero/media/registry.tsx
@@ -13,6 +13,7 @@ import type { ComponentType } from "react";
  */
 export const heroMediaRegistry: Record<string, ComponentType> = {
   reactConsultingSvg: dynamic(() => import("./ReactConsultingHeroMedia")),
+  aiConsultingSvg: dynamic(() => import("./AiConsultingHeroMedia")),
 };
 
 export type HeroMediaKey = keyof typeof heroMediaRegistry;

--- a/components/blocks/v3/pills/pills.schema.tsx
+++ b/components/blocks/v3/pills/pills.schema.tsx
@@ -1,0 +1,76 @@
+import type { Template } from "tinacms";
+import alternatingHeadingSchema from "../../../blocksSubtemplates/alternatingHeading.schema";
+import { backgroundSchema } from "../../../layout/v2ComponentWrapper.schema";
+
+export const V3PillsSchema: Template = {
+  name: "v3Pills",
+  label: "<V3> Pills",
+  ui: {
+    defaultItem: {
+      background: { backgroundColour: 7 },
+      brow: "TECH WE USE",
+      heading: "AI Models We Work With",
+      pills: [{ label: "Claude" }, { label: "ChatGPT" }, { label: "Gemini" }],
+    },
+  },
+  fields: [
+    //@ts-expect-error – custom component typing won't be pinned down
+    backgroundSchema,
+    {
+      type: "string",
+      label: "Brow",
+      name: "brow",
+      description: "Small eyebrow text above the title.",
+    },
+    alternatingHeadingSchema,
+    {
+      type: "string",
+      label: "Subtitle",
+      name: "subtitle",
+      description: "Optional short line beneath the title.",
+      ui: { component: "textarea" },
+    },
+    {
+      type: "object",
+      label: "Pills",
+      name: "pills",
+      list: true,
+      description: "Labels shown as a wrapping row of pills.",
+      ui: {
+        itemProps: (item) => ({ label: item?.label ?? "Pill" }),
+        defaultItem: { label: "Lorem" },
+      },
+      fields: [
+        {
+          type: "string",
+          label: "Label",
+          name: "label",
+        },
+        {
+          type: "image",
+          label: "Image",
+          name: "image",
+          description: "Optional. Shown to the left of the label.",
+        },
+        {
+          type: "string",
+          label: "Image Alt Text",
+          name: "imageAlt",
+          description: "Defaults to the label.",
+        },
+        {
+          type: "string",
+          label: "Link",
+          name: "link",
+          description:
+            "Optional. If set, the pill becomes clickable. Use a relative path (e.g. /consulting) for internal links or a full URL (https://…) for external ones.",
+        },
+        {
+          type: "boolean",
+          label: "Open in New Tab",
+          name: "newTab",
+        },
+      ],
+    },
+  ],
+};

--- a/components/blocks/v3/pills/pills.tsx
+++ b/components/blocks/v3/pills/pills.tsx
@@ -1,0 +1,92 @@
+import AlternatingText from "@/components/alternating-text";
+import V2ComponentWrapper from "@/components/layout/v2ComponentWrapper";
+import { Container } from "@/components/util/container";
+import Image from "next/image";
+import Link from "next/link";
+import { tinaField } from "tinacms/dist/react";
+
+export function V3Pills({ data }) {
+  const pills = data?.pills ?? [];
+
+  return (
+    <V2ComponentWrapper data={data}>
+      <Container
+        size="custom"
+        padding="px-4 sm:px-8"
+        className="py-16 md:py-24"
+      >
+        {data?.brow && (
+          <span
+            data-tina-field={tinaField(data, "brow")}
+            className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-sswRed"
+          >
+            {data.brow}
+          </span>
+        )}
+        {data?.heading && (
+          <h2
+            data-tina-field={tinaField(data, "heading")}
+            className="my-4 text-3xl text-white lg:text-4xl"
+          >
+            <AlternatingText text={data.heading} />
+          </h2>
+        )}
+        {data?.subtitle && (
+          <p
+            data-tina-field={tinaField(data, "subtitle")}
+            className="max-w-2xl text-base font-light text-gray-400"
+          >
+            {data.subtitle}
+          </p>
+        )}
+
+        {pills.length > 0 && (
+          <div className="mt-10 flex flex-wrap gap-3">
+            {pills.map((pill, index) => {
+              const inner = (
+                <>
+                  {pill?.image && (
+                    <span className="relative size-5 shrink-0">
+                      <Image
+                        src={pill.image}
+                        alt={pill?.imageAlt ?? pill?.label ?? ""}
+                        fill
+                        sizes="20px"
+                        className="object-contain"
+                      />
+                    </span>
+                  )}
+                  <span>{pill?.label}</span>
+                </>
+              );
+
+              const className =
+                "flex h-12 items-center gap-2.5 rounded-xl border-0.75 border-sswBorder bg-sswCard px-5 font-semibold text-white";
+
+              return pill?.link ? (
+                <Link
+                  key={`v3-pill-${index}`}
+                  href={pill.link}
+                  target={pill?.newTab ? "_blank" : undefined}
+                  rel={pill?.newTab ? "noopener noreferrer" : undefined}
+                  data-tina-field={tinaField(pill, "label")}
+                  className={`${className} !no-underline transition hover:border-sswRed`}
+                >
+                  {inner}
+                </Link>
+              ) : (
+                <div
+                  key={`v3-pill-${index}`}
+                  data-tina-field={tinaField(pill, "label")}
+                  className={className}
+                >
+                  {inner}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Container>
+    </V2ComponentWrapper>
+  );
+}

--- a/components/blocks/v3/testimonials/testimonials.schema.tsx
+++ b/components/blocks/v3/testimonials/testimonials.schema.tsx
@@ -45,8 +45,14 @@ export const V3TestimonialsSchema: Template = {
           type: "string",
           label: "Case Study URL",
           name: "caseStudyUrl",
+          description: "If set, a link is shown below the quote.",
+        },
+        {
+          type: "string",
+          label: "Case Study Link Text",
+          name: "caseStudyLabel",
           description:
-            "If set, a 'SEE CASE STUDY' link is shown below the quote.",
+            "Text for the case study link (always shown in uppercase). Defaults to 'See Case Study'.",
         },
         {
           type: "string",

--- a/components/blocks/v3/testimonials/testimonials.tsx
+++ b/components/blocks/v3/testimonials/testimonials.tsx
@@ -173,7 +173,9 @@ export function V3Testimonials({ data }) {
                 }}
                 className="group mt-6 inline-flex items-center gap-1 text-sm font-semibold uppercase tracking-wide text-foreground transition hover:text-sswRed"
               >
-                See Case Study
+                <span data-tina-field={tinaField(current, "caseStudyLabel")}>
+                  {current.caseStudyLabel || "See Case Study"}
+                </span>
                 <TiArrowRight className="size-5 transition group-hover:translate-x-1" />
               </motion.a>
             )}

--- a/components/layout/v2ComponentWrapper.schema.tsx
+++ b/components/layout/v2ComponentWrapper.schema.tsx
@@ -38,7 +38,8 @@ export const backgroundSchema = {
       type: "boolean",
       label: "Bleed",
       name: "bleed",
-      description: "If true, the background will bleed into lower blocks.",
+      description:
+        "If true, the background image and red glow extend past this block into the ones above and below.",
     },
     {
       type: "boolean",

--- a/components/layout/v2ComponentWrapper.tsx
+++ b/components/layout/v2ComponentWrapper.tsx
@@ -96,11 +96,21 @@ const V2ComponentWrapper = ({
         <>
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 z-10 bg-red-glow-tl"
+            className={classNames(
+              "pointer-events-none absolute inset-x-0 z-10",
+              data.background?.bleed
+                ? "-inset-y-40 bg-red-glow-tl-bleed"
+                : "inset-y-0 bg-red-glow-tl"
+            )}
           />
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 z-10 bg-red-glow-r"
+            className={classNames(
+              "pointer-events-none absolute inset-x-0 z-10",
+              data.background?.bleed
+                ? "-inset-y-40 bg-red-glow-r-bleed"
+                : "inset-y-0 bg-red-glow-r"
+            )}
           />
         </>
       )}

--- a/content/consultingv2/ai-discovery-workshop.json
+++ b/content/consultingv2/ai-discovery-workshop.json
@@ -14,414 +14,342 @@
   },
   "blocks": [
     {
-      "topLabel": {
-        "labelText": "On-Site 3-Day AI Discovery Workshop"
-      },
-      "heading": "Uncover AI Opportunities in a **3-day Workshop**",
-      "isH1": true,
-      "description": "In this intensive engagement, our AI strategists work with your team to identify where AI can drive real value... In just three days, you'll go from wondering about AI to having a clear, actionable implementation roadmap.\n",
-      "tabletTextAlignment": "Left",
-      "featureColumns": {
-        "twoColumns": true
-      },
-      "buttons": [
-        {
-          "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "colour": 0
-        }
-      ],
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": false
       },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Left",
-        "verticalPlacement": "Centered",
-        "mobilePlacement": "Above",
-        "imageHeight": 1721,
-        "imageWidth": 2891,
-        "youtubeUrl": "https://youtu.be/-qf8uyS4_Y8?si=fd_OUbXgdNsUKvAr"
-      },
-      "_template": "imageTextBlock"
+      "finalBreadcrumb": "AI Discovery Workshop",
+      "_template": "breadcrumbs"
     },
     {
       "background": {
-        "backgroundColour": 2
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "Trusted in Sydney, Melbourne, Brisbane, and Newcastle by",
-      "paused": false,
-      "isWhiteImages": true,
-      "logos": [
+      "brow": "ON-SITE 3-DAY WORKSHOP",
+      "heading": "Uncover AI opportunities in a **3-day workshop**",
+      "description": "Two senior AI consultants come to you, sit with your team, and map where AI earns its keep. You finish the three days with a costed, prioritised roadmap instead of a list of tools.\n",
+      "buttons": [
         {
-          "logo": "/images/ssw-web/logos/toll_logo.png",
-          "scale": 195,
-          "altText": "Toll"
+          "buttonText": "Book a Free Initial Meeting",
+          "buttonLink": "#lead-capture-heading",
+          "colour": 0
         },
         {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 1
+        }
+      ],
+      "mediaType": "image",
+      "image": {
+        "altText": "SSW consultants running an on-site workshop",
+        "imageSource": "/images/ssw-web/hero/ssw-workshop-inhouse.jpg",
+        "imageWidth": 2891,
+        "imageHeight": 1721
+      },
+      "_template": "v3Hero"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Trusted in Sydney, Melbourne, Brisbane and Newcastle by",
+      "logos": [
+        { "logo": "/images/ssw-web/logos/toll_logo.png", "altText": "Toll" },
+        {
           "logo": "/images/ssw-web/logos/symantec_logo.png",
-          "scale": 160,
           "altText": "Symantec"
         },
         {
           "logo": "/images/ssw-web/logos/microsoft_logo.png",
-          "scale": 180,
           "altText": "Microsoft"
         },
         {
           "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
-          "scale": 200,
           "altText": "Event Cinemas"
         },
         {
           "logo": "/images/ssw-web/logos/domain_logo.png",
-          "scale": 175,
           "altText": "Domain"
         },
-        {
-          "logo": "/images/ssw-web/logos/cisco_logo.png",
-          "scale": 175,
-          "altText": "Cisco"
-        },
+        { "logo": "/images/ssw-web/logos/cisco_logo.png", "altText": "Cisco" },
         {
           "logo": "/images/ssw-web/logos/cba_logo.png",
-          "scale": 170,
           "altText": "Commonwealth Bank"
         },
         {
           "logo": "/images/ssw-web/logos/allianz_logo.png",
-          "scale": 195,
           "altText": "Allianz"
         }
       ],
-      "_template": "logoCarousel"
+      "_template": "v3LogoCarousel"
     },
     {
-      "topLabel": {
-        "labelText": "",
-        "icon": "BiRecycle"
-      },
-      "heading": "A **Collaborative Discovery Process** That Works",
-      "isH1": false,
-      "description": "",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "Why Businesses Struggle with AI",
-            "description": "Every business leader knows AI is transformative, but we often hear: \"We don't know where to start”, “We lack internal expertise”, “We're worried about wasting money”, “We need a strategy, not just tools”.",
-            "icon": "BiCloudLightning"
-          },
-          {
-            "heading": "Improving your Workflows",
-            "description": "We don't just talk theory; we embed ourselves in your business… a hands-on process led by senior AI consultants and developers.",
-            "icon": "BiBulb"
-          }
-        ]
-      },
       "background": {
-        "backgroundColour": 4,
-        "bleed": true
+        "backgroundColour": 7
       },
-      "_template": "imageTextBlock"
+      "brow": "WHY TEAMS BOOK THIS",
+      "heading": "Everyone knows AI matters. Almost nobody knows where to start.",
+      "description": "Every business leader we meet is in roughly the same place: convinced AI is going to change their industry, and stuck on what to fund first. These are the four sentences we hear most.\n",
+      "steps": [
+        {
+          "brow": "01",
+          "heading": "\"We don't know where to start\"",
+          "description": "There are a hundred plausible ideas and no way to rank them, so nothing gets funded.\n"
+        },
+        {
+          "brow": "02",
+          "heading": "\"We lack internal expertise\"",
+          "description": "Nobody in the building can tell a two-week integration from a twelve-month research project.\n"
+        },
+        {
+          "brow": "03",
+          "heading": "\"We're worried about wasting money\"",
+          "description": "The horror stories are real. Without a feasibility check, picking wrong feels worse than doing nothing.\n"
+        },
+        {
+          "brow": "04",
+          "heading": "\"We need a strategy, not just tools\"",
+          "description": "Buying licences is easy. Knowing which processes should change, and in what order, is the hard part.\n"
+        }
+      ],
+      "_template": "v3FeatureSteps"
     },
     {
-      "topLabel": {
-        "labelText": "Process",
-        "icon": "BiDirections"
-      },
-      "heading": "What to Expect in **3 Days**",
-      "isH1": false,
-      "description": "",
-      "featureColumns": {
-        "twoColumns": false,
-        "features": [
-          {
-            "heading": "Day 1 - Explore & Ideate",
-            "description": "In-depth interviews with stakeholders; understand pain points and your environment.",
-            "icon": "BiBookOpen"
-          },
-          {
-            "heading": "Day 2 - Analysis & Feasibility",
-            "description": "Map pain points to AI solutions: assess data readiness, integration complexity and feasibility.",
-            "icon": "BiMapPin"
-          },
-          {
-            "heading": "Day 3 - Roadmap & Next Steps",
-            "description": "Prioritize initiatives, build implementation roadmap and timeline, present recommendations to align team.",
-            "icon": "BiBulb"
-          }
-        ]
-      },
       "background": {
-        "backgroundColour": 5
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "_template": "imageTextBlock"
+      "testimonials": [
+        {
+          "quote": "**Uly's enthusiasm was contagious.**",
+          "caseStudyUrl": "https://www.youtube.com/watch?v=zaQOlw0-jQ4",
+          "caseStudyLabel": "Watch the video",
+          "authorName": "Tracy",
+          "authorTitle": "Director, APA"
+        }
+      ],
+      "_template": "v3Testimonials"
     },
     {
-      "isStacked": true,
-      "heading": "What You’ll Walk Away With",
-      "isH1": false,
-      "body": "By the end, you'll have a prioritized list of AI projects, and a step-by-step plan to implement them.",
-      "cardStyle": 0,
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "THE THREE DAYS",
+      "heading": "What to expect on site",
+      "description": "We don't talk theory. We embed in your business, led by senior AI consultants and developers rather than a sales team.\n",
+      "steps": [
+        {
+          "heading": "Day 1 - Explore & Ideate",
+          "description": "In-depth interviews with stakeholders to understand your pain points and your environment.\n"
+        },
+        {
+          "heading": "Day 2 - Analysis & Feasibility",
+          "description": "Map pain points to AI solutions, then assess data readiness, integration complexity and feasibility.\n"
+        },
+        {
+          "heading": "Day 3 - Roadmap & Next Steps",
+          "description": "Prioritise initiatives, build the implementation roadmap and timeline, and present recommendations to align the team.\n"
+        }
+      ],
+      "_template": "v3Process"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "DELIVERABLES",
+      "heading": "What you'll walk away with",
+      "subtitle": "A prioritised list of AI projects, and a step-by-step plan to implement them.",
       "cards": [
         {
-          "guid": "4qkep6",
-          "altText": "Easy Wins",
-          "icon": "info",
-          "heading": "1️⃣ Easy Wins",
-          "description": "We'll map out the low effort, high impact integrations for routine tasks. Expect immediate results where we see the opportunities.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "Easy Wins",
+          "description": "The low effort, high impact integrations for routine tasks. Immediate results where we see the opportunity."
         },
         {
-          "guid": "4ob77n",
-          "altText": "Medium Projects",
-          "icon": "info",
-          "heading": "2️⃣ Medium Projects",
-          "description": "Projects that require some integration or light development work, typically connect AI into your existing systems, automate multi-step workflows, or enhance internal tools. Expect meaningful efficiency gains and measurable ROI within weeks.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "Medium Projects",
+          "description": "Light development connecting AI into your existing systems and automating multi-step workflows. Measurable ROI within weeks."
         },
         {
-          "guid": "tydp",
-          "altText": "Transformational Ideas",
-          "icon": "info",
-          "heading": "3️⃣ Transformational Ideas",
-          "description": "High-impact initiatives that reshape how your business operates. These are end-to-end AI solutions, new product capabilities, or major process redesigns that unlock entirely new value. These projects require deeper data work and engineering, but deliver genuine competitive advantage.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "Transformational Ideas",
+          "description": "End-to-end solutions and process redesigns. Deeper data and engineering work, but genuine competitive advantage."
+        }
+      ],
+      "_template": "v3StackCards"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "At a glance",
+      "statistics": [
+        {
+          "figure": 3,
+          "heading": "Days on-site",
+          "description": "Two senior AI consultants, in your office"
+        },
+        {
+          "figure": 12000,
+          "figureSuffix": " + GST",
+          "heading": "Fixed price",
+          "description": "No hourly surprises"
+        },
+        {
+          "figure": 8,
+          "heading": "Attendees max",
+          "description": "Business and technical stakeholders"
+        }
+      ],
+      "_template": "v3Statistics"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "TAILORED TO YOUR STACK",
+      "heading": "We recommend what fits your environment",
+      "subtitle": "The roadmap is built around what you already run, not what we'd prefer to sell.",
+      "pills": [
+        { "label": "Microsoft" },
+        { "label": "Azure AI" },
+        { "label": "AWS" },
+        { "label": "OpenAI" },
+        { "label": "Gemini" },
+        { "label": "Anthropic" },
+        { "label": "Copilot" },
+        { "label": "Semantic Kernel" }
+      ],
+      "_template": "v3Pills"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true
+      },
+      "videoUrl": "https://youtu.be/-qf8uyS4_Y8",
+      "brow": "AI EXPERTS",
+      "heading": "Led by Ulysses Maclaren",
+      "description": "Uly brings 20+ years of enterprise consulting experience, helping companies adopt emerging technology with confidence. He's led AI enablement sessions for businesses looking to cut through the hype and build systems that drive measurable outcomes.\n",
+      "highlights": [
+        {
+          "title": "Built on real delivery",
+          "desc2": "SSW isn't guessing. We've been building and fixing AI systems for years, across industries and stacks. The workshop distils what we learned the expensive way.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-ai/",
+          "linkText": "Rules to Better AI"
+        },
+        {
+          "title": "No lock-in",
+          "desc2": "The deliverables are yours. Run the roadmap with your own team, with us, or a mix of both.\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Tell us about **your** business",
+      "description": "Answer a few quick questions. We'll set up an initial meeting and show you where we'd start\n",
+      "_template": "v3LeadCapture"
+    },
+    {
+      "isStacked": false,
+      "brow": "learn more on SSWTV",
+      "heading": "Tech wisdom from the trenches",
+      "isH1": false,
+      "body": "SSW has been building enterprise projects for thirty years. We document what we learn for free on SSW Rules and SSW TV.",
+      "tabletTextAlignment": "Left",
+      "cards": [
+        {
+          "guid": "adw001",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://www.youtube.com/watch?v=Rd8cBi8Fv-4",
+          "altText": "Contextive - writing code that aligns with business needs",
+          "category": "DevTools",
+          "heading": "Contextive: code that aligns with business needs"
+        },
+        {
+          "guid": "adw002",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://www.youtube.com/watch?v=BQtWkD7ek5E",
+          "altText": "AI's growing energy demands",
+          "category": "Insights",
+          "heading": "AI's energy demands and the infrastructure behind them"
+        },
+        {
+          "guid": "adw003",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://www.youtube.com/watch?v=LzFG7pUylZo",
+          "altText": "If you think AI is cheating, you're doing it wrong!",
+          "category": "Responsible AI",
+          "heading": "If you think AI is cheating, you're doing it wrong!"
         }
       ],
       "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "/images/ssw-web/background/bckg-9-25-ssw.png",
-        "bleed": true
+        "backgroundColour": 7
       },
-      "_template": "cardCarousel"
+      "_template": "v3CardCarousel"
     },
     {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "At a Glance",
-      "isH1": false,
-      "description": "A 3-day, on-site workshop to get to understand your businesses workflows, and identify where AI can drive value.",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "$12,000 + GST",
-            "description": "Includes two Senior AI Consultants on-site for three full days.",
-            "icon": "BiMoneyWithdraw"
-          },
-          {
-            "heading": "Deep Business Understanding",
-            "description": "We interview stakeholders, map processes, and analyse pain points across your teams.",
-            "icon": "BiSolidContact"
-          },
-          {
-            "heading": "Prioritized AI Roadmap",
-            "description": "A clear set of recommended initiatives ranked by value, feasibility, and ROI.",
-            "icon": "BiSolidWrench"
-          },
-          {
-            "heading": "Tailored to Your Stack",
-            "description": "We identify solutions that fit your environment: Microsoft, AWS, OpenAI, Gemini, and more.",
-            "icon": "BiSolidCustomize"
-          }
-        ]
-      },
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 8
       },
-      "mediaConfiguration": {
-        "placement": "Left",
-        "imageSource": "/images/ssw-web/hero/hero-2-ssw.png",
-        "imageHeight": 768,
-        "imageWidth": 1024
-      },
-      "_template": "imageTextBlock"
-    },
-    {
       "heading": "Workshop FAQ",
-      "body": "",
-      "accordionItems": [
+      "faqs": [
         {
-          "label": "Is this an AI training workshop or a consulting engagement?",
-          "content": "This is a strategic consulting engagement, not a training course. Instead of teaching generic AI tools, we work with your team to map your processes, identify specific AI opportunities, and design a practical implementation roadmap tailored to your business.\n"
+          "question": "Is this an AI training workshop or a consulting engagement?",
+          "answer": "This is a strategic consulting engagement, not a training course. Instead of teaching generic AI tools, we work with your team to map your processes, identify specific AI opportunities, and design a practical implementation roadmap tailored to your business.\n"
         },
         {
-          "label": "Who should attend the 3-day workshop?",
-          "content": "We recommend a mix of business and technical stakeholders, for example:\n\n* An executive sponsor (e.g. CEO, COO, CTO)\n* Key business process owners (Operations, Sales, HR, Finance, etc.)\n* Someone who understands your current systems and data (IT/architect)\n* Individuals experiencing day-to-day pains with cumbersome processes\n\nIdeally 4–8 people who can commit for most of the 3 days.\n"
+          "question": "Who should attend the 3-day workshop?",
+          "answer": "We recommend a mix of business and technical stakeholders, for example:\n\n* An executive sponsor (e.g. CEO, COO, CTO)\n* Key business process owners (Operations, Sales, HR, Finance, etc.)\n* Someone who understands your current systems and data (IT/architect)\n* Individuals experiencing day-to-day pains with cumbersome processes\n\nIdeally 4-8 people who can commit for most of the 3 days.\n"
         },
         {
-          "label": "Do we need any AI knowledge or preparation beforehand?",
-          "content": "No AI expertise is required. You bring knowledge of your business, processes, and pain points – we bring the AI experience. Before the workshop we’ll share a short checklist (key systems, current pain points, any existing AI tools), but there’s no heavy pre-work.\n"
+          "question": "Do we need any AI knowledge or preparation beforehand?",
+          "answer": "No AI expertise is required. You bring knowledge of your business, processes, and pain points - we bring the AI experience. Before the workshop we'll share a short checklist (key systems, current pain points, any existing AI tools), but there's no heavy pre-work.\n"
         },
         {
-          "label": "What do we actually get at the end of the 3 days?",
-          "content": "You’ll walk away with a concrete AI strategy pack, typically including:\n\n* A prioritized list of AI use cases for your business\n* Quick-win recommendations using out-of-the-box tools\n* High-level designs for any proposed custom solutions\n* A phased implementation roadmap with effort/complexity indicators\n* Clear next steps and options for implementation\n"
+          "question": "What do we get at the end of the 3 days?",
+          "answer": "You'll walk away with a concrete AI strategy pack, typically including:\n\n* A prioritized list of AI use cases for your business\n* Quick-win recommendations using out-of-the-box tools\n* High-level designs for any proposed custom solutions\n* A phased implementation roadmap with effort/complexity indicators\n* Clear next steps and options for implementation\n"
         },
         {
-          "label": "What happens after the workshop? Do we have to use SSW for implementation?",
-          "content": "You have complete flexibility. You can:\n\n* Execute the roadmap with your internal team\n* Engage SSW to help design and build the AI solutions\n* Use a hybrid approach, where we tackle the complex pieces and your team handles simpler items\n* The deliverables are yours to use however you choose, with no lock-in\n"
+          "question": "What happens after the workshop? Do we have to use SSW for implementation?",
+          "answer": "You have complete flexibility. You can:\n\n* Execute the roadmap with your internal team\n* Engage SSW to help design and build the AI solutions\n* Use a hybrid approach, where we tackle the complex pieces and your team handles simpler items\n\nThe deliverables are yours to use however you choose, with no lock-in.\n"
         }
       ],
-      "isMultipleOpen": true,
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "accordionBlock"
+      "_template": "v3Faq"
     },
     {
-      "topLabel": {
-        "labelText": "AI Experts"
-      },
-      "heading": "Ulysses Maclaren",
-      "isH1": false,
-      "description": "Uly brings 20+ years of enterprise consulting experience, helping companies adopt emerging technology with confidence. He’s led AI enablement sessions for businesses looking to cut through the hype and build systems that drive measurable outcomes.\n",
-      "featureColumns": {
-        "twoColumns": false,
-        "features": [
-          {
-            "heading": "Uly's enthusiasm was contagious",
-            "description": "Tracy, Director of APA",
-            "icon": "BiSolidQuoteAltLeft"
-          }
-        ]
-      },
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Left",
-        "imageHeight": 768,
-        "imageWidth": 1024,
-        "youtubeUrl": "https://www.youtube.com/watch?v=zaQOlw0-jQ4"
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "isStacked": true,
-      "heading": "Built on Real-World AI Delivery",
-      "isH1": false,
-      "body": "SSW isn’t guessing. We’ve been building and fixing AI systems for years, across industries, tech stacks, and use cases. This workshop distills the lessons that save teams time, money, and frustration.",
+      "heading": "Equip your team with essential **AI skills**",
+      "description": "Get in touch and we'll set up an initial meeting to show you where we'd start\n",
       "buttons": [
         {
-          "buttonText": "Rules to Better AI Development",
-          "buttonLink": "/rules/rules-to-better-ai/",
+          "buttonText": "Book a Free Initial Meeting",
+          "buttonLink": "#lead-capture-heading",
+          "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
           "colour": 1
         }
       ],
-      "cardStyle": 1,
-      "cards": [
-        {
-          "guid": "uh77mq",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=Rd8cBi8Fv-4",
-          "altText": "DevTools",
-          "chips": [
-            {
-              "chipText": "DevTools",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "18 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "",
-          "description": "SSW’s Gert Marx joins Chris Simon at NDC Melbourne to break down the latest on Contextive, the open-source tool helping devs write code that better aligns with business needs.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "itqfs7",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=BQtWkD7ek5E",
-          "altText": "Insights",
-          "chips": [
-            {
-              "chipText": "Insights",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "11 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "",
-          "description": "At NDC, Ulysses Maclaren talks with Richard Campbell about AI’s growing energy demands, Microsoft’s nuclear plans, and the massive infrastructure shifts behind our data-hungry future.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "2eb7hu",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=LzFG7pUylZo",
-          "altText": "Responsible AI",
-          "chips": [
-            {
-              "chipText": "Responsible AI",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "6 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "",
-          "description": "Ulysses shares best practices for responsible AI: transparency, critical thinking, privacy, and using AI to actually boost productivity and stay ahead in your career.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        }
-      ],
-      "background": {
-        "backgroundColour": 2
-      },
-      "_template": "cardCarousel"
-    },
-    {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "Equip your team with essential **AI skills**",
-      "isH1": false,
-      "description": "",
-      "featureColumns": {
-        "twoColumns": true
-      },
-      "buttons": [
-        {
-          "buttonText": "Book Now",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "colour": 0
-        }
-      ],
-      "background": {
-        "backgroundColour": 5
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "150px",
-      "background": {
-        "backgroundColour": 5,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3Cta"
     }
   ]
 }

--- a/content/consultingv2/ai-powered-phone-system.json
+++ b/content/consultingv2/ai-powered-phone-system.json
@@ -8,300 +8,255 @@
   "blocks": [
     {
       "background": {
-        "backgroundColour": 3
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": false
       },
       "finalBreadcrumb": "AI-Powered Phone System",
       "_template": "breadcrumbs"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "Want to turn your phone system into a 24/7 AI assistant?",
-      "isH1": true,
-      "description": "Turn your phone system into an Intelligent 24/7 conversational assistant that automates inbound and outbound calls, improves customer experience, reduce wait times\n\nAt SSW, our AI phone system saves us a huge amount of time, freeing our team for higher-value work.\n\nCall us to try it now.\n",
-      "featureColumns": {
-        "twoColumns": true
-      },
+      "brow": "AI VOICE",
+      "heading": "Turn your phone system into a **24/7 AI assistant**",
+      "description": "An intelligent conversational assistant that handles inbound and outbound calls, cuts wait times, and hands over to a human the moment it should. Our own phone system runs on it, which is the most honest reference we can offer. Call us and try it.\n",
       "buttons": [
         {
-          "buttonText": "Call +61 2 9953 3000",
-          "buttonLink": "<a href=\"tel:+61212345678\">Call us</a>",
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 0
+        },
+        {
+          "buttonText": "Book a Free Initial Meeting",
+          "buttonLink": "#lead-capture-heading",
+          "colour": 1
+        }
+      ],
+      "mediaType": "image",
+      "image": {
+        "altText": "SSW team working on an AI phone system",
+        "imageSource": "/images/ssw-web/hero/hero-2-ssw.png",
+        "imageWidth": 1024,
+        "imageHeight": 768
+      },
+      "_template": "v3Hero"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Trusted in Sydney, Melbourne, Brisbane and Newcastle by",
+      "logos": [
+        { "logo": "/images/ssw-web/logos/toll_logo.png", "altText": "Toll" },
+        {
+          "logo": "/images/ssw-web/logos/symantec_logo.png",
+          "altText": "Symantec"
+        },
+        {
+          "logo": "/images/ssw-web/logos/microsoft_logo.png",
+          "altText": "Microsoft"
+        },
+        {
+          "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
+          "altText": "Event Cinemas"
+        },
+        {
+          "logo": "/images/ssw-web/logos/domain_logo.png",
+          "altText": "Domain"
+        },
+        { "logo": "/images/ssw-web/logos/cisco_logo.png", "altText": "Cisco" },
+        {
+          "logo": "/images/ssw-web/logos/cba_logo.png",
+          "altText": "Commonwealth Bank"
+        },
+        {
+          "logo": "/images/ssw-web/logos/allianz_logo.png",
+          "altText": "Allianz"
+        }
+      ],
+      "_template": "v3LogoCarousel"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "WHAT IT CHANGES",
+      "heading": "Automate the calls, keep the human touch",
+      "description": "The goal isn't to keep customers away from your team. It's to make sure the calls that reach your team are the ones worth their time.\n",
+      "steps": [
+        {
+          "brow": "01",
+          "heading": "Natural conversations, clean handoffs",
+          "description": "The AI handles routine calls conversationally and passes to your team the moment the conversation needs a person.\n"
+        },
+        {
+          "brow": "02",
+          "heading": "Lower call load, lower cost",
+          "description": "Answer, route and resolve automatically. Wait times drop and your team gets its day back.\n"
+        },
+        {
+          "brow": "03",
+          "heading": "Wired into your systems",
+          "description": "Connected to your CRM, booking system and internal tools, so every call becomes structured, actionable data instead of a note someone forgot to write.\n"
+        }
+      ],
+      "_template": "v3FeatureSteps"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true
+      },
+      "videoUrl": "https://www.youtube.com/watch?v=-q9lLqtkC00",
+      "heading": "Why choose SSW?",
+      "description": "SSW's Consulting Services have delivered best-in-class Microsoft solutions for thousands of clients in 15 countries for more than 30 years.\n",
+      "highlights": [
+        {
+          "title": "We run it ourselves",
+          "desc2": "SSW's own phone system is AI-powered. It saves us a significant amount of time and frees the team for higher-value work.\n"
+        },
+        {
+          "title": "Results over rhetoric",
+          "desc2": "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it work?\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-ai/",
+          "linkText": "Rules to Better AI"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "OUR PROCESS",
+      "heading": "What to expect working with SSW",
+      "steps": [
+        {
+          "heading": "Initial Call",
+          "description": "A short call with a senior engineer to talk through your project.\n",
+          "link": "https://www.ssw.com.au/rules/prepare-for-initial-meetings"
+        },
+        {
+          "heading": "Spec Review",
+          "description": "A clear, costed plan with scope, timing and the fastest path to ROI.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
+        },
+        {
+          "heading": "Build & Deliver",
+          "description": "SSW can either handle the project from end-to-end or join your existing team, build your product, and ship your solution.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-scrum"
+        },
+        {
+          "heading": "Service Plan",
+          "description": "We can stay on post-launch to ensure a successful project handover.\n",
+          "link": "https://www.ssw.com.au/consulting/support-plans"
+        }
+      ],
+      "_template": "v3Process"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Tell us about **your** phone system",
+      "description": "Answer a few quick questions. We'll set up an initial meeting and show you where we'd start\n",
+      "_template": "v3LeadCapture"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "Related Services",
+      "heading": "What we usually connect it to",
+      "subtitle": "A phone assistant is only as good as the systems behind it.",
+      "cards": [
+        {
+          "title": "Power Platform",
+          "description": "Build apps, automate workflows and analyse data, without heavy coding.",
+          "link": "/consulting/power-platform"
+        },
+        {
+          "title": "Chatbots",
+          "description": "The same assistant on your website, trained on your own content.",
+          "link": "/consulting/chat-bots"
+        },
+        {
+          "title": "Service Desk",
+          "description": "Centralised support that resolves issues fast and keeps operations running.",
+          "link": "/consulting/service-desk"
+        },
+        {
+          "title": "Entra ID",
+          "description": "Secure identity and access management that keeps people and apps connected.",
+          "link": "/consulting/entra-id-1-hour-briefing"
+        }
+      ],
+      "_template": "v3StackCards"
+    },
+    {
+      "background": {
+        "backgroundColour": 8
+      },
+      "heading": "Frequently asked questions",
+      "faqs": [
+        {
+          "question": "What is an AI-powered phone system?",
+          "answer": "An AI-powered phone system uses speech recognition and natural language understanding to answer calls, understand intent, respond conversationally, and route or escalate calls when needed.\n"
+        },
+        {
+          "question": "What types of calls can the AI handle?",
+          "answer": "Common enquiries such as FAQs, appointment bookings, order or case lookups, lead qualification, call routing and after-hours support, while escalating complex calls to a human.\n"
+        },
+        {
+          "question": "Can the AI transfer calls to a real person?",
+          "answer": "Yes. Calls can be transferred at any point based on intent, confidence level, keywords or customer request, ensuring a smooth handover without repeating information.\n"
+        },
+        {
+          "question": "Does this replace our existing phone system?",
+          "answer": "It depends on your starting point. We can integrate with your existing telephone provider and systems, extending what you already have rather than forcing a full replacement. Sometimes it's best to start fresh, particularly when migrating from a complex setup. Costs vary based on which path you take, and many customers see reduced overall costs.\n"
+        },
+        {
+          "question": "How accurate is the voice recognition?",
+          "answer": "Accuracy is high and improves over time. We train the system using your terminology, common phrases and call data, then continue refining it after launch.\n"
+        },
+        {
+          "question": "What happens in the free initial meeting?",
+          "answer": "You'll talk with one of our experienced Solution Architects and your Account Manager. You can discuss your project idea, business challenges and goals. We'll listen, ask questions, offer initial thoughts on potential approaches or technologies, and determine if SSW is the right fit to help you achieve your objectives. There's no obligation.\n",
+          "link": "https://www.ssw.com.au/rules/prepare-for-initial-meetings"
+        }
+      ],
+      "_template": "v3Faq"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
+      },
+      "heading": "Talk to us about implementing **AI** into your business today",
+      "description": "Get in touch and we'll set up an initial meeting to show you where we'd start\n",
+      "buttons": [
+        {
+          "buttonText": "Book a Free Initial Meeting",
+          "buttonLink": "#lead-capture-heading",
+          "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
           "icon": "BiPhone",
           "iconFirst": true,
           "colour": 1
-        },
-        {
-          "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "colour": 0
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Right",
-        "verticalPlacement": "Centered",
-        "mobilePlacement": "Above",
-        "imageHeight": 768,
-        "imageWidth": 1024,
-        "youtubeUrl": "https://www.youtube.com/watch?v=-q9lLqtkC00&t=5s",
-        "altText": "The Future of Business with AI - Why choose SSW"
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "background": {
-        "backgroundColour": 6
-      },
-      "heading": "Trusted in Sydney, Melbourne, Brisbane, and Newcastle by",
-      "paused": false,
-      "isWhiteImages": true,
-      "logos": [
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/event_cinemas_logo.png",
-          "scale": 200,
-          "altText": "Event Cinemas Logo"
-        },
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/7-removebg-preview.png",
-          "scale": 195,
-          "altText": "Toll Logo"
-        },
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/5-removebg-preview.png",
-          "scale": 180,
-          "altText": "Microsoft Logo"
-        },
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/6-removebg-preview.png",
-          "scale": 160,
-          "altText": "Symantec Logo"
-        },
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/4-removebg-preview.png",
-          "scale": 175,
-          "altText": "Domain Logo"
-        },
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/3-removebg-preview.png",
-          "scale": 170,
-          "altText": "CBA Logo"
-        },
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/2-removebg-preview.png",
-          "scale": 175,
-          "altText": "Cisco Logo"
-        },
-        {
-          "logo": "/images/Louis%20Test%20Images/Incident-io-batch/Logos/1-removebg-preview.png",
-          "scale": 195,
-          "altText": "Allianz Logo"
-        }
-      ],
-      "_template": "logoCarousel"
-    },
-    {
-      "isStacked": true,
-      "heading": "",
-      "isH1": false,
-      "body": "",
-      "cardStyle": 0,
-      "cards": [
-        {
-          "guid": "lxpq3m",
-          "altText": "Lorem Ipsum",
-          "icon": "BiBrain",
-          "heading": "Automate Calls Without Losing the Human Touch",
-          "description": "We design AI phone systems that handle routine conversations naturally, while seamlessly handing off to your team when it matters most.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "7mtu8j",
-          "altText": "Lorem Ipsum",
-          "icon": "BiMoneyWithdraw",
-          "heading": "Reduce Call Load and Operational Costs",
-          "description": "Our AI voice solutions answer, route, and resolve calls automatically - cutting client wait times and freeing up your team.",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
-        },
-        {
-          "guid": "5q8kz",
-          "altText": "Lorem Ipsum",
-          "icon": "BiUserVoice",
-          "heading": "Integrate Voice AI Into Your Existing Systems",
-          "description": "Connect your AI phone system with CRMs, booking systems, and internal tools so every call becomes structured, actionable data",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
-        }
-      ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "/images/ssw-web/background/bckg-9-25-ssw.png",
-        "bleed": true
-      },
-      "_template": "cardCarousel"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
-    },
-    {
-      "heading": "Frequently Asked Questions",
-      "body": "",
-      "accordionItems": [
-        {
-          "label": "What is an AI-powered phone system?",
-          "content": "An AI-powered phone system uses speech recognition and natural language understanding to answer calls, understand intent, respond conversationally, and route or escalate calls when needed.\n"
-        },
-        {
-          "label": "What types of calls can the AI handle?",
-          "content": "The AI can handle common enquiries such as FAQs, appointment bookings, order or case lookups, lead qualification, call routing, and after-hours support - while escalating complex calls to a human.\n"
-        },
-        {
-          "label": "Can the AI transfer calls to a real person?",
-          "content": "Yes. Calls can be transferred at any point based on intent, confidence level, keywords, or customer request, ensuring a smooth handover without repeating information.\n"
-        },
-        {
-          "label": "Does this replace our existing phone system?",
-          "content": "It depends on your starting point. We can integrate with your existing telephone provider and systems, extending what you already have rather than forcing a full replacement. In some cases, it’s best to start fresh — particularly when migrating from a complex setup — and costs vary based on whether you’re starting new or transitioning from another system, with many customers seeing reduced overall costs.\n"
-        },
-        {
-          "label": "How accurate is the voice recognition?",
-          "content": "Accuracy is high and improves over time. We train the system using your terminology, common phrases, and call data, and continuously refine it after launch.\n"
-        },
-        {
-          "label": "What happens in the free initial meeting?",
-          "content": "In this meeting, you'll talk with one of our experienced Solution Architects and your Account Manager. You can discuss your project idea, business challenges, and goals. We'll listen, ask questions, offer initial thoughts on potential approaches or technologies, and determine if SSW is the right fit to help you achieve your objectives. There's no obligation.\n"
-        }
-      ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "accordionBlock"
-    },
-    {
-      "isStacked": false,
-      "heading": "Related Technologies",
-      "isH1": false,
-      "body": "",
-      "cards": [
-        {
-          "guid": "h3ueb",
-          "altText": "Lorem Ipsum",
-          "icon": "BiLogoMicrosoft",
-          "heading": "Power Platform",
-          "description": "Build apps, automate workflows, and analyse data, all without heavy coding.",
-          "embeddedButton": {
-            "buttonText": "Read More",
-            "buttonLink": "https://www.ssw.com.au/consulting/power-platform"
-          }
-        },
-        {
-          "guid": "v93zjp",
-          "altText": "Lorem Ipsum",
-          "icon": "BiCommentCheck",
-          "heading": "Zendesk",
-          "description": "Streamline support by centralising all communication channels into one hub.",
-          "embeddedButton": {
-            "buttonText": "Read More",
-            "buttonLink": "https://www.ssw.com.au/consulting/zendesk"
-          }
-        },
-        {
-          "guid": "fm6ndo",
-          "altText": "Lorem Ipsum",
-          "icon": "BiCloudUpload",
-          "heading": "Intune",
-          "description": "A cloud-based unified management solution for mobile devices and operating systems. ",
-          "embeddedButton": {
-            "buttonText": "Read More",
-            "buttonLink": "https://www.ssw.com.au/consulting/intune"
-          }
-        },
-        {
-          "guid": "gylswt8",
-          "altText": "Lorem Ipsum",
-          "icon": "BiFingerprint",
-          "heading": "Azure Entra ID",
-          "description": "Secure identity and access management that keeps your people and apps connected.",
-          "embeddedButton": {
-            "buttonText": "Read More",
-            "buttonLink": "https://www.ssw.com.au/rules/managing-microsoft-entra-id/"
-          }
-        },
-        {
-          "guid": "e7umlf",
-          "altText": "",
-          "icon": "BiUserVoice",
-          "heading": "Service Desk",
-          "description": "Centralised support that resolves issues fast and keeps your operations running smoothly.",
-          "embeddedButton": {
-            "buttonText": "Read More",
-            "buttonLink": "https://www.ssw.com.au/consulting/service-desk"
-          }
-        }
-      ],
-      "background": {
-        "backgroundColour": 6,
-        "bleed": false
-      },
-      "_template": "cardCarousel"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
-    },
-    {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "Talk to us about implementing **AI** into your business today",
-      "isH1": false,
-      "description": "Connect with our Account Managers to discuss how we can help.\n",
-      "featureColumns": {
-        "twoColumns": true
-      },
-      "buttons": [
-        {
-          "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "colour": 0
-        }
-      ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": true
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "150px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3Cta"
     }
   ]
 }

--- a/content/consultingv2/artificial-intelligence.json
+++ b/content/consultingv2/artificial-intelligence.json
@@ -15,491 +15,377 @@
   "blocks": [
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "finalBreadcrumb": "Expert AI Consultants",
-      "_template": "breadcrumbs"
-    },
-    {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "Custom AI solutions, **expertly implemented**",
-      "isH1": true,
-      "description": "Our solutions go beyond basic automation to create real business value, turning AI into a genuine intellectual partner for your specific business challenges.\n",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "",
-            "description": ""
-          },
-          {
-            "heading": "",
-            "description": ""
-          }
-        ]
-      },
+      "brow": "AI CONSULTING",
+      "heading": "Build AI your business can actually rely on",
+      "description": "Most AI demos impress in the room and stall on the way to production. We build the ones that ship, grounded in your data, secured for your business, and measured on results you can point at.\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "leadCaptureFormOption": "",
+          "buttonLink": "#lead-capture-heading",
+          "iconFirst": false,
           "colour": 0
         },
         {
-          "buttonText": " AI Discovery Workshop",
-          "buttonLink": "/consulting/ai-discovery-workshop",
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
           "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "mobilePlacement": "Above",
-        "imageSource": "/images/Louis Test Images/Incident-io-batch/hero/hero_1400_700px(MS2).png",
-        "imageHeight": 700,
-        "imageWidth": 1400
-      },
-      "_template": "imageTextBlock"
+      "mediaType": "aiConsultingSvg",
+      "_template": "v3Hero"
     },
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7
       },
-      "heading": "Trusted in Sydney, Melbourne, Brisbane, and Newcastle by",
-      "paused": false,
-      "isWhiteImages": true,
+      "heading": "Trusted in Sydney, Melbourne, Brisbane and Newcastle by",
       "logos": [
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/7-removebg-preview.png",
-          "scale": 195
+          "logo": "/images/ssw-web/logos/toll_logo.png",
+          "altText": "Toll"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/6-removebg-preview.png",
-          "scale": 160
+          "logo": "/images/ssw-web/logos/symantec_logo.png",
+          "altText": "Symantec"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/5-removebg-preview.png",
-          "scale": 180
+          "logo": "/images/ssw-web/logos/microsoft_logo.png",
+          "altText": "Microsoft"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/4-removebg-preview.png",
-          "scale": 175
+          "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
+          "altText": "Event Cinemas"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/3-removebg-preview.png",
-          "scale": 170
+          "logo": "/images/ssw-web/logos/domain_logo.png",
+          "altText": "Domain"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/1-removebg-preview.png",
-          "scale": 195,
-          "altText": "Logo"
+          "logo": "/images/ssw-web/logos/cisco_logo.png",
+          "altText": "Cisco"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/2-removebg-preview.png",
-          "scale": 175
+          "logo": "/images/ssw-web/logos/cba_logo.png",
+          "altText": "Commonwealth Bank"
+        },
+        {
+          "logo": "/images/ssw-web/logos/allianz_logo.png",
+          "altText": "Allianz"
         }
       ],
-      "_template": "logoCarousel"
+      "_template": "v3LogoCarousel"
     },
     {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "From quick prototypes to secure AI models, **we make AI work for you.**",
-      "isH1": false,
-      "description": "AI can be overwhelming, but we make it simple. Our consultants analyze your systems and recommend practical AI solutions to improve efficiency, automate tasks, and extract insights from data.\n\nGet expert guidance to integrate AI where it matters most.\n",
-      "featureColumns": {
-        "twoColumns": false
-      },
-      "buttons": [
-        {
-          "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "iconFirst": true
-        },
-        {
-          "buttonText": "Rules to Better AI",
-          "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-ai/",
-          "icon": "BiSolidWrench",
-          "colour": 1
-        }
-      ],
       "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "/images/ssw-web/background/bckg-9-25-ssw.png",
-        "bleed": true
+        "backgroundColour": 7
       },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Left",
-        "mobilePlacement": "Above",
-        "youtubeUrl": "https://youtu.be/-q9lLqtkC00?si=ep-UD9gBNQ_gUcSR",
-        "altText": "The Future of Business with AI: Automation, Intelligence, and Customer Relations"
-      },
-      "_template": "imageTextBlock"
+      "brow": "BASED ON OUR EXPERIENCE",
+      "heading": "Why most AI projects never leave the demo",
+      "description": "Getting a model to say something clever takes an afternoon. Putting it in front of customers, on your data, inside your compliance rules, is a different job. This is where teams stall.\n",
+      "steps": [
+        {
+          "brow": "01",
+          "heading": "The pilot never reaches production",
+          "description": "The prototype wins the room, then hits hosting, security and evaluation. With no plan for any of it, the demo stays a demo.\n"
+        },
+        {
+          "brow": "02",
+          "heading": "It answers confidently and wrongly",
+          "description": "A model with no grounding in your data will happily invent an answer. One bad answer in front of a customer costs more than the project saved.\n"
+        },
+        {
+          "brow": "03",
+          "heading": "Nobody can prove it paid off",
+          "description": "Token spend climbs, value stays unmeasured, and the budget gets pulled before the useful part ever shipped.\n"
+        }
+      ],
+      "_template": "v3FeatureSteps"
     },
     {
-      "isStacked": true,
-      "heading": "",
-      "isH1": false,
-      "body": "",
-      "cardStyle": 0,
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true
+      },
+      "videoUrl": "https://youtu.be/-q9lLqtkC00",
+      "greyscaleThumbnail": true,
+      "figure": "Video: The Future of Business with AI - Automation, Intelligence and Customer Relations",
+      "heading": "Why choose SSW?",
+      "description": "SSW's Consulting Services have delivered best-in-class Microsoft solutions for thousands of clients in 15 countries for more than 30 years.\n",
+      "highlights": [
+        {
+          "title": "Deep expertise",
+          "desc2": "We go deep on every technology we touch - building with it, codifying best practices, and making that knowledge freely available\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-ai/",
+          "linkText": "Rules to Better AI"
+        },
+        {
+          "title": "Results over rhetoric",
+          "desc2": "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it actually work?\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "OUR PROCESS",
+      "heading": "What to expect working with SSW",
+      "description": "",
+      "steps": [
+        {
+          "heading": "Initial Call",
+          "description": "A short call with a senior engineer to talk through your project.\n",
+          "link": "https://www.ssw.com.au/rules/prepare-for-initial-meetings"
+        },
+        {
+          "heading": "AI Discovery Workshop",
+          "description": "A structured session to find where AI pays off in your business, and where it does not.\n",
+          "link": "/consulting/ai-discovery-workshop"
+        },
+        {
+          "heading": "Build & Deliver",
+          "description": "SSW can either handle the project from end-to-end or join your existing team, build your product, and ship your solution.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-scrum"
+        },
+        {
+          "heading": "Service Plan",
+          "description": "We can stay on post-launch to ensure a successful project handover.\n",
+          "link": "https://www.ssw.com.au/consulting/support-plans"
+        }
+      ],
+      "_template": "v3Process"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Tell us about **your** AI project",
+      "description": "Answer a few quick questions. We'll set up an initial meeting and show you where we'd start\n",
+      "_template": "v3LeadCapture"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Why teams choose SSW for AI Consulting",
+      "statistics": [
+        {
+          "figure": 7000,
+          "figureSuffix": "+",
+          "heading": "Solutions delivered",
+          "description": "Enterprise-grade software"
+        },
+        {
+          "figure": 1800,
+          "figureSuffix": "+",
+          "heading": "Happy clients",
+          "description": "Across all industries"
+        },
+        {
+          "figure": 30,
+          "figureSuffix": "+",
+          "heading": "Years experience",
+          "description": "Trusted since 1999"
+        }
+      ],
+      "_template": "v3Statistics"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
+      },
+      "testimonials": [
+        {
+          "quote": "You've got soccer players and then you have the professional soccer players. **They are the professional soccer players.**",
+          "caseStudyUrl": "/company/clients/fpe",
+          "authorName": "Thomas Bidou",
+          "authorTitle": "French Payroll Expert",
+          "authorImage": "/images/testimonialAvatars/thomas-bideau.png",
+          "authorImageAlt": "Thomas Bidou",
+          "companyLogo": "/images/clientLogos/FPE.png",
+          "companyLogoAlt": "French Payroll Expert"
+        }
+      ],
+      "_template": "v3Testimonials"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "BUILT BY SSW",
+      "videoUrl": "https://youtu.be/CBes1SEvV54",
+      "greyscaleThumbnail": true,
+      "figure": "Video: YakShaver - AI to make the perfect PBI in 30 seconds",
+      "heading": "We don't just talk about AI. We ship it.",
+      "description": "YakShaver is our own AI agent. It watches a screen recording, works out what needs doing, and writes the work item. It is the same approach we bring to your projects: practical AI, aimed at a task people actually repeat.\n",
+      "highlights": [
+        {
+          "title": "Real work, not a chatbot",
+          "desc2": "YakShaver replaced a task every developer does several times a day, which is where AI returns the most.\n",
+          "link": "https://www.ssw.com.au/articles/yakshaver-article",
+          "linkText": "Read the story"
+        },
+        {
+          "title": "Try it yourself",
+          "desc2": "It's free in the Chrome Web Store, so you can judge the output before you judge us.\n",
+          "link": "https://chromewebstore.google.com/detail/yakshaver/glcoihkbmomiblcbpnlkafcipcfnikjc",
+          "linkText": "Get the extension"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "Beyond the model",
+      "heading": "One team for the whole AI build",
+      "subtitle": "The model is the easy part. We build everything around it.",
       "cards": [
         {
-          "guid": "ib0xbk",
-          "altText": "Lorem Ipsum",
-          "icon": "BiLogoMicrosoft",
-          "heading": "Intelligent Automation, Precisely Applied",
-          "description": "We build automation that cuts through complexity and adapts to your specific business needs. No generic solutions, just practical AI that solves real problems.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "AI Discovery Workshop",
+          "description": "A structured day to find where AI pays off in your business.",
+          "link": "/consulting/ai-discovery-workshop"
         },
         {
-          "guid": "hukqtq",
-          "altText": "Lorem Ipsum",
-          "icon": "BiSolidLockAlt",
-          "heading": "Secure, Compliant Implementation",
-          "description": "AI models offer incredible capabilities but require proper security and compliance guardrails. We implement safeguards that protect your customer data, ensuring your solutions stay both powerful and compliant.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "Chat Bots",
+          "description": "Assistants grounded in your own documents, not the open internet.",
+          "link": "/consulting/chat-bots"
         },
         {
-          "guid": "65qp3c",
-          "altText": "Lorem Ipsum",
-          "icon": "BiSolidStar",
-          "heading": "Trusted Expertise at Scale",
-          "description": "From operational efficiency to customer experience, we scale AI solutions that deliver measurable results. Our team brings enterprise-level expertise to organizations of all size.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        }
-      ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "cardCarousel"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
-    },
-    {
-      "topLabel": {
-        "labelText": "Case Study"
-      },
-      "heading": "Boosting Payroll Expertise with a **Custom AI Chatbot**",
-      "isH1": false,
-      "description": "French Payroll Expert (FPE) spent too much time answering the same questions about French labor law. We built them a custom AI chatbot that delivers accurate, multilingual answers 24/7, directly from official sources.\n",
-      "chips": [
-        {
-          "chipText": "Semantic Kernel",
-          "chipType": "filledChip"
+          "title": "Local LLMs",
+          "description": "Run models on your own infrastructure, with your data staying put.",
+          "link": "/consulting/local-llm-deployment"
         },
         {
-          "chipText": "OpenAI",
-          "chipType": "filledChip"
+          "title": "Azure",
+          "description": "Cloud foundations that keep AI fast and affordable as it scales.",
+          "link": "/consulting/azure"
         }
       ],
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "Instant Answers, Any Language",
-            "description": "Clients get fast, 24/7 payroll answers in their own language. The AI uses verified French legislation, breaking down barriers."
-          },
-          {
-            "heading": "AI Becomes a Selling Point",
-            "description": "The chatbot isn't just support, it's a competitive edge that helped FPE attract new clients and win more business."
-          }
-        ]
-      },
-      "buttons": [
-        {
-          "buttonText": "Read the full story",
-          "buttonLink": "https://www.ssw.com.au/company/clients/fpe",
-          "colour": 0
-        }
-      ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Right",
-        "verticalPlacement": "Centered",
-        "mobilePlacement": "Above",
-        "youtubeUrl": "https://www.youtube.com/watch?v=YlsbPEvVyq4"
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
-    },
-    {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "**YakShaver:** Our AI Agent in Action",
-      "isH1": false,
-      "description": "At SSW, we don't just talk about AI, we build it. YakShaver is our AI solution that automates work item creation, proving how AI can streamline repetitive dev tasks.\n\nBeyond the typical chatbot, YakShaver shows how AI capabilities can transform development workflows.\n\nIt's the same approach we bring to your projects, practical AI that delivers real results.\n",
-      "featureColumns": {
-        "twoColumns": true
-      },
-      "buttons": [
-        {
-          "buttonText": "Give it a try",
-          "buttonLink": "https://chromewebstore.google.com/detail/yakshaver/glcoihkbmomiblcbpnlkafcipcfnikjc?pli=1"
-        },
-        {
-          "buttonText": "Learn more",
-          "buttonLink": "https://www.ssw.com.au/articles/yakshaver-article",
-          "colour": 1
-        }
-      ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Left",
-        "verticalPlacement": "Centered",
-        "mobilePlacement": "Above",
-        "youtubeUrl": "https://youtu.be/CBes1SEvV54?si=LV2O5t0MthCIaYIF",
-        "altText": "YakShaver - AI to make the perfect PBI in 30 seconds"
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3StackCards"
     },
     {
       "isStacked": false,
-      "heading": "Tech Wisdom from the Trenches",
+      "brow": "learn more on SSWTV",
+      "heading": "Tech wisdom from the trenches",
       "isH1": false,
-      "body": "At SSW, we’ve been knee-deep in projects for years: debugging giant solutions, fixing game-stopping bugs, and staying on the cutting edge. No guesswork, just proven tips that help you build better software.",
-      "cardStyle": 1,
+      "body": "At SSW, we've been building enterprise projects for thirty years: We're thought leaders in software architecture, and document all our learning for free on the SSW Rules and SSW TV.",
+      "tabletTextAlignment": "Left",
       "cards": [
         {
           "guid": "arf4s",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=LzFG7pUylZo",
-          "altText": "AI",
-          "chips": [
-            {
-              "chipText": "AI Use",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "6 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "If you think AI is cheating, you're doing it wrong!",
-          "description": "AI is the tool of this generation, but are we using it responsibly? Ulysses Maclaren dives into the best practices for AI use - covering transparency, critical thinking, data privacy, and how to leverage AI to boost productivity. Learn why using AI intelligently is the key to staying ahead in your career.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "altText": "If you think AI is cheating, you're doing it wrong!",
+          "category": "AI Use",
+          "heading": "If you think AI is cheating, you're doing it wrong!"
         },
         {
           "guid": "ui7a6e",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=BlqJ7bnivLE",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Trends",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "90 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "The Year of the AI Agent: Automation to Intelligence",
-          "description": "Dive into the future of AI with Ulysses Maclaren in this insightful SSW User Group session! Explore the exciting shift from automation to true AI intelligence and discover what the year of the AI agent holds for developers.",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
+          "altText": "The Year of the AI Agent: Automation to Intelligence",
+          "category": "AI Trends",
+          "heading": "The Year of the AI Agent: Automation to Intelligence"
         },
         {
           "guid": "hhszy",
           "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/sVELvhGdSfs?si=YgXhKVW1AOiyx-CQ",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Model Guides",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "3 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "Choosing the Right AI Model? GitHub Models Makes It Easy!",
-          "description": "Confused about selecting the perfect AI model? Join Isaac Lombard and Caleb Williams as they explore how GitHub Models simplifies the process! Discover the ease of finding and utilizing AI models for your projects in this quick guide.",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
-        },
-        {
-          "guid": "20ehn",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/Us04IRcNJ9c?si=e03yF4HpD0eFosqu",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "Multi-Language AI Apps",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "60 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "Creating Multi-Language AI-Powered Apps w/ Rust, Python & Blazor",
-          "description": "Discover how to build AI-powered applications that speak multiple languages! Join TJ Gokken in this User Group session as he dives into the world of multi-language app development using Rust, Python, and Blazor. Learn practical techniques and best practices for creating global-ready AI solutions.",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
+          "youtubeUrl": "https://youtu.be/sVELvhGdSfs",
+          "altText": "Choosing the Right AI Model? GitHub Models Makes It Easy!",
+          "category": "AI Model Guides",
+          "heading": "Choosing the Right AI Model? GitHub Models Makes It Easy!"
         },
         {
           "guid": "hupqdh",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=WwF69cj8490",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Strategy",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "8 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "How to supercharge a company with AI",
-          "description": "Supercharge your company with AI!  🚀  See how SSW transformed their business and Tina CMS using practical AI strategies, from customer support chatbots to AI-powered product features.  Discover actionable tips to implement AI",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "altText": "How to supercharge a company with AI",
+          "category": "AI Strategy",
+          "heading": "How to supercharge a company with AI"
         },
         {
           "guid": "akn4ur",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=_Lx1DmMMJbg",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Strategy",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "1 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "Do you provide an llms.txt file to make your website LLM-friendly?",
-          "description": "Ever wondered how to make your website visible to AI models like ChatGPT, Claude, and Cursor? 🤖 Traditional SEO is all about optimizing for search engines, but in the AI era, we need to rethink our approach!",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "altText": "Do you provide an llms.txt file to make your website LLM-friendly?",
+          "category": "AI Strategy",
+          "heading": "Do you provide an llms.txt file to make your website LLM-friendly?"
         }
       ],
       "background": {
-        "backgroundColour": 2
+        "backgroundColour": 7
       },
-      "_template": "cardCarousel"
+      "_template": "v3CardCarousel"
     },
     {
-      "technologies": [
+      "background": {
+        "backgroundColour": 8
+      },
+      "heading": "Frequently asked questions",
+      "faqs": [
         {
-          "technology": "content/v2Technologies/technologies/GitHub-Copilot-v2.mdx"
+          "question": "How much does it cost?",
+          "answer": "Every engagement is scoped to your goals, so there's no single price. The initial call is always 100% **free**. The specification review will be used to give the most accurate estimation possible for a projects scope, price and duration.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
         },
         {
-          "technology": "content/v2Technologies/technologies/Google-Vertex-AI-v2.mdx"
+          "question": "Will our data be used to train someone else's model?",
+          "answer": "Not unless you want it to. We build on enterprise agreements where your prompts and data are not used for training, and where the requirement is stricter, we deploy models to your own infrastructure so nothing leaves your environment.\n",
+          "link": "https://www.ssw.com.au/consulting/local-llm-deployment"
         },
         {
-          "technology": "content/v2Technologies/technologies/Microsoft-AutoGen.mdx"
+          "question": "Which AI model should we use?",
+          "answer": "That's a decision we make together, with your data, your budget and your compliance rules on the table. We build so the model can be swapped later, because the best one today rarely stays the best one for long.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-ai/"
         },
         {
-          "technology": "content/v2Technologies/technologies/Python.mdx"
+          "question": "Do you work with our existing team?",
+          "answer": "Yes! We can either take over a project from end-to-end with our own team at SSW, or embed our developers into your existing team.\n",
+          "link": "https://www.ssw.com.au/consulting/mentoring"
         },
         {
-          "technology": "content/v2Technologies/technologies/Semantic-Kernel-v2.mdx"
+          "question": "How does SSW ensure quality and success of a software project?",
+          "answer": "Quality and success are the heart of our processes; we use:\n\n* Clean Architecture: Designing for scalability, testability, and maintainability.\n* Scrum Methodology: Ensuring transparency, client involvement, and adaptability through fast feedback loops.\n* DevOps Practices: Streamlining development and deployment for faster delivery and reliability.\n* Best Practices: Adhering to and sharing industry best practices (via SSW Rules and SSW TV).\n* Expert Teams: Employing rigorously hired and continuously developed technical experts.\n* Strong Communication: Keeping clients informed and involved throughout the project lifecycle.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-successful-projects"
         }
       ],
-      "isStacked": false,
-      "techCardStyle": 0,
-      "background": {
-        "backgroundColour": 3
-      },
-      "_template": "technologyCardCarousel"
+      "_template": "v3Faq"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "Talk to Us About Your AI Project Today",
-      "isH1": false,
-      "description": "Connect with our Account Managers to discuss how we can help.\n",
-      "featureColumns": {
-        "twoColumns": true
-      },
+      "heading": "Let's build AI you can put in front of customers",
+      "description": "Get in touch and we'll set up an initial meeting to show you where we'd start\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "100px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3Cta"
     }
   ]
 }

--- a/content/consultingv2/artificial-intelligence.json
+++ b/content/consultingv2/artificial-intelligence.json
@@ -31,17 +31,18 @@
           "colour": 0
         },
         {
-          "buttonText": "+61 2 9953 3000",
-          "buttonLink": "tel:+61299533000",
-          "icon": "BiPhone",
-          "iconFirst": true,
+          "buttonText": "AI Discovery Workshop",
+          "buttonLink": "/consulting/ai-discovery-workshop",
+          "icon": "BiChevronRight",
+          "iconFirst": false,
           "colour": 1
         }
       ],
       "mediaType": "image",
       "image": {
-        "imageHeight": 1432,
-        "imageWidth": 2555
+        "imageSource": "/images/ssw-web/hero/Jean.JPG",
+        "imageHeight": 1926,
+        "imageWidth": 2889
       },
       "_template": "v3Hero"
     },
@@ -96,17 +97,17 @@
       "steps": [
         {
           "brow": "01",
-          "heading": "We build automation that fits your business",
+          "heading": "Automation that fits your business",
           "description": "We study how your business operates before we build anything. The automation we deliver is shaped around your systems and your problems, so it works from day one.\n"
         },
         {
           "brow": "02",
-          "heading": "We implement with security and compliance from dya one",
-          "description": "AI is only as good as the guardrails around it. We put safeguards in place to protect your customer data, so your solution stays powerful and compliant.\n"
+          "heading": "Security and compliance from day one",
+          "description": "AI is only as good as the guardrails around it. We put safeguards in place to protect your customer data, so your solution stays both powerful and compliant.\n"
         },
         {
           "brow": "03",
-          "heading": "We bring enterprise expertise, at any scale",
+          "heading": "Enterprise expertise, at any scale",
           "description": "From operational efficiency to customer experience, our team has delivered AI solutions at enterprise level. We bring that same rigor to organizations of every size, with results you can measure.\n"
         }
       ],
@@ -118,7 +119,7 @@
         "gridOverlay": true
       },
       "videoUrl": "https://youtu.be/-q9lLqtkC00",
-      "greyscaleThumbnail": true,
+      "greyscaleThumbnail": false,
       "figure": "Video: The Future of Business with AI - Automation, Intelligence and Customer Relations",
       "heading": "Why choose SSW?",
       "description": "SSW's Consulting Services have delivered best-in-class Microsoft solutions for thousands of clients in 15 countries for more than 30 years.\n",
@@ -150,9 +151,9 @@
           "link": "https://www.ssw.com.au/rules/prepare-for-initial-meetings"
         },
         {
-          "heading": "AI Discovery Workshop",
-          "description": "A structured session to find where AI pays off in your business, and where it does not.\n",
-          "link": "/consulting/ai-discovery-workshop"
+          "heading": "Spec Review",
+          "description": "A clear, costed plan with scope, timing and the fastest path to ROI.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
         },
         {
           "heading": "Build & Deliver",
@@ -212,6 +213,7 @@
         {
           "quote": "You've got soccer players and then you have the professional soccer players. **They are the professional soccer players.**",
           "caseStudyUrl": "/company/clients/fpe",
+          "caseStudyLabel": "See case study video",
           "authorName": "Thomas Bidou",
           "authorTitle": "French Payroll Expert",
           "authorImage": "/images/testimonialAvatars/thomas-bideau.png",
@@ -227,7 +229,7 @@
         "backgroundColour": 7
       },
       "videoUrl": "https://youtu.be/CBes1SEvV54",
-      "greyscaleThumbnail": true,
+      "greyscaleThumbnail": false,
       "figure": "Video: YakShaver - AI to make the perfect PBI in 30 seconds",
       "brow": "BUILT BY SSW",
       "heading": "We don't just talk about AI. We ship it.",

--- a/content/consultingv2/artificial-intelligence.json
+++ b/content/consultingv2/artificial-intelligence.json
@@ -17,6 +17,16 @@
       "background": {
         "backgroundColour": 7,
         "gridOverlay": true,
+        "redGlow": false
+      },
+      "finalBreadcrumb": "Expert AI Consultants",
+      "_template": "breadcrumbs"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
         "redGlow": true
       },
       "brow": "AI CONSULTING",
@@ -33,7 +43,6 @@
         {
           "buttonText": "AI Discovery Workshop",
           "buttonLink": "/consulting/ai-discovery-workshop",
-          "icon": "BiChevronRight",
           "iconFirst": false,
           "colour": 1
         }
@@ -116,6 +125,7 @@
     {
       "background": {
         "backgroundColour": 7,
+        "bleed": true,
         "gridOverlay": true,
         "redGlow": true
       },
@@ -153,7 +163,7 @@
         },
         {
           "title": "Results over rhetoric",
-          "desc2": "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it actually work?\n"
+          "desc2": "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it work?\n"
         }
       ],
       "_template": "v3VideoHighlights"
@@ -233,7 +243,7 @@
       "figure": "Video: YakShaver - AI to make the perfect PBI in 30 seconds",
       "brow": "BUILT BY SSW",
       "heading": "We don't just talk about AI. We ship it.",
-      "description": "YakShaver is our own AI agent. It watches a screen recording, works out what needs doing, and writes the work item. It is the same approach we bring to your projects: practical AI, aimed at a task people actually repeat.\n",
+      "description": "YakShaver watches a screen recording, works out what needs doing, and writes the work item before you've finished talking. No forms, no triage, no Monday morning spent tidying the backlog. It's a great example of the sort of intelligence and automation we can bring to your company\n",
       "highlights": [
         {
           "title": "Real work, not a chatbot",
@@ -243,9 +253,9 @@
         },
         {
           "title": "Try it yourself",
-          "desc2": "It's free in the Chrome Web Store, so you can judge the output before you judge us.\n",
-          "link": "https://chromewebstore.google.com/detail/yakshaver/glcoihkbmomiblcbpnlkafcipcfnikjc",
-          "linkText": "Get the extension"
+          "desc2": "Put YakShaver to the test with your own screen recording. It's free to try at yakshaver.ai\n",
+          "link": "https://www.yakshaver.ai",
+          "linkText": "Try it now"
         }
       ],
       "_template": "v3VideoHighlights"
@@ -264,9 +274,9 @@
           "link": "/consulting/ai-discovery-workshop"
         },
         {
-          "title": "Chat Bots",
-          "description": "Assistants grounded in your own documents, not the open internet.",
-          "link": "/consulting/chat-bots"
+          "title": "Vibe Coding",
+          "description": "Ship faster by putting AI to work inside your dev team.",
+          "link": "/consulting/vibe-coding"
         },
         {
           "title": "Local LLMs",
@@ -307,7 +317,7 @@
           "label": "DeepSeek"
         },
         {
-          "label": "LLama"
+          "label": "Spark"
         },
         {
           "label": "Mistral"
@@ -316,7 +326,7 @@
           "label": "Gemma"
         },
         {
-          "label": "Kimi"
+          "label": "Kimi K"
         }
       ],
       "_template": "v3Pills"

--- a/content/consultingv2/artificial-intelligence.json
+++ b/content/consultingv2/artificial-intelligence.json
@@ -116,6 +116,27 @@
     {
       "background": {
         "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
+      },
+      "testimonials": [
+        {
+          "quote": "You've got soccer players and then you have the professional soccer players. **They are the professional soccer players.**",
+          "caseStudyUrl": "/company/clients/fpe",
+          "caseStudyLabel": "See case study video",
+          "authorName": "Thomas Bidou",
+          "authorTitle": "French Payroll Expert",
+          "authorImage": "/images/testimonialAvatars/thomas-bideau.png",
+          "authorImageAlt": "Thomas Bidou",
+          "companyLogo": "/images/clientLogos/FPE.png",
+          "companyLogoAlt": "French Payroll Expert"
+        }
+      ],
+      "_template": "v3Testimonials"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
         "gridOverlay": true
       },
       "videoUrl": "https://youtu.be/-q9lLqtkC00",
@@ -205,27 +226,6 @@
     },
     {
       "background": {
-        "backgroundColour": 7,
-        "gridOverlay": true,
-        "redGlow": true
-      },
-      "testimonials": [
-        {
-          "quote": "You've got soccer players and then you have the professional soccer players. **They are the professional soccer players.**",
-          "caseStudyUrl": "/company/clients/fpe",
-          "caseStudyLabel": "See case study video",
-          "authorName": "Thomas Bidou",
-          "authorTitle": "French Payroll Expert",
-          "authorImage": "/images/testimonialAvatars/thomas-bideau.png",
-          "authorImageAlt": "Thomas Bidou",
-          "companyLogo": "/images/clientLogos/FPE.png",
-          "companyLogoAlt": "French Payroll Expert"
-        }
-      ],
-      "_template": "v3Testimonials"
-    },
-    {
-      "background": {
         "backgroundColour": 7
       },
       "videoUrl": "https://youtu.be/CBes1SEvV54",
@@ -280,6 +280,46 @@
         }
       ],
       "_template": "v3StackCards"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "",
+      "heading": "AI Models We Work With",
+      "pills": [
+        {
+          "label": "Claude"
+        },
+        {
+          "label": "ChatGPT"
+        },
+        {
+          "label": "Gemini"
+        },
+        {
+          "label": "Microsoft Copilot"
+        },
+        {
+          "label": "Grok"
+        },
+        {
+          "label": "DeepSeek"
+        },
+        {
+          "label": "LLama"
+        },
+        {
+          "label": "Mistral"
+        },
+        {
+          "label": "Gemma"
+        },
+        {
+          "label": "Kimi"
+        }
+      ],
+      "_template": "v3Pills"
     },
     {
       "isStacked": false,

--- a/content/consultingv2/artificial-intelligence.json
+++ b/content/consultingv2/artificial-intelligence.json
@@ -20,8 +20,8 @@
         "redGlow": true
       },
       "brow": "AI CONSULTING",
-      "heading": "Build AI your business can actually rely on",
-      "description": "Most AI demos impress in the room and stall on the way to production. We build the ones that ship, grounded in your data, secured for your business, and measured on results you can point at.\n",
+      "heading": " Custom AI solutions, expertly implemented",
+      "description": "Our solutions go beyond basic automation to create real business value, turning AI into a genuine intellectual partner for your specific business challenges.\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
@@ -38,7 +38,11 @@
           "colour": 1
         }
       ],
-      "mediaType": "aiConsultingSvg",
+      "mediaType": "image",
+      "image": {
+        "imageHeight": 1432,
+        "imageWidth": 2555
+      },
       "_template": "v3Hero"
     },
     {
@@ -87,23 +91,23 @@
         "backgroundColour": 7
       },
       "brow": "BASED ON OUR EXPERIENCE",
-      "heading": "Why most AI projects never leave the demo",
-      "description": "Getting a model to say something clever takes an afternoon. Putting it in front of customers, on your data, inside your compliance rules, is a different job. This is where teams stall.\n",
+      "heading": "Why teams trust us to get AI right",
+      "description": "AI can be overwhelming, but we make it simple. Our consultants analyze your systems and recommend practical AI solutions to improve efficiency, automate tasks, and extract insights from data.\n\nGet expert guidance to integrate AI where it matters most.\n",
       "steps": [
         {
           "brow": "01",
-          "heading": "The pilot never reaches production",
-          "description": "The prototype wins the room, then hits hosting, security and evaluation. With no plan for any of it, the demo stays a demo.\n"
+          "heading": "We build automation that fits your business",
+          "description": "We study how your business operates before we build anything. The automation we deliver is shaped around your systems and your problems, so it works from day one.\n"
         },
         {
           "brow": "02",
-          "heading": "It answers confidently and wrongly",
-          "description": "A model with no grounding in your data will happily invent an answer. One bad answer in front of a customer costs more than the project saved.\n"
+          "heading": "We implement with security and compliance from dya one",
+          "description": "AI is only as good as the guardrails around it. We put safeguards in place to protect your customer data, so your solution stays powerful and compliant.\n"
         },
         {
           "brow": "03",
-          "heading": "Nobody can prove it paid off",
-          "description": "Token spend climbs, value stays unmeasured, and the budget gets pulled before the useful part ever shipped.\n"
+          "heading": "We bring enterprise expertise, at any scale",
+          "description": "From operational efficiency to customer experience, our team has delivered AI solutions at enterprise level. We bring that same rigor to organizations of every size, with results you can measure.\n"
         }
       ],
       "_template": "v3FeatureSteps"
@@ -222,10 +226,10 @@
       "background": {
         "backgroundColour": 7
       },
-      "brow": "BUILT BY SSW",
       "videoUrl": "https://youtu.be/CBes1SEvV54",
       "greyscaleThumbnail": true,
       "figure": "Video: YakShaver - AI to make the perfect PBI in 30 seconds",
+      "brow": "BUILT BY SSW",
       "heading": "We don't just talk about AI. We ship it.",
       "description": "YakShaver is our own AI agent. It watches a screen recording, works out what needs doing, and writes the work item. It is the same approach we bring to your projects: practical AI, aimed at a task people actually repeat.\n",
       "highlights": [
@@ -357,7 +361,7 @@
         },
         {
           "question": "How does SSW ensure quality and success of a software project?",
-          "answer": "Quality and success are the heart of our processes; we use:\n\n* Clean Architecture: Designing for scalability, testability, and maintainability.\n* Scrum Methodology: Ensuring transparency, client involvement, and adaptability through fast feedback loops.\n* DevOps Practices: Streamlining development and deployment for faster delivery and reliability.\n* Best Practices: Adhering to and sharing industry best practices (via SSW Rules and SSW TV).\n* Expert Teams: Employing rigorously hired and continuously developed technical experts.\n* Strong Communication: Keeping clients informed and involved throughout the project lifecycle.\n",
+          "answer": "Quality and success are the heart of our processes; we use:\n\nClean Architecture: Designing for scalability, testability, and maintainability.\n\nScrum Methodology: Ensuring transparency, client involvement, and adaptability through fast feedback loops.\n\nDevOps Practices: Streamlining development and deployment for faster delivery and reliability.\n\nBest Practices: Adhering to and sharing industry best practices (via SSW Rules and SSW TV).\n\nExpert Teams: Employing rigorously hired and continuously developed technical experts.\n\nStrong Communication: Keeping clients informed and involved throughout the project lifecycle.\n",
           "link": "https://www.ssw.com.au/rules/rules-to-successful-projects"
         }
       ],

--- a/content/consultingv2/azure.json
+++ b/content/consultingv2/azure.json
@@ -15,313 +15,299 @@
   },
   "blocks": [
     {
-      "finalBreadcrumb": "Azure consultants - Landing zones, migration & DevOps | SSW",
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": false
+      },
+      "finalBreadcrumb": "Azure Consultants",
       "_template": "breadcrumbs"
     },
     {
-      "topLabel": {
-        "labelText": "Azure Consulting"
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "From quick assessments to secure, scalable platforms, **we make Azure work for you.**",
-      "isH1": false,
-      "description": "Azure can be complex. We keep it simple and outcome-driven. Our consultants analyse your environment and deliver practical improvements that boost reliability, security, and speed while keeping costs under control.\n",
-      "tabletTextAlignment": "Left",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "Built for real-world cloud teams",
-            "description": "From strategy to hands-on delivery, we help you get Azure right the first time.",
-            "icon": "BiAnalyse"
-          },
-          {
-            "heading": "Secure, scalable, and cost-efficient",
-            "description": "Get guidance that improves reliability, strengthens security, and cuts unnecessary spend.",
-            "icon": "BiShieldAlt2"
-          }
-        ]
-      },
+      "brow": "AZURE CONSULTING",
+      "heading": "From quick assessments to secure, scalable platforms, **we make Azure work for you**",
+      "description": "Azure can be complex. We keep it simple and outcome-driven. Our consultants analyse your environment and deliver practical improvements that boost reliability, security and speed while keeping costs under control.\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "placement": "Right",
-        "imageSource": "/images/Louis%20Test%20Images/Incident-io-batch/hero/hero_1400_700px(MS2).png",
-        "imageHeight": 700,
+      "mediaType": "image",
+      "image": {
+        "altText": "SSW Azure consultants at work",
+        "imageSource": "/images/ssw-web/hero/hero_1400_700px(MS2).png",
         "imageWidth": 1400,
-        "altText": "Meeting with an Azure Solution Architect"
+        "imageHeight": 700
       },
-      "_template": "imageTextBlock"
+      "_template": "v3Hero"
     },
     {
       "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "/images/ssw-web/background/bckg-9-25-ssw.png"
+        "backgroundColour": 7
       },
-      "heading": "Trusted in Sydney, Melbourne, Brisbane, and Newcastle by",
-      "tabletTextAlignment": "Center",
-      "isWhiteImages": true,
+      "heading": "Trusted in Sydney, Melbourne, Brisbane and Newcastle by",
       "logos": [
+        { "logo": "/images/ssw-web/logos/toll_logo.png", "altText": "Toll" },
         {
-          "logo": "/images/ssw-web/logos/allianz_logo.png",
-          "altText": "Allianz"
-        },
-        {
-          "logo": "/images/ssw-web/logos/cba_logo.png",
-          "altText": "CommBank"
-        },
-        {
-          "logo": "/images/ssw-web/logos/cisco_logo.png",
-          "altText": "Cisco"
-        },
-        {
-          "logo": "/images/ssw-web/logos/domain_logo.png",
-          "altText": "Domain"
-        },
-        {
-          "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
-          "altText": "Event"
+          "logo": "/images/ssw-web/logos/symantec_logo.png",
+          "altText": "Symantec"
         },
         {
           "logo": "/images/ssw-web/logos/microsoft_logo.png",
           "altText": "Microsoft"
         },
         {
-          "logo": "/images/ssw-web/logos/ASF-Transparent.png",
-          "altText": "ASF"
+          "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
+          "altText": "Event Cinemas"
         },
         {
-          "logo": "/images/ssw-web/logos/toll_logo.png",
-          "altText": "Toll"
+          "logo": "/images/ssw-web/logos/domain_logo.png",
+          "altText": "Domain"
+        },
+        { "logo": "/images/ssw-web/logos/cisco_logo.png", "altText": "Cisco" },
+        {
+          "logo": "/images/ssw-web/logos/cba_logo.png",
+          "altText": "Commonwealth Bank"
         },
         {
-          "logo": "/images/ssw-web/logos/symantec_logo.png",
-          "altText": "Symantec"
+          "logo": "/images/ssw-web/logos/allianz_logo.png",
+          "altText": "Allianz"
         }
       ],
-      "_template": "logoCarousel"
+      "_template": "v3LogoCarousel"
     },
     {
-      "topLabel": {
-        "labelText": "Azure services"
-      },
-      "heading": "Planning a move to Azure? Start with a proven **migration roadmap.**",
-      "isH1": false,
-      "description": "We work with regulated, high-scale, multi-subscription Azure estates. Our consultants review your environment, identify quick wins, and deliver secure, scalable cloud solutions that reduce cost and improve performance.\n\nWhether you’re migrating, modernizing, or tightening security, we give you a clear path forward.\n",
-      "tabletTextAlignment": "Center",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "Practical advice, proven results",
-            "description": "We analyse your environment and give you a clear plan with fast, low-risk wins.",
-            "icon": "BiAtom"
-          },
-          {
-            "heading": "Control your costs",
-            "description": "SpendOps guidance that keeps your Azure bill predictable and transparent.",
-            "icon": "BiDollarCircle"
-          }
-        ]
-      },
-      "buttons": [
-        {
-          "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "colour": 0
-        },
-        {
-          "buttonText": "Rules to better Azure ",
-          "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-azure/",
-          "icon": "BiSolidCloud",
-          "colour": 1
-        }
-      ],
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7
       },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Left",
-        "youtubeUrl": "https://youtu.be/Ai2Xv1jq3_s"
-      },
-      "_template": "imageTextBlock"
+      "brow": "AZURE SERVICES",
+      "heading": "Planning a move to Azure? Start with a proven **migration roadmap**",
+      "description": "We work with regulated, high-scale, multi-subscription Azure estates. Our consultants review your environment, identify quick wins, and deliver secure, scalable cloud solutions that reduce cost and improve performance. Whether you're migrating, modernising or tightening security, you get a clear plan.\n",
+      "steps": [
+        {
+          "brow": "01",
+          "heading": "Built for real-world cloud teams",
+          "description": "From strategy to hands-on delivery, we help you get Azure right the first time.\n"
+        },
+        {
+          "brow": "02",
+          "heading": "Secure, scalable and cost-efficient",
+          "description": "Guidance that improves reliability, strengthens security, and cuts unnecessary spend.\n"
+        },
+        {
+          "brow": "03",
+          "heading": "Practical advice, proven results",
+          "description": "We analyse your environment and give you a clear plan with fast, low-risk wins.\n"
+        },
+        {
+          "brow": "04",
+          "heading": "Control your costs",
+          "description": "SpendOps guidance that keeps your Azure bill predictable and transparent.\n"
+        }
+      ],
+      "_template": "v3FeatureSteps"
     },
     {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true
+      },
+      "videoUrl": "https://youtu.be/Ai2Xv1jq3_s",
+      "heading": "Why choose SSW?",
+      "description": "SSW's Consulting Services have delivered best-in-class Microsoft solutions for thousands of clients in 15 countries for more than 30 years.\n",
+      "highlights": [
+        {
+          "title": "Deep expertise",
+          "desc2": "We go deep on every technology we touch - building with it, codifying best practices, and making that knowledge freely available\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-azure/",
+          "linkText": "Rules to Better Azure"
+        },
+        {
+          "title": "Results over rhetoric",
+          "desc2": "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it work?\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "videoUrl": "https://youtu.be/whXWijQCQTU",
+      "brow": "FOUNDATIONS",
       "heading": "Azure Landing Zones",
-      "body": "A clear, secure, repeatable foundation for any workload in Azure.",
-      "tabletTextAlignment": "Center",
-      "accordionItems": [
+      "description": "A clear, secure, repeatable foundation for any workload in Azure. Get the subscription design, networking, identity and guardrails right once, and every workload after it lands faster.\n",
+      "highlights": [
         {
-          "label": "Cloud Migrations",
-          "content": "We assess your existing environment, plan the move, and migrate workloads safely into Azure. Whether it’s rehost, refactor, or modernise, we ensure reliability and cost efficiency.\n"
+          "title": "Secure by default",
+          "desc2": "Policy, identity and network guardrails baked into the foundation rather than retrofitted after an audit.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-cloud-security/",
+          "linkText": "Rules to Better Cloud Security"
         },
         {
-          "label": "DevOps & CI/CD Automation",
-          "content": "We build automated CI/CD pipelines with Azure DevOps or GitHub Actions, improve deployment speed, reduce failures, and set you up with a clean development workflow.\n"
+          "title": "Costs you can predict",
+          "desc2": "Tagging, budgets and right-sizing from day one, so the bill stays explainable as the estate grows.\n",
+          "link": "https://www.ssw.com.au/rules/reduce-azure-costs/",
+          "linkText": "Cost Optimization in Azure"
         }
       ],
-      "buttons": [
-        {
-          "buttonText": "Rules to Better Cloud Security",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-cloud-security/",
-          "colour": 1
-        },
-        {
-          "buttonText": "Cost Optimization in Azure Rule",
-          "buttonLink": "https://www.ssw.com.au/rules/reduce-azure-costs/",
-          "colour": 1
-        }
-      ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Right",
-        "youtubeUrl": "https://youtu.be/whXWijQCQTU?si=epp1wOYCkjuX2Gx7"
-      },
-      "_template": "accordionBlock"
+      "_template": "v3VideoHighlights"
     },
     {
-      "isStacked": false,
-      "heading": "Related Technologies",
-      "isH1": false,
-      "body": "",
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "OUR PROCESS",
+      "heading": "What to expect working with SSW",
+      "steps": [
+        {
+          "heading": "Initial Call",
+          "description": "A short call with a senior engineer to talk through your project.\n",
+          "link": "https://www.ssw.com.au/rules/prepare-for-initial-meetings"
+        },
+        {
+          "heading": "Spec Review",
+          "description": "A clear, costed plan with scope, timing and the fastest path to ROI.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
+        },
+        {
+          "heading": "Build & Deliver",
+          "description": "SSW can either handle the project from end-to-end or join your existing team, build your product, and ship your solution.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-scrum"
+        },
+        {
+          "heading": "Service Plan",
+          "description": "We can stay on post-launch to ensure a successful project handover.\n",
+          "link": "https://www.ssw.com.au/consulting/support-plans"
+        }
+      ],
+      "_template": "v3Process"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Tell us about **your** Azure project",
+      "description": "Answer a few quick questions. We'll set up an initial meeting and show you where we'd start\n",
+      "_template": "v3LeadCapture"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "Related Services",
+      "heading": "The rest of the Azure estate",
+      "subtitle": "Landing zones are the start. These are the workloads that usually land on them.",
       "cards": [
         {
-          "guid": "ik9aho",
-          "altText": "Lorem Ipsum",
-          "icon": "BiSolidBarChartAlt2",
-          "heading": "Azure Synapse",
-          "description": "An integrated enterprise analytics service that unifies data warehousing and big data systems.",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.ssw.com.au/consulting/azure-synapse"
-          }
+          "title": "Azure Synapse",
+          "description": "Enterprise analytics that unifies data warehousing and big data systems.",
+          "link": "/consulting/azure-synapse"
         },
         {
-          "guid": "jhhhl9",
-          "altText": "Lorem Ipsum",
-          "icon": "BiCloud",
-          "heading": "Azure App Service",
-          "description": "A fully managed platform-as-a-service (PaaS) for hosting web applications, REST APIs, and mobile backends.",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-azure"
-          }
+          "title": "Database Development",
+          "description": "Limitless, trusted, AI-ready apps on a fully managed SQL database.",
+          "link": "/consulting/database-development"
         },
         {
-          "guid": "jk7m5l",
-          "altText": "Lorem Ipsum",
-          "icon": "BiServer",
-          "heading": "Azure Blob Storage",
-          "description": "Massively scalable and secure object storage for cloud-native workloads, archives, data lakes, HPC, and machine learning.\n\n",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-azure"
-          }
+          "title": "DevOps",
+          "description": "CI/CD pipelines that ship faster and fail less, on Azure DevOps or GitHub.",
+          "link": "/consulting/devops"
         },
         {
-          "guid": "6bap5",
-          "altText": "Lorem Ipsum",
-          "icon": "BiLogoPostgresql",
-          "heading": "Azure SQL Database",
-          "description": "Build limitless, trusted, AI-ready apps on a fully managed SQL database\n\n",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-sql-server-schema-deployment"
-          }
-        },
-        {
-          "guid": "hh8nhk",
-          "altText": "Lorem Ipsum",
-          "icon": "BiCoinStack",
-          "heading": "Azure Cosmos DB",
-          "description": "Develop AI-powered apps and agents with a fully managed and serverless NoSQL vector database at any scale.",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-azure"
-          }
-        },
-        {
-          "guid": "sv6mmo",
-          "altText": "Lorem Ipsum",
-          "icon": "BiLogoDocker",
-          "heading": "Docker",
-          "description": "Containerization platform that packages applications with their dependencies, enabling consistent deployments across any environment.",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.youtube.com/watch?v=Yhp37fPn6dQ"
-          }
-        },
-        {
-          "guid": "oed4sf",
-          "altText": "Lorem Ipsum",
-          "icon": "BiLogoKubernetes",
-          "heading": "Kubernetes",
-          "description": "Container orchestration platform for deploying, scaling, and managing containerized applications in production environments.\n\n",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.youtube.com/watch?v=J-xyKoYW4Pc"
-          }
-        },
-        {
-          "guid": "qmd20r",
-          "altText": "Lorem Ipsum",
-          "icon": "BiBarChartAlt2",
-          "heading": "Power BI",
-          "description": "Transform complex SQL data into intuitive, actionable business insights.\n\n",
-          "embeddedButton": {
-            "buttonText": "Read more",
-            "buttonLink": "https://www.ssw.com.au/consulting/power-bi"
-          }
-        },
-        {
-          "guid": "nanos",
-          "altText": "Lorem Ipsum",
-          "icon": "BiColor",
-          "heading": "EF Core",
-          "description": "A modern object-database mapper for .NET. It supports LINQ queries, change tracking, updates, and schema migrations\n\n",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "Power BI",
+          "description": "Turn complex SQL data into intuitive, actionable business insights.",
+          "link": "/consulting/powerbiv2"
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "cardCarousel"
+      "_template": "v3StackCards"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "TECH WE USE",
+      "heading": "Services we work with every day",
+      "pills": [
+        { "label": "Azure App Service" },
+        { "label": "Azure Blob Storage" },
+        { "label": "Azure SQL" },
+        { "label": "Cosmos DB" },
+        { "label": "Azure DevOps" },
+        { "label": "GitHub Actions" },
+        { "label": "Docker" },
+        { "label": "Kubernetes" },
+        { "label": "Entra ID" },
+        { "label": "EF Core" }
+      ],
+      "_template": "v3Pills"
+    },
+    {
+      "background": {
+        "backgroundColour": 8
+      },
+      "heading": "Frequently asked questions",
+      "faqs": [
+        {
+          "question": "Can you help us migrate to Azure?",
+          "answer": "Yes. We assess your existing environment, plan the move, and migrate workloads safely into Azure. Whether it's rehost, refactor or modernise, we make sure it stays reliable and cost-efficient.\n"
+        },
+        {
+          "question": "Do you set up DevOps and CI/CD?",
+          "answer": "We build automated CI/CD pipelines with Azure DevOps or GitHub Actions, improve deployment speed, reduce failures, and set you up with a clean development workflow.\n",
+          "link": "https://www.ssw.com.au/consulting/devops"
+        },
+        {
+          "question": "Our Azure bill keeps climbing. Can you help?",
+          "answer": "That's one of the most common reasons people call. We look at right-sizing, reserved capacity, orphaned resources and tagging, then give you the guardrails that keep the bill predictable rather than a one-off cleanup.\n",
+          "link": "https://www.ssw.com.au/rules/reduce-azure-costs/"
+        },
+        {
+          "question": "How much does it cost?",
+          "answer": "Every engagement is scoped to your goals, so there's no single price. The initial call is always 100% **free**. The specification review will be used to give the most accurate estimation possible for a projects scope, price and duration.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
+        }
+      ],
+      "_template": "v3Faq"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
       },
       "heading": "Talk to us about your Azure project today",
-      "isH1": false,
-      "description": "Connect with our Account Managers to discuss how we can help.\n",
-      "featureColumns": {
-        "twoColumns": false
-      },
+      "description": "Get in touch and we'll set up an initial meeting to show you where we'd start\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "imageTextBlock"
+      "_template": "v3Cta"
     }
   ]
 }

--- a/content/consultingv2/chat-bots.json
+++ b/content/consultingv2/chat-bots.json
@@ -2,7 +2,7 @@
   "seo": {
     "title": "Chatbot Consulting & Development | SSW",
     "description": "Custom AI-powered chatbot solutions in Sydney, Brisbane, Melbourne & Newcastle. Delivering instant, intelligent, and personalized support 24/7. ",
-    "canonical": "https://www.ssw.com.au/consulting/artificial-intelligence",
+    "canonical": "https://www.ssw.com.au/consulting/chat-bots",
     "images": [
       {
         "url": "/images/consulting/open-graph/ai.jpg",
@@ -15,440 +15,333 @@
   "blocks": [
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": false
       },
       "finalBreadcrumb": "AI Chatbot Development",
       "_template": "breadcrumbs"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
       },
+      "brow": "AI CHATBOTS",
       "heading": "Want an AI-powered **chatbot** on your website?",
-      "isH1": true,
-      "description": "Our AI-powered chatbots are redefining customer service. Delivering instant, intelligent, and personalized support 24/7.\n",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "",
-            "description": ""
-          },
-          {
-            "heading": "",
-            "description": ""
-          }
-        ]
-      },
+      "description": "Our chatbots are trained on your content, answer in your voice, and work at 3am. Instant, intelligent, personalised support, 24/7.\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
         },
         {
-          "buttonText": " AI Discovery Workshop",
+          "buttonText": "AI Discovery Workshop",
           "buttonLink": "/consulting/ai-discovery-workshop",
           "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
+      "mediaType": "image",
+      "image": {
+        "altText": "SSW developer presenting a chatbot build",
+        "imageSource": "/images/ssw-web/hero/dev-presenting-2.png",
+        "imageWidth": 642,
+        "imageHeight": 481
       },
-      "mediaConfiguration": {
-        "mobilePlacement": "Above",
-        "imageSource": "/images/Louis Test Images/Incident-io-batch/hero/hero_1400_700px(MS2).png",
-        "imageHeight": 700,
-        "imageWidth": 1400
-      },
-      "_template": "imageTextBlock"
+      "_template": "v3Hero"
     },
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7
       },
-      "heading": "Trusted in Sydney, Melbourne, Brisbane, and Newcastle by",
-      "paused": false,
-      "isWhiteImages": true,
+      "heading": "Trusted in Sydney, Melbourne, Brisbane and Newcastle by",
       "logos": [
+        { "logo": "/images/ssw-web/logos/toll_logo.png", "altText": "Toll" },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/7-removebg-preview.png",
-          "scale": 195
+          "logo": "/images/ssw-web/logos/symantec_logo.png",
+          "altText": "Symantec"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/6-removebg-preview.png",
-          "scale": 160
+          "logo": "/images/ssw-web/logos/microsoft_logo.png",
+          "altText": "Microsoft"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/5-removebg-preview.png",
-          "scale": 180
+          "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
+          "altText": "Event Cinemas"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/4-removebg-preview.png",
-          "scale": 175
+          "logo": "/images/ssw-web/logos/domain_logo.png",
+          "altText": "Domain"
+        },
+        { "logo": "/images/ssw-web/logos/cisco_logo.png", "altText": "Cisco" },
+        {
+          "logo": "/images/ssw-web/logos/cba_logo.png",
+          "altText": "Commonwealth Bank"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/3-removebg-preview.png",
-          "scale": 170
-        },
-        {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/1-removebg-preview.png",
-          "scale": 195,
-          "altText": "Logo"
-        },
-        {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/2-removebg-preview.png",
-          "scale": 175
+          "logo": "/images/ssw-web/logos/allianz_logo.png",
+          "altText": "Allianz"
         }
       ],
-      "_template": "logoCarousel"
+      "_template": "v3LogoCarousel"
     },
     {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "Why invest in **Chatbots** now?",
-      "isH1": false,
-      "description": "Previously, chatbots posed financial and technical risks due to their high costs and frequent bugs. But times have changed. Advanced AI language models, such as ChatGPT, offer reliable and effective chatbots at a fraction of the former cost - just $3,990 + GST.\n\nNeglecting to include a robust chatbot on your website is now a missed opportunity for optimizing customer engagement.\n",
-      "featureColumns": {
-        "twoColumns": false
-      },
-      "buttons": [
-        {
-          "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "iconFirst": true
-        },
-        {
-          "buttonText": "Rules to Better AI",
-          "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-ai/",
-          "icon": "BiSolidWrench",
-          "colour": 1
-        }
-      ],
       "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "/images/ssw-web/background/bckg-9-25-ssw.png",
-        "bleed": true
+        "backgroundColour": 7
       },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Left",
-        "mobilePlacement": "Above",
-        "youtubeUrl": "https://youtu.be/sZY1BqHBbR0?si=-YZTZghyMiiAfshW",
-        "altText": "Website Chatbot in 1 day | Ulysses Maclaren"
-      },
-      "_template": "imageTextBlock"
+      "brow": "WHAT YOU GET",
+      "heading": "What a good chatbot actually changes",
+      "description": "Chatbots used to be a financial and technical risk: expensive to build and buggy in front of customers. Advanced language models changed the economics. The same quality of experience now starts at $3,990 + GST.\n",
+      "steps": [
+        {
+          "brow": "01",
+          "heading": "Customer support that never sleeps",
+          "description": "Immediate assistance day or night, at a fraction of the cost of extending your support hours.\n"
+        },
+        {
+          "brow": "02",
+          "heading": "Conversations that don't feel robotic",
+          "description": "Our bots read tone and respond like people. Whether you're a small shop or a large enterprise, the experience stays personal.\n"
+        },
+        {
+          "brow": "03",
+          "heading": "Trained on your knowledge",
+          "description": "You choose the sources: web pages, documents, or direct text. The bot can re-train itself every 24 hours so it never drifts out of date.\n"
+        }
+      ],
+      "_template": "v3FeatureSteps"
     },
     {
-      "isStacked": true,
-      "heading": "",
-      "isH1": false,
-      "body": "",
-      "cardStyle": 0,
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true
+      },
+      "videoUrl": "https://youtu.be/sZY1BqHBbR0",
+      "heading": "Why choose SSW?",
+      "description": "SSW's Consulting Services have delivered best-in-class Microsoft solutions for thousands of clients in 15 countries for more than 30 years.\n",
+      "highlights": [
+        {
+          "title": "Deep expertise",
+          "desc2": "We go deep on every technology we touch - building with it, codifying best practices, and making that knowledge freely available\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-ai/",
+          "linkText": "Rules to Better AI"
+        },
+        {
+          "title": "Results over rhetoric",
+          "desc2": "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it work?\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
+      },
+      "testimonials": [
+        {
+          "quote": "You've got soccer players and then you have the professional soccer players. **They are the professional soccer players.**",
+          "caseStudyUrl": "/company/clients/fpe",
+          "caseStudyLabel": "See case study video",
+          "authorName": "Thomas Bidou",
+          "authorTitle": "French Payroll Expert",
+          "authorImage": "/images/testimonialAvatars/thomas-bideau.png",
+          "authorImageAlt": "Thomas Bidou",
+          "companyLogo": "/images/clientLogos/FPE.png",
+          "companyLogoAlt": "French Payroll Expert"
+        }
+      ],
+      "_template": "v3Testimonials"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "videoUrl": "https://www.youtube.com/watch?v=YlsbPEvVyq4",
+      "figure": "Video: Boosting payroll expertise with a custom AI chatbot",
+      "brow": "CASE STUDY",
+      "heading": "Boosting payroll expertise with a **custom AI chatbot**",
+      "description": "French Payroll Expert spent too much time answering the same questions about French labor law. We built them a custom AI chatbot that delivers accurate, multilingual answers 24/7, directly from official sources.\n",
+      "highlights": [
+        {
+          "title": "Instant answers, any language",
+          "desc2": "Clients get fast, 24/7 payroll answers in their own language, drawn from verified French legislation.\n",
+          "link": "https://www.ssw.com.au/company/clients/fpe",
+          "linkText": "Read the full story"
+        },
+        {
+          "title": "AI becomes a selling point",
+          "desc2": "The chatbot isn't just support. It's a competitive edge that helped FPE attract new clients and win more business.\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Tell us about **your** chatbot",
+      "description": "Answer a few quick questions. We'll set up an initial meeting and show you where we'd start\n",
+      "_template": "v3LeadCapture"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "TECH WE USE",
+      "heading": "What we build chatbots with",
+      "pills": [
+        { "label": "ChatGPT" },
+        { "label": "Azure OpenAI" },
+        { "label": "Azure AI Search" },
+        { "label": "Semantic Kernel" },
+        { "label": "Azure Cognitive Services" },
+        { "label": "Copilot Studio" },
+        { "label": ".NET" }
+      ],
+      "_template": "v3Pills"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "Beyond the bot",
+      "heading": "One team for the whole AI build",
+      "subtitle": "A chatbot is usually the first thing people ship. It's rarely the last.",
       "cards": [
         {
-          "guid": "ib0xbk",
-          "altText": "Lorem Ipsum",
-          "icon": "BiSupport",
-          "heading": "Customer Support",
-          "description": "Get customer support that never sleeps. An AI-powered chatbot gives your customers immediate assistance, day or night – and costs less!just practical AI that solves real problems.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "GPT Integration",
+          "description": "Language AI wired into the products and processes you already run.",
+          "link": "/consulting/gpt"
         },
         {
-          "guid": "65qp3c",
-          "altText": "Lorem Ipsum",
-          "icon": "BiSolidStar",
-          "heading": "Customer Experience",
-          "description": "Our chatbots talk like real people and have expert emotional intelligence. Whether you run a small shop or a big company, our tailored bots make customer service easy and personal.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "AI Phone System",
+          "description": "The same idea on the phone line: a 24/7 conversational assistant.",
+          "link": "/consulting/ai-powered-phone-system"
         },
         {
-          "guid": "hukqtq",
-          "altText": "Lorem Ipsum",
-          "icon": "BiSolidCustomize",
-          "heading": "Customization",
-          "description": "You choose what information to train your bot with – webpages, documents, and/or direct text. The chatbot is trained on all your sources of knowledge and can be configured to stay updated by automatically re-training itself every 24 hours.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        }
-      ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "cardCarousel"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
-    },
-    {
-      "topLabel": {
-        "labelText": "Case Study"
-      },
-      "heading": "Boosting Payroll Expertise with a **Custom AI Chatbot**",
-      "isH1": false,
-      "description": "French Payroll Expert (FPE) spent too much time answering the same questions about French labor law. We built them a custom AI chatbot that delivers accurate, multilingual answers 24/7, directly from official sources.\n",
-      "chips": [
-        {
-          "chipText": "Semantic Kernel",
-          "chipType": "filledChip"
+          "title": "AI Discovery Workshop",
+          "description": "A structured three days to find where AI pays off in your business.",
+          "link": "/consulting/ai-discovery-workshop"
         },
         {
-          "chipText": "OpenAI",
-          "chipType": "filledChip"
+          "title": "Artificial Intelligence",
+          "description": "The full picture: strategy, build and support for custom AI.",
+          "link": "/consulting/artificial-intelligence"
         }
       ],
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "Instant Answers, Any Language",
-            "description": "Clients get fast, 24/7 payroll answers in their own language. The AI uses verified French legislation, breaking down barriers."
-          },
-          {
-            "heading": "AI Becomes a Selling Point",
-            "description": "The chatbot isn't just support, it's a competitive edge that helped FPE attract new clients and win more business."
-          }
-        ]
-      },
-      "buttons": [
-        {
-          "buttonText": "Read the full story",
-          "buttonLink": "https://www.ssw.com.au/company/clients/fpe",
-          "colour": 0
-        }
-      ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Right",
-        "verticalPlacement": "Centered",
-        "mobilePlacement": "Above",
-        "youtubeUrl": "https://www.youtube.com/watch?v=YlsbPEvVyq4"
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3StackCards"
     },
     {
       "isStacked": false,
-      "heading": "Tech Wisdom from the Trenches",
+      "brow": "learn more on SSWTV",
+      "heading": "Tech wisdom from the trenches",
       "isH1": false,
-      "body": "At SSW, we’ve been knee-deep in projects for years: debugging giant solutions, fixing game-stopping bugs, and staying on the cutting edge. No guesswork, just proven tips that help you build better software.",
-      "cardStyle": 1,
+      "body": "SSW has been building enterprise projects for thirty years. We document what we learn for free on SSW Rules and SSW TV.",
+      "tabletTextAlignment": "Left",
       "cards": [
         {
-          "guid": "arf4s",
+          "guid": "cb001",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://youtu.be/LrnMP8T4HDE",
+          "altText": "Create a Killer Chatbot with OpenAI",
+          "category": "AI Strategy",
+          "heading": "Create a Killer Chatbot with OpenAI"
+        },
+        {
+          "guid": "cb002",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=LzFG7pUylZo",
-          "altText": "AI",
-          "chips": [
-            {
-              "chipText": "AI Use",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "6 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "If you think AI is cheating, you're doing it wrong!",
-          "description": "AI is the tool of this generation, but are we using it responsibly? Ulysses Maclaren dives into the best practices for AI use - covering transparency, critical thinking, data privacy, and how to leverage AI to boost productivity. Learn why using AI intelligently is the key to staying ahead in your career.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "altText": "If you think AI is cheating, you're doing it wrong!",
+          "category": "AI Use",
+          "heading": "If you think AI is cheating, you're doing it wrong!"
         },
         {
-          "guid": "ui7a6e",
+          "guid": "cb003",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=BlqJ7bnivLE",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Trends",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "90 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "The Year of the AI Agent: Automation to Intelligence",
-          "description": "Dive into the future of AI with Ulysses Maclaren in this insightful SSW User Group session! Explore the exciting shift from automation to true AI intelligence and discover what the year of the AI agent holds for developers.",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
+          "altText": "The Year of the AI Agent: Automation to Intelligence",
+          "category": "AI Trends",
+          "heading": "The Year of the AI Agent: Automation to Intelligence"
         },
         {
-          "guid": "hhszy",
+          "guid": "cb004",
           "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/F06MV1qm51Y?si=u1mOLqpFCaty4NrL",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Model Guides",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "12 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": " 3 Creative Uses for OpenAI API ",
-          "description": "From smart home automation to content generation, he unveils three groundbreaking ideas that leverage the power of AI. Discover how chat GPT can output commands and instructions for other systems, making your home smarter and more efficient. Witness the potential of automated content generation and its impact on your productivity. Get inspired and join the future of innovation!",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
+          "youtubeUrl": "https://youtu.be/Us04IRcNJ9c",
+          "altText": "Creating Multi-Language AI-Powered Apps w/ Rust, Python & Blazor",
+          "category": "Multi-Language AI Apps",
+          "heading": "Creating Multi-Language AI-Powered Apps"
         },
         {
-          "guid": "akn4ur",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/LrnMP8T4HDE?si=uorL-73cVGtHxMTh",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Strategy",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "18 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": " Create a Killer Chatbot with OpenAI",
-          "description": "Discover the power of the OpenAI API, its ability to generate intelligent responses, and the step-by-step process of building effective chatbots. Enhance user experience and save time by harnessing the natural language processing capabilities of ChatGPT.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "20ehn",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/Us04IRcNJ9c?si=e03yF4HpD0eFosqu",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "Multi-Language AI Apps",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "60 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "Creating Multi-Language AI-Powered Apps w/ Rust, Python & Blazor",
-          "description": "Discover how to build AI-powered applications that speak multiple languages! Join TJ Gokken in this User Group session as he dives into the world of multi-language app development using Rust, Python, and Blazor. Learn practical techniques and best practices for creating global-ready AI solutions.",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
-        },
-        {
-          "guid": "hupqdh",
+          "guid": "cb005",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=WwF69cj8490",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Strategy",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "8 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "How to supercharge a company with AI",
-          "description": "Supercharge your company with AI!  🚀  See how SSW transformed their business and Tina CMS using practical AI strategies, from customer support chatbots to AI-powered product features.  Discover actionable tips to implement AI",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "altText": "How to supercharge a company with AI",
+          "category": "AI Strategy",
+          "heading": "How to supercharge a company with AI"
         }
       ],
       "background": {
-        "backgroundColour": 2
+        "backgroundColour": 7
       },
-      "_template": "cardCarousel"
+      "_template": "v3CardCarousel"
     },
     {
-      "technologies": [
+      "background": {
+        "backgroundColour": 8
+      },
+      "heading": "Frequently asked questions",
+      "faqs": [
         {
-          "technology": "content/v2Technologies/technologies/chatgpt.mdx"
+          "question": "How much does a chatbot cost?",
+          "answer": "A standard website chatbot starts at **$3,990 + GST**. Anything more custom is scoped to your goals, and the initial call is always 100% free.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
         },
         {
-          "technology": "content/v2Technologies/technologies/gpt-4.mdx"
+          "question": "What can we train it on?",
+          "answer": "Web pages, documents, or text you paste in directly. The bot is trained across all of your sources and can be configured to re-train itself automatically every 24 hours.\n"
         },
         {
-          "technology": "content/v2Technologies/technologies/azure-cognitive-services.mdx"
+          "question": "Will it make things up?",
+          "answer": "It answers from the sources you give it rather than the open internet, and we can show where each answer came from. That grounding is the difference between a demo and something you'd put in front of a customer.\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-ai/"
+        },
+        {
+          "question": "Do you work with our existing team?",
+          "answer": "Yes! We can either take over a project from end-to-end with our own team at SSW, or embed our developers into your existing team.\n",
+          "link": "https://www.ssw.com.au/consulting/mentoring"
         }
       ],
-      "isStacked": true,
-      "techCardStyle": 0,
-      "background": {
-        "backgroundColour": 3
-      },
-      "_template": "technologyCardCarousel"
+      "_template": "v3Faq"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "Talk to Us About Your AI Project Today",
-      "isH1": false,
-      "description": "Connect with our Account Managers to discuss how we can help.\n",
-      "featureColumns": {
-        "twoColumns": true
-      },
+      "heading": "Talk to us about your AI project today",
+      "description": "Get in touch and we'll set up an initial meeting to show you where we'd start\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "100px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3Cta"
     }
   ]
 }

--- a/content/consultingv2/gpt.json
+++ b/content/consultingv2/gpt.json
@@ -15,450 +15,337 @@
   "blocks": [
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": false
       },
       "finalBreadcrumb": "GPT Integration Services",
       "_template": "breadcrumbs"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "Want to revolutionize your business with **GPT** and **ChatGPT** integration?",
-      "isH1": true,
-      "description": "Unlock the power of language AI for your business\n",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "",
-            "description": ""
-          },
-          {
-            "heading": "",
-            "description": ""
-          }
-        ]
-      },
+      "brow": "GPT & CHATGPT INTEGRATION",
+      "heading": "Put **GPT** to work inside your business",
+      "description": "Language AI is only useful once it knows your data, your tone and your rules. We build GPT into the products and processes you already run, so it answers like someone who works there.\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
         },
         {
-          "buttonText": " AI Discovery Workshop",
+          "buttonText": "AI Discovery Workshop",
           "buttonLink": "/consulting/ai-discovery-workshop",
           "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "mobilePlacement": "Above",
-        "imageSource": "/images/Louis Test Images/Incident-io-batch/hero/hero_1400_700px(MS2).png",
-        "imageHeight": 700,
-        "imageWidth": 1400
-      },
-      "_template": "imageTextBlock"
+      "mediaType": "aiConsultingSvg",
+      "_template": "v3Hero"
     },
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7
       },
-      "heading": "Trusted in Sydney, Melbourne, Brisbane, and Newcastle by",
-      "paused": false,
-      "isWhiteImages": true,
+      "heading": "Trusted in Sydney, Melbourne, Brisbane and Newcastle by",
       "logos": [
+        { "logo": "/images/ssw-web/logos/toll_logo.png", "altText": "Toll" },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/7-removebg-preview.png",
-          "scale": 195
+          "logo": "/images/ssw-web/logos/symantec_logo.png",
+          "altText": "Symantec"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/6-removebg-preview.png",
-          "scale": 160
+          "logo": "/images/ssw-web/logos/microsoft_logo.png",
+          "altText": "Microsoft"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/5-removebg-preview.png",
-          "scale": 180
+          "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
+          "altText": "Event Cinemas"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/4-removebg-preview.png",
-          "scale": 175
+          "logo": "/images/ssw-web/logos/domain_logo.png",
+          "altText": "Domain"
+        },
+        { "logo": "/images/ssw-web/logos/cisco_logo.png", "altText": "Cisco" },
+        {
+          "logo": "/images/ssw-web/logos/cba_logo.png",
+          "altText": "Commonwealth Bank"
         },
         {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/3-removebg-preview.png",
-          "scale": 170
-        },
-        {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/1-removebg-preview.png",
-          "scale": 195,
-          "altText": "Logo"
-        },
-        {
-          "logo": "/images/Louis Test Images/Incident-io-batch/Logos/2-removebg-preview.png",
-          "scale": 175
+          "logo": "/images/ssw-web/logos/allianz_logo.png",
+          "altText": "Allianz"
         }
       ],
-      "_template": "logoCarousel"
+      "_template": "v3LogoCarousel"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7
       },
+      "brow": "WHERE IT PAYS OFF",
       "heading": "Experience the advantages of implementing **GPT** and **ChatGPT**",
-      "isH1": false,
-      "description": "Integrating GPT and ChatGPT enables intelligent, human-like automation for customer service, content, and data tasks, boosting efficiency and user experience.\n\nWant an example? Try the chatbot in the bottom right corner of your screen!\n",
-      "featureColumns": {
-        "twoColumns": false
+      "description": "Integrating GPT enables intelligent, human-like automation for customer service, content, and data tasks, boosting efficiency and user experience. Want an example? Try the chatbot in the bottom right corner of your screen.\n",
+      "steps": [
+        {
+          "brow": "01",
+          "heading": "Transform your business communication",
+          "description": "Automate customer support and streamline internal communication. The models understand and generate human-like responses, so customers and staff get a seamless experience.\n"
+        },
+        {
+          "brow": "02",
+          "heading": "Optimise your workflows",
+          "description": "Automate the repetitive work and free your team for the strategic and creative jobs. Models are customised to your business, not dropped in generically.\n"
+        },
+        {
+          "brow": "03",
+          "heading": "Expand your product offerings",
+          "description": "Integrate GPT into existing products or build new AI-driven ones. We work with you on applications that put language AI in front of your customers.\n"
+        },
+        {
+          "brow": "04",
+          "heading": "Training and support that sticks",
+          "description": "Tailored sessions and ongoing support, so your team can actually run what we build together.\n"
+        }
+      ],
+      "_template": "v3FeatureSteps"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true
       },
+      "videoUrl": "https://youtu.be/-q9lLqtkC00",
+      "heading": "Why choose SSW?",
+      "description": "SSW's Consulting Services have delivered best-in-class Microsoft solutions for thousands of clients in 15 countries for more than 30 years.\n",
+      "highlights": [
+        {
+          "title": "Deep expertise",
+          "desc2": "We go deep on every technology we touch - building with it, codifying best practices, and making that knowledge freely available\n",
+          "link": "https://www.ssw.com.au/rules/rules-to-better-chatgpt-prompt-engineering",
+          "linkText": "Rules to Better Prompt Engineering"
+        },
+        {
+          "title": "Results over rhetoric",
+          "desc2": "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it work?\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
+      },
+      "testimonials": [
+        {
+          "quote": "You've got soccer players and then you have the professional soccer players. **They are the professional soccer players.**",
+          "caseStudyUrl": "/company/clients/fpe",
+          "caseStudyLabel": "See case study video",
+          "authorName": "Thomas Bidou",
+          "authorTitle": "French Payroll Expert",
+          "authorImage": "/images/testimonialAvatars/thomas-bideau.png",
+          "authorImageAlt": "Thomas Bidou",
+          "companyLogo": "/images/clientLogos/FPE.png",
+          "companyLogoAlt": "French Payroll Expert"
+        }
+      ],
+      "_template": "v3Testimonials"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "videoUrl": "https://www.youtube.com/watch?v=YlsbPEvVyq4",
+      "figure": "Video: Boosting payroll expertise with a custom AI chatbot",
+      "brow": "CASE STUDY",
+      "heading": "Boosting payroll expertise with a **custom AI chatbot**",
+      "description": "French Payroll Expert spent too much time answering the same questions about French labor law. We built them a custom AI chatbot that delivers accurate, multilingual answers 24/7, directly from official sources.\n",
+      "highlights": [
+        {
+          "title": "Instant answers, any language",
+          "desc2": "Clients get fast, 24/7 payroll answers in their own language, drawn from verified French legislation.\n",
+          "link": "https://www.ssw.com.au/company/clients/fpe",
+          "linkText": "Read the full story"
+        },
+        {
+          "title": "AI becomes a selling point",
+          "desc2": "The chatbot isn't just support. It's a competitive edge that helped FPE attract new clients and win more business.\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Tell us about **your** GPT project",
+      "description": "Answer a few quick questions. We'll set up an initial meeting and show you where we'd start\n",
+      "_template": "v3LeadCapture"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "TECH WE USE",
+      "heading": "What we build GPT integrations with",
+      "pills": [
+        { "label": "ChatGPT" },
+        { "label": "OpenAI API" },
+        { "label": "Azure OpenAI" },
+        { "label": "Custom GPTs" },
+        { "label": "Semantic Kernel" },
+        { "label": "Azure AI Search" },
+        { "label": ".NET" },
+        { "label": "Python" }
+      ],
+      "_template": "v3Pills"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "Beyond the model",
+      "heading": "One team for the whole AI build",
+      "subtitle": "GPT is one piece. We build everything it plugs into.",
+      "cards": [
+        {
+          "title": "Chatbots",
+          "description": "Assistants grounded in your own documents, not the open internet.",
+          "link": "/consulting/chat-bots"
+        },
+        {
+          "title": "AI Discovery Workshop",
+          "description": "A structured three days to find where AI pays off in your business.",
+          "link": "/consulting/ai-discovery-workshop"
+        },
+        {
+          "title": "Local LLMs",
+          "description": "Run models on your own infrastructure, with your data staying put.",
+          "link": "/consulting/local-llm-deployment"
+        },
+        {
+          "title": "Artificial Intelligence",
+          "description": "The full picture: strategy, build and support for custom AI.",
+          "link": "/consulting/artificial-intelligence"
+        }
+      ],
+      "_template": "v3StackCards"
+    },
+    {
+      "isStacked": false,
+      "brow": "learn more on SSWTV",
+      "heading": "Tech wisdom from the trenches",
+      "isH1": false,
+      "body": "SSW has been building enterprise projects for thirty years. We document what we learn for free on SSW Rules and SSW TV.",
+      "tabletTextAlignment": "Left",
+      "cards": [
+        {
+          "guid": "gpt001",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://youtu.be/voZx9AD38QE",
+          "altText": "ChatGPT & OpenAI solutions",
+          "category": "AI Strategy",
+          "heading": "ChatGPT & OpenAI solutions"
+        },
+        {
+          "guid": "gpt002",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://youtu.be/F06MV1qm51Y",
+          "altText": "3 Creative Uses for OpenAI API",
+          "category": "AI Model Guides",
+          "heading": "3 Creative Uses for OpenAI API"
+        },
+        {
+          "guid": "gpt003",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://youtu.be/LrnMP8T4HDE",
+          "altText": "Create a Killer Chatbot with OpenAI",
+          "category": "AI Strategy",
+          "heading": "Create a Killer Chatbot with OpenAI"
+        },
+        {
+          "guid": "gpt004",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://youtu.be/1Rb8dl6lGus",
+          "altText": "The Only ChatGPT Cheat Sheet You'll Ever Need",
+          "category": "Prompt Engineering",
+          "heading": "The Only ChatGPT Cheat Sheet You'll Ever Need"
+        },
+        {
+          "guid": "gpt005",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://www.youtube.com/watch?v=WwF69cj8490",
+          "altText": "How to supercharge a company with AI",
+          "category": "AI Strategy",
+          "heading": "How to supercharge a company with AI"
+        },
+        {
+          "guid": "gpt006",
+          "mediaType": "youtube",
+          "youtubeUrl": "https://www.youtube.com/watch?v=LzFG7pUylZo",
+          "altText": "If you think AI is cheating, you're doing it wrong!",
+          "category": "AI Use",
+          "heading": "If you think AI is cheating, you're doing it wrong!"
+        }
+      ],
+      "background": {
+        "backgroundColour": 7
+      },
+      "_template": "v3CardCarousel"
+    },
+    {
+      "background": {
+        "backgroundColour": 8
+      },
+      "heading": "Frequently asked questions",
+      "faqs": [
+        {
+          "question": "How much does it cost?",
+          "answer": "Every engagement is scoped to your goals, so there's no single price. The initial call is always 100% **free**. The specification review will be used to give the most accurate estimation possible for a projects scope, price and duration.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
+        },
+        {
+          "question": "Can GPT answer using our own documents?",
+          "answer": "Yes, and this is usually the point. We ground the model in your content so answers come from your sources rather than the open internet, and we can cite where each answer came from.\n",
+          "link": "https://www.ssw.com.au/consulting/chat-bots"
+        },
+        {
+          "question": "Do you work with our existing team?",
+          "answer": "Yes! We can either take over a project from end-to-end with our own team at SSW, or embed our developers into your existing team.\n",
+          "link": "https://www.ssw.com.au/consulting/mentoring"
+        }
+      ],
+      "_template": "v3Faq"
+    },
+    {
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
+      },
+      "heading": "Talk to us about your AI project today",
+      "description": "Get in touch and we'll set up an initial meeting to show you where we'd start\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "iconFirst": true
+          "buttonLink": "#lead-capture-heading",
+          "colour": 0
         },
         {
-          "buttonText": "Rules to Better Prompt Engineering",
-          "buttonLink": "https://www.ssw.com.au/rules/rules-to-better-chatgpt-prompt-engineering",
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
           "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "/images/ssw-web/background/bckg-9-25-ssw.png",
-        "bleed": true
-      },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Left",
-        "mobilePlacement": "Above",
-        "youtubeUrl": "https://youtu.be/-q9lLqtkC00?si=cYrKKEBJTKIRzIGY",
-        "altText": "The Future of Business with AI: Automation, Intelligence, and Customer Relations | Ulysses Maclaren (10 mins)"
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "isStacked": false,
-      "heading": "",
-      "isH1": false,
-      "body": "",
-      "cardStyle": 0,
-      "cards": [
-        {
-          "guid": "ib0xbk",
-          "altText": "TRANSFORM YOUR BUSINESS COMMUNICATION",
-          "icon": "VscCommentDiscussion",
-          "heading": "Transform Your Business Communication",
-          "description": "Use GPT to automate customer support, streamline internal communication, and enhance collaboration within your team. These AI models can understand and generate human-like responses, allowing you to provide a seamless and efficient experience for your customers and employees.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "65qp3c",
-          "altText": "Optimize Your Workflows",
-          "icon": "BiGitBranch",
-          "heading": "Optimize Your Workflows",
-          "description": "With GPT your business can automate repetitive tasks, freeing up valuable time for your team to focus on more strategic and creative endeavors. The AI models can be customized to suit your unique business needs, helping you achieve optimal efficiency and productivity.",
-          "embeddedButton": {
-            "buttonText": "For an example of this see: YakShaver",
-            "buttonLink": "https://yakshaver.ai/"
-          }
-        },
-        {
-          "guid": "hukqtq",
-          "altText": "Lorem Ipsum",
-          "icon": "BiGlobe",
-          "heading": "Expand Your Product Offerings",
-          "description": "Integrating GPT into your existing products or creating new AI-driven solutions can help your business stay ahead of the competition. Our team of experts will work closely with you to develop innovative applications that harness the power of language AI for the benefit of your customers and stakeholders.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "lfxdb5",
-          "altText": "Customized Training and Support",
-          "icon": "BiDiamond",
-          "heading": "Customized Training and Support",
-          "description": "We provide tailored training sessions and ongoing support to help you maximize the benefits of GPT integration. Our experienced team will guide you through the process, ensuring that you can fully utilize these cutting-edge AI technologies to drive your business success.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        }
-      ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "cardCarousel"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
-    },
-    {
-      "topLabel": {
-        "labelText": "Case Study"
-      },
-      "heading": "Boosting Payroll Expertise with a **Custom AI Chatbot**",
-      "isH1": false,
-      "description": "French Payroll Expert (FPE) spent too much time answering the same questions about French labor law. We built them a custom AI chatbot that delivers accurate, multilingual answers 24/7, directly from official sources.\n",
-      "chips": [
-        {
-          "chipText": "Semantic Kernel",
-          "chipType": "filledChip"
-        },
-        {
-          "chipText": "OpenAI",
-          "chipType": "filledChip"
-        }
-      ],
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "Instant Answers, Any Language",
-            "description": "Clients get fast, 24/7 payroll answers in their own language. The AI uses verified French legislation, breaking down barriers."
-          },
-          {
-            "heading": "AI Becomes a Selling Point",
-            "description": "The chatbot isn't just support, it's a competitive edge that helped FPE attract new clients and win more business."
-          }
-        ]
-      },
-      "buttons": [
-        {
-          "buttonText": "Read the full story",
-          "buttonLink": "https://www.ssw.com.au/company/clients/fpe",
-          "colour": 0
-        }
-      ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "placement": "Right",
-        "verticalPlacement": "Centered",
-        "mobilePlacement": "Above",
-        "youtubeUrl": "https://www.youtube.com/watch?v=YlsbPEvVyq4"
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "50px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
-    },
-    {
-      "isStacked": false,
-      "heading": "Tech Wisdom from the Trenches",
-      "isH1": false,
-      "body": "At SSW, we’ve been knee-deep in projects for years: debugging giant solutions, fixing game-stopping bugs, and staying on the cutting edge. No guesswork, just proven tips that help you build better software.",
-      "cardStyle": 1,
-      "cards": [
-        {
-          "guid": "arf4s",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=LzFG7pUylZo",
-          "altText": "AI",
-          "chips": [
-            {
-              "chipText": "AI Use",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "6 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "If you think AI is cheating, you're doing it wrong!",
-          "description": "AI is the tool of this generation, but are we using it responsibly? Ulysses Maclaren dives into the best practices for AI use - covering transparency, critical thinking, data privacy, and how to leverage AI to boost productivity. Learn why using AI intelligently is the key to staying ahead in your career.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "ui7a6e",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/voZx9AD38QE?si=1TlDyebFDNNrK9t_",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Strategy",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "110 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "ChatGPT & OpenAI solutions",
-          "description": "Discover how AI is revolutionizing businesses with ChatGPT and the OpenAI API. Join SSW Chief Architect Adam Cogan as he reveals practical tips to enhance software development and streamline internal processes using AI. Learn how Custom GPTs and Semantic Kernel empower rapid problem-solving and scalable enterprise solutions.",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
-        },
-        {
-          "guid": "hhszy",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/F06MV1qm51Y?si=u1mOLqpFCaty4NrL",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Model Guides",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "12 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": " 3 Creative Uses for OpenAI API ",
-          "description": "From smart home automation to content generation, he unveils three groundbreaking ideas that leverage the power of AI. Discover how chat GPT can output commands and instructions for other systems, making your home smarter and more efficient. Witness the potential of automated content generation and its impact on your productivity. Get inspired and join the future of innovation!",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
-        },
-        {
-          "guid": "akn4ur",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/LrnMP8T4HDE?si=uorL-73cVGtHxMTh",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Strategy",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "18 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": " Create a Killer Chatbot with OpenAI",
-          "description": "Discover the power of the OpenAI API, its ability to generate intelligent responses, and the step-by-step process of building effective chatbots. Enhance user experience and save time by harnessing the natural language processing capabilities of ChatGPT.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        },
-        {
-          "guid": "20ehn",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://youtu.be/1Rb8dl6lGus?si=qG50v0jAmUIUK3RA",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "Prompt Engineering",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "6 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "The Only ChatGPT Cheat Sheet You'll Ever Need",
-          "description": "As ChatGPT becomes increasingly popular, users are discovering the most effective ways to prompt the AI for different scenarios. One way to compile this information is by putting it in easy to read graphics called cheat sheets. Cheat sheets can spark ideas that you would not have otherwise thought of!",
-          "embeddedButton": {
-            "buttonText": "",
-            "buttonLink": ""
-          }
-        },
-        {
-          "guid": "hupqdh",
-          "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=WwF69cj8490",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "AI Strategy",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "8 min",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "How to supercharge a company with AI",
-          "description": "Supercharge your company with AI!  🚀  See how SSW transformed their business and Tina CMS using practical AI strategies, from customer support chatbots to AI-powered product features.  Discover actionable tips to implement AI",
-          "embeddedButton": {
-            "buttonText": ""
-          }
-        }
-      ],
-      "background": {
-        "backgroundColour": 2
-      },
-      "_template": "cardCarousel"
-    },
-    {
-      "technologies": [
-        {
-          "technology": "content/v2Technologies/technologies/chatgpt.mdx"
-        },
-        {
-          "technology": "content/v2Technologies/technologies/gpt-4.mdx"
-        },
-        {
-          "technology": "content/v2Technologies/technologies/Semantic-Kernel-v2.mdx"
-        }
-      ],
-      "isStacked": true,
-      "techCardStyle": 0,
-      "background": {
-        "backgroundColour": 3
-      },
-      "_template": "technologyCardCarousel"
-    },
-    {
-      "topLabel": {
-        "labelText": ""
-      },
-      "heading": "Talk to Us About Your AI Project Today",
-      "isH1": false,
-      "description": "Connect with our Account Managers to discuss how we can help.\n",
-      "featureColumns": {
-        "twoColumns": true
-      },
-      "buttons": [
-        {
-          "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
-          "colour": 0
-        }
-      ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "100px",
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3Cta"
     }
   ]
 }

--- a/content/consultingv2/local-llm-deployment.json
+++ b/content/consultingv2/local-llm-deployment.json
@@ -7,416 +7,286 @@
   "blocks": [
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": false
       },
       "finalBreadcrumb": "Local LLM Deployment",
       "_template": "breadcrumbs"
     },
     {
-      "topLabel": {
-        "labelText": "Own Your AI. Keep Your Data."
+      "background": {
+        "backgroundColour": 7,
+        "bleed": true,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "Run open-source LLMs inside your network. Private, fast, and under **your control.**",
-      "isH1": false,
-      "description": "",
-      "featureColumns": {
-        "twoColumns": true,
-        "features": [
-          {
-            "heading": "Total Data Sovereignty\t",
-            "description": "Guarantee data privacy and compliance by keeping everything inside your network.\t",
-            "icon": "BiSolidCheckShield"
-          },
-          {
-            "heading": "Instant Integration",
-            "description": "Your developers can use their favorite tools by simply changing an API endpoint.",
-            "icon": "BiNetworkChart"
-          }
-        ]
-      },
+      "brow": "OWN YOUR AI. KEEP YOUR DATA.",
+      "heading": "Run open-source LLMs inside your network. Private, fast, and under **your control**",
+      "description": "No prompts leaving your perimeter, no vendor holding your data, no surprise pricing change. We stand up open-source models on your infrastructure and hand your developers an endpoint they already know how to use.\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "mediaConfiguration": {
+      "mediaType": "image",
+      "image": {
+        "altText": "Local LLM deployment running on-premises",
         "imageSource": "/images/ssw-web/hero/local-llm-hero.jpg",
-        "imageHeight": 752,
-        "imageWidth": 1392
+        "imageWidth": 1392,
+        "imageHeight": 752
       },
-      "_template": "imageTextBlock"
+      "_template": "v3Hero"
     },
     {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7
       },
-      "heading": "Trusted in Sydney, Melbourne, Brisbane, and Newcastle by",
-      "isWhiteImages": true,
+      "heading": "Trusted in Sydney, Melbourne, Brisbane and Newcastle by",
       "logos": [
+        { "logo": "/images/ssw-web/logos/toll_logo.png", "altText": "Toll" },
         {
-          "logo": "/images/ssw-web/logos/cisco_logo.png",
-          "scale": 120,
-          "altText": "Logo"
+          "logo": "/images/ssw-web/logos/symantec_logo.png",
+          "altText": "Symantec"
         },
         {
-          "logo": "/images/ssw-web/logos/cba_logo.png"
+          "logo": "/images/ssw-web/logos/microsoft_logo.png",
+          "altText": "Microsoft"
         },
         {
-          "logo": "/images/ssw-web/logos/microsoft_logo.png"
+          "logo": "/images/ssw-web/logos/event_cinemas_logo.png",
+          "altText": "Event Cinemas"
         },
         {
-          "logo": "/images/ssw-web/logos/domain_logo.png"
+          "logo": "/images/ssw-web/logos/domain_logo.png",
+          "altText": "Domain"
+        },
+        { "logo": "/images/ssw-web/logos/cisco_logo.png", "altText": "Cisco" },
+        {
+          "logo": "/images/ssw-web/logos/cba_logo.png",
+          "altText": "Commonwealth Bank"
         },
         {
-          "logo": "/images/ssw-web/logos/symantec_logo.png"
-        },
-        {
-          "logo": "/images/ssw-web/logos/event_cinemas_logo.png"
-        },
-        {
-          "logo": "/images/ssw-web/logos/toll_logo.png"
-        },
-        {
-          "logo": "/images/ssw-web/logos/allianz_logo.png"
+          "logo": "/images/ssw-web/logos/allianz_logo.png",
+          "altText": "Allianz"
         }
       ],
-      "_template": "logoCarousel"
+      "_template": "v3LogoCarousel"
     },
     {
-      "isStacked": true,
-      "heading": "",
-      "isH1": false,
-      "body": "",
-      "cardStyle": 1,
-      "cards": [
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "WHY RUN IT YOURSELF",
+      "heading": "Everything stays where the auditors can see it",
+      "description": "Cloud AI is fine until legal asks where the prompts go. Running the model on your own infrastructure turns that conversation from a risk assessment into a network diagram.\n",
+      "steps": [
         {
-          "guid": "pzx5dv",
-          "image": "/images/ssw-web/hero/local-llm.jpg",
-          "altText": "Lorem Ipsum",
+          "brow": "01",
           "heading": "Run where the auditors are happy",
-          "description": "VPC, private cloud, or on-prem with air-gap.",
-          "featureList": {
-            "features": [
-              {
-                "heading": "Zero data leaves",
-                "description": "Sensitive info never leaves; tick SOC 2/HIPAA boxes.",
-                "icon": "BiSolidCheckShield"
-              },
-              {
-                "heading": "Performance local",
-                "description": "Cut network hops and jitter for more reliable responses.",
-                "icon": "BiSolidBolt"
-              }
-            ]
-          },
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "description": "VPC, private cloud, or on-prem with a full air-gap. You pick the boundary and we deploy inside it.\n"
         },
         {
-          "guid": "07ihrh",
-          "image": "/images/ssw-web/blog/openai-api.jpg",
-          "altText": "Lorem Ipsum",
-          "icon": "info",
-          "heading": "Drop-in integration",
-          "description": "Your developers can use the tools they already know and love. Simply swap a single API endpoint.",
-          "featureList": {
-            "features": [
-              {
-                "heading": "No learning curve",
-                "description": "Teams ship features faster because nothing gets rewritten",
-                "icon": "BiCodeCurly"
-              },
-              {
-                "heading": "Model freedom",
-                "description": "Swap open-source models (OpenAI, Qwen, etc.) without changing your app.",
-                "icon": "BiSolidBrain"
-              }
-            ]
-          },
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "brow": "02",
+          "heading": "Zero data leaves",
+          "description": "Sensitive information never crosses your perimeter, which makes the SOC 2 and HIPAA conversations considerably shorter.\n"
         },
         {
-          "guid": "xnidab",
-          "image": "/images/ssw-web/blog/one-click-deploy.jpg",
-          "altText": "Lorem Ipsum",
-          "icon": "info",
-          "heading": "One-click model management",
-          "description": "Launch, scale, and roll back without MLOps drama.",
-          "featureList": {
-            "features": [
-              {
-                "heading": "Simple ops",
-                "description": "Autoscale for traffic spikes without pager chaos",
-                "icon": "BiArrowToTop"
-              },
-              {
-                "heading": "Minutes, not months",
-                "description": "Go from “found a model” to “prod endpoint” quickly.",
-                "icon": "BiAlarm"
-              }
-            ]
-          },
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "brow": "03",
+          "heading": "Performance stays local",
+          "description": "Cutting the network hops and the jitter that comes with them gives you response times you can actually design around.\n"
         }
       ],
-      "background": {
-        "backgroundColour": 6,
-        "backgroundImage": ""
-      },
-      "_template": "cardCarousel"
+      "_template": "v3FeatureSteps"
     },
     {
-      "topLabel": {
-        "labelText": "From Theory to Reality"
-      },
-      "heading": "Offline AI in Action: A Developer's Guide to Local LLMs",
-      "isH1": false,
-      "description": "Discover why running large language models locally is a game-changer for data privacy, security, and speed. In this session, SSW Solution Architect Jernej Kavka provides a hands-on guide to the essential tools and techniques, culminating in a live demo of an offline AI copilot for home automation.\n",
-      "featureColumns": {
-        "twoColumns": false
-      },
       "background": {
-        "backgroundColour": 6,
-        "backgroundImage": "/images/ssw-web/background/ssw_background_3.png",
-        "bleed": true
+        "backgroundColour": 7,
+        "gridOverlay": true
       },
-      "mediaConfiguration": {
-        "mediaType": "youtube",
-        "imageSource": "/images/ssw-web/hero/case_study_local-llm.jpg",
-        "imageHeight": 768,
-        "imageWidth": 1408,
-        "youtubeUrl": "https://www.youtube.com/watch?v=is4fO4NnjY0"
-      },
-      "_template": "imageTextBlock"
+      "videoUrl": "https://www.youtube.com/watch?v=is4fO4NnjY0",
+      "brow": "FROM THEORY TO REALITY",
+      "heading": "Offline AI in action: a developer's guide to local LLMs",
+      "description": "SSW Solution Architect Jernej Kavka walks through why running large language models locally is a game-changer for privacy, security and speed, then gives a hands-on guide to the tooling and a live demo of an offline AI copilot for home automation.\n",
+      "highlights": [
+        {
+          "title": "Drop-in integration",
+          "desc2": "We expose an OpenAI-compatible endpoint, so your developers keep the tools they already know and swap a single base URL.\n"
+        },
+        {
+          "title": "Model freedom",
+          "desc2": "Swap open-source models without touching your app, so you're never stuck with whoever was best the month you signed.\n"
+        }
+      ],
+      "_template": "v3VideoHighlights"
     },
     {
-      "isStacked": true,
-      "heading": "",
-      "isH1": false,
-      "body": "",
-      "cardStyle": 0,
+      "background": {
+        "backgroundColour": 7
+      },
+      "brow": "WHAT YOU GET",
+      "heading": "Production-ready, not a science project",
+      "subtitle": "Standing a model up is the easy half. Keeping it running is the half we're here for.",
       "cards": [
         {
-          "guid": "e4a7x7",
-          "altText": "Lorem Ipsum",
-          "icon": "BiCrosshair",
-          "heading": "100% Air-Gap Ready",
-          "description": "",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "No learning curve",
+          "description": "Teams ship features faster because nothing has to be rewritten to talk to it."
         },
         {
-          "guid": "2jlc1p",
-          "altText": "Lorem Ipsum",
-          "icon": "BiSolidLock",
-          "heading": "Satisfy the most rigorous security audits with ease",
-          "description": "",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "One-click model management",
+          "description": "Launch, scale and roll back without the MLOps drama."
         },
         {
-          "guid": "pwvxts",
-          "altText": "Lorem Ipsum",
-          "icon": "BiCurrentLocation",
-          "heading": "Process requests instantly without cloud latency",
-          "description": "",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "title": "Simple ops",
+          "description": "Autoscale for traffic spikes without pager chaos."
+        },
+        {
+          "title": "Minutes, not months",
+          "description": "Go from \"found a model\" to \"prod endpoint\" quickly."
         }
       ],
+      "_template": "v3StackCards"
+    },
+    {
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7
       },
-      "_template": "cardCarousel"
+      "brow": "TECH WE USE",
+      "heading": "Models we deploy",
+      "subtitle": "All open-weight, all running on hardware you control.",
+      "pills": [
+        { "label": "Llama" },
+        { "label": "Qwen" },
+        { "label": "Mistral" },
+        { "label": "Gemma" },
+        { "label": "DeepSeek" },
+        { "label": "Phi" },
+        { "label": "Ollama" },
+        { "label": "vLLM" },
+        { "label": "Kubernetes" }
+      ],
+      "_template": "v3Pills"
+    },
+    {
+      "background": {
+        "backgroundColour": 7
+      },
+      "heading": "Tell us about **your** deployment",
+      "description": "Answer a few quick questions. We'll set up an initial meeting and show you where we'd start\n",
+      "_template": "v3LeadCapture"
     },
     {
       "isStacked": false,
+      "brow": "learn more on SSWTV",
       "heading": "Tech wisdom from the trenches",
       "isH1": false,
-      "body": "At SSW, we’ve been knee-deep in projects for years: debugging giant solutions, fixing game-stopping bugs, and staying on the cutting edge. No guesswork, just proven tips that help you build better software.",
-      "cardStyle": 1,
+      "body": "SSW has been building enterprise projects for thirty years. We document what we learn for free on SSW Rules and SSW TV.",
+      "tabletTextAlignment": "Left",
       "cards": [
         {
-          "guid": "20w4bj",
+          "guid": "llm001",
           "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=sE5VCL48bzo&t=2480s",
+          "youtubeUrl": "https://www.youtube.com/watch?v=sE5VCL48bzo",
           "altText": "Build AI Tools Faster with MCP",
-          "chips": [
-            {
-              "chipText": "Model Context Protocol",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "52 min.",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "Build AI Tools Faster with MCP",
-          "description": "Join Anton Polkanov to demystify MCP! Build and connect an MCP server in .NET 9, wire up tools, resources, and prompts, add human-in-the-loop & secure actions, and deploy via Docker or remote endpoints!",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "category": "Model Context Protocol",
+          "heading": "Build AI Tools Faster with MCP"
         },
         {
-          "guid": "y1uoh",
+          "guid": "llm002",
           "mediaType": "youtube",
           "youtubeUrl": "https://youtu.be/BlqJ7bnivLE",
           "altText": "The Year of the AI Agent: Automation to Intelligence",
-          "chips": [
-            {
-              "chipText": "AI Trends",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "90 min.",
-              "chipType": "filledChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "The Year of the AI Agent: Automation to Intelligence",
-          "description": "Dive into the future of AI with Ulysses Maclaren in this insightful SSW User Group session! Explore the exciting shift from automation to true AI intelligence and discover what the year of the AI agent holds for developers.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "category": "AI Trends",
+          "heading": "The Year of the AI Agent: Automation to Intelligence"
         },
         {
-          "guid": "n7hexc",
+          "guid": "llm003",
           "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=nD6XDMP1-CM&t=104s",
+          "youtubeUrl": "https://www.youtube.com/watch?v=nD6XDMP1-CM",
           "altText": "Mastering Microsoft Copilot, Agents & Connectors",
-          "chips": [
-            {
-              "chipText": "MS Copilot",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "8 min.",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "Mastering Microsoft Copilot, Agents & Connectors",
-          "description": "Join Jean Thirion (SSW France) to explore the three Copilot types, when to use them, and how agents + connectors tap internal and external data (SQL, Jira). See Copilot Studio, M365 architecture, and next steps for ROI!",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "category": "MS Copilot",
+          "heading": "Mastering Microsoft Copilot, Agents & Connectors"
         },
         {
-          "guid": "0jobui",
+          "guid": "llm004",
           "mediaType": "youtube",
-          "youtubeUrl": "https://www.youtube.com/watch?v=NXY80p4k6Ac&t=1s",
+          "youtubeUrl": "https://www.youtube.com/watch?v=NXY80p4k6Ac",
           "altText": "Beyond the API: MCP for Plug-and-Play Integrations",
-          "chips": [
-            {
-              "chipText": "Model Context Protocol",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "2 hr.",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "Beyond the API: MCP for Plug-and-Play Integrations",
-          "description": "Join Calum Simpson as he demystifies Model Context Protocol, evolving brittle APIs into AI-ready workflows! Explore Cloud Code, GitHub MCP, and TeloScript, with demos from dev automation to Scrum mastering.",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "category": "Model Context Protocol",
+          "heading": "Beyond the API: MCP for Plug-and-Play Integrations"
         },
         {
-          "guid": "pv7uh",
+          "guid": "llm005",
           "mediaType": "youtube",
           "youtubeUrl": "https://www.youtube.com/watch?v=WwF69cj8490",
-          "altText": "Lorem Ipsum",
-          "chips": [
-            {
-              "chipText": "Business",
-              "chipType": "filledChip"
-            },
-            {
-              "chipText": "8 min.",
-              "chipType": "clearChip"
-            }
-          ],
-          "icon": "info",
-          "heading": "How to supercharge a company with AI",
-          "description": "Supercharge your company with AI! 🚀 See how SSW transformed their business and Tina CMS using practical AI strategies, from customer support chatbots to AI-powered product features. Discover actionable tips to implement AI",
-          "embeddedButton": {
-            "buttonText": ""
-          }
+          "altText": "How to supercharge a company with AI",
+          "category": "Business",
+          "heading": "How to supercharge a company with AI"
         }
       ],
       "background": {
-        "backgroundColour": 6
+        "backgroundColour": 7
       },
-      "_template": "cardCarousel"
+      "_template": "v3CardCarousel"
     },
     {
-      "heading": "FAQ",
-      "body": "",
-      "accordionItems": [
+      "background": {
+        "backgroundColour": 8
+      },
+      "heading": "Frequently asked questions",
+      "faqs": [
         {
-          "label": "How do you prove zero data egress?",
-          "content": "Default-deny firewall + Kubernetes NetworkPolicy, scripted egress probes (hourly), and signed logs. We include the egress test pack and data-flow diagram for audits.\n"
+          "question": "How do you prove zero data egress?",
+          "answer": "Default-deny firewall plus Kubernetes NetworkPolicy, scripted egress probes hourly, and signed logs. We include the egress test pack and a data-flow diagram for your audits.\n"
         },
         {
-          "label": "Do we need GPUs?",
-          "content": "Recommended for throughput and p95. Typical start: 4× L40S (or A100/H100 equivalents). CPU-only is fine for light loads or batch jobs; we share a sizing guide.\n\nPrivate cloud is also an option if you don't have any of your own hardware.\n"
+          "question": "Do we need GPUs?",
+          "answer": "Recommended for throughput and p95. A typical start is 4x L40S, or A100/H100 equivalents. CPU-only is fine for light loads or batch jobs, and we share a sizing guide. Private cloud is an option if you don't have your own hardware.\n"
         },
         {
-          "label": "Will our apps need changes?",
-          "content": "Minimal. We expose an OpenAI-compatible endpoint, so existing clients usually point to a new base URL. Auth and rate limits are configured in the gateway.\n"
+          "question": "Will our apps need changes?",
+          "answer": "Minimal. We expose an OpenAI-compatible endpoint, so existing clients usually just point at a new base URL. Auth and rate limits are configured in the gateway.\n"
+        },
+        {
+          "question": "How much does it cost?",
+          "answer": "Every engagement is scoped to your goals, so there's no single price. The initial call is always 100% **free**. The specification review will be used to give the most accurate estimation possible for a projects scope, price and duration.\n",
+          "link": "https://www.ssw.com.au/rules/what-is-a-spec-review"
         }
       ],
-      "background": {
-        "backgroundColour": 6
-      },
-      "_template": "accordionBlock"
+      "_template": "v3Faq"
     },
     {
-      "topLabel": {
-        "labelText": ""
+      "background": {
+        "backgroundColour": 7,
+        "gridOverlay": true,
+        "redGlow": true
       },
-      "heading": "Bring models to your data. Zero egress. Real numbers.",
-      "isH1": false,
-      "description": "",
-      "featureColumns": {
-        "twoColumns": true
-      },
+      "heading": "Bring models to your data. Zero egress, real numbers.",
+      "description": "Get in touch and we'll set up an initial meeting to show you where we'd start\n",
       "buttons": [
         {
-          "buttonText": "👉 Book a Free Initial Meeting",
-          "leadCaptureFormOption": "bookingJotFormId",
+          "buttonText": "Book a Free Initial Meeting",
+          "buttonLink": "#lead-capture-heading",
           "colour": 0
+        },
+        {
+          "buttonText": "+61 2 9953 3000",
+          "buttonLink": "tel:+61299533000",
+          "icon": "BiPhone",
+          "iconFirst": true,
+          "colour": 1
         }
       ],
-      "background": {
-        "backgroundColour": 2
-      },
-      "_template": "imageTextBlock"
-    },
-    {
-      "spacerHeight": "150px",
-      "background": {
-        "backgroundColour": 5,
-        "backgroundImage": "",
-        "bleed": false
-      },
-      "_template": "spacer"
+      "_template": "v3Cta"
     }
   ]
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -327,7 +327,7 @@ export default {
         sswRed: "#cc4141",
         sswDarkRed: "#8e2c2c",
         sswBlack: "#333333",
-        sswDarkGray: '#090909',
+        sswDarkGray: "#090909",
         sswBorder: "#212121",
         sswCard: "#0d0d0d",
         // SSW design-system tokens (from ssw-tokens via shadcn registry), mapped
@@ -440,11 +440,19 @@ export default {
         },
       }),
       backgroundImage: {
-        "dot-grid": "radial-gradient(circle, var(--dot-color) 1px, transparent 1px)",
+        "dot-grid":
+          "radial-gradient(circle, var(--dot-color) 1px, transparent 1px)",
         "red-glow-tl":
           "radial-gradient(circle at top left, rgba(204,65,65,0.15), transparent 35%)",
         "red-glow-r":
           "radial-gradient(circle at 78% 50%, rgba(204,65,65,0.15), transparent 25%)",
+        // Bleed variants: the layer is grown 10rem past the block top and bottom,
+        // so the top-left glow is anchored 10rem down to keep its centre on the
+        // block's corner, and both stops shrink to offset the taller gradient box.
+        "red-glow-tl-bleed":
+          "radial-gradient(circle at left 10rem, rgba(204,65,65,0.15), transparent 30%)",
+        "red-glow-r-bleed":
+          "radial-gradient(circle at 78% 50%, rgba(204,65,65,0.15), transparent 23%)",
         "red-radial": "radial-gradient(circle, #cc4141, transparent 70%)",
         done: "url('/images/icons/done.png')",
         "arrow-right": "url('/images/icons/arrow-right.png')",


### PR DESCRIPTION
## TL;DR

Stacked on #4950. That PR moved `/consulting/artificial-intelligence` to v3 and built the blocks needed to do it; this one applies the same treatment to the six pages around it — AI Discovery Workshop, GPT, Azure, Local LLM Deployment, Chatbots and AI-Powered Phone System. Content only: no component changes, so the diff is six JSON files.

**Files to review (6, +1205 / -1686):**

| File | Blocks |
|---|---|
| `ai-discovery-workshop.json` *(start here)* | 14 — the most page-specific of the six |
| `gpt.json` | 13 |
| `chat-bots.json` | 13 |
| `azure.json` | 12 |
| `local-llm-deployment.json` | 11 |
| `ai-powered-phone-system.json` | 10 |

## Why

Every one of these was still on `imageTextBlock` + `spacer`, several with placeholder logos from `/images/Louis Test Images/`. They sit one click from the AI page, so the inconsistency is visible in a single browsing session.

## Reviewer notes

- **Not one template.** Block choice and order follow each page's own content. The workshop leads with the three-day structure and prices it in `v3Statistics` (3 days / $12,000 + GST / 8 attendees max); Azure gets two `v3VideoHighlights` (why SSW, then landing zones); the phone system has no `v3Pills` because its tech list is four consulting services, which is a `v3StackCards`.
- **Copy is carried over, not rewritten.** Headings and FAQ answers come from the existing pages, tightened for the v3 layout. The new writing is the `v3FeatureSteps` problem framings, where v2 had no equivalent section.
- **Two FAQ sets are partly new.** GPT and Chatbots had no FAQ block at all; theirs reuse the standard cost/team answers plus two page-specific ones. Worth a read.
- **`chat-bots.json` had the wrong canonical** — it pointed at `/consulting/artificial-intelligence`. Fixed to `/consulting/chat-bots`.
- **`ai-powered-phone-system.json` canonical points at `/consulting/aiphonesystem`**, a different slug from the file. Left alone in case a redirect depends on it, but it looks wrong.
- **Placeholder hero images replaced** with real assets from `/images/ssw-web/hero/`. GPT uses the animated `aiConsultingSvg` from #4950.
- **Validated** that every `_template` is registered, every `/consulting/*` link resolves to a content file, and every image path exists on disk.

## Follow-up

`/consulting/chatbots` (v1 MDX) and `/consulting/bots` (v2) both overlap heavily with `chat-bots`. Per our call these should become redirects, but that's a separate change and not in this PR.

## Links

- Stacked on: #4950