### PR TITLE
🐛 Push hero further out of view when the scroll arrow is clicked

### DIFF
--- a/components/blocks/v3/heroBox/heroBox.tsx
+++ b/components/blocks/v3/heroBox/heroBox.tsx
@@ -63,7 +63,7 @@ export const V3HeroBox = ({ data, priority = false }) => {
           // the top of the screen, pulling the hero up out of the way.
           const { top } = e.currentTarget.getBoundingClientRect();
           window.scrollTo({
-            top: window.scrollY + top - window.innerHeight * 0.1,
+            top: window.scrollY + top - window.innerHeight * -0.1,
             behavior: "smooth",
           });
         }}

--- a/components/blocks/v3/heroBox/heroBox.tsx
+++ b/components/blocks/v3/heroBox/heroBox.tsx
@@ -63,7 +63,7 @@ export const V3HeroBox = ({ data, priority = false }) => {
           // screen, clearing the hero out of the way.
           const { top } = e.currentTarget.getBoundingClientRect();
           window.scrollTo({
-            top: window.scrollY + top - window.innerHeight * -0.1,
+            top: window.scrollY + top + window.innerHeight * 0.1,
             behavior: "smooth",
           });
         }}

--- a/components/blocks/v3/heroBox/heroBox.tsx
+++ b/components/blocks/v3/heroBox/heroBox.tsx
@@ -59,8 +59,8 @@ export const V3HeroBox = ({ data, priority = false }) => {
         type="button"
         aria-label="Scroll to content"
         onClick={(e) => {
-          // Scroll so the arrow ends up 10% of the viewport height down from
-          // the top of the screen, pulling the hero up out of the way.
+          // Scroll the arrow 10% of the viewport height past the top of the
+          // screen, clearing the hero out of the way.
           const { top } = e.currentTarget.getBoundingClientRect();
           window.scrollTo({
             top: window.scrollY + top - window.innerHeight * -0.1,


### PR DESCRIPTION
The arrow landed 10% of viewport height *below* the top of the screen, leaving a slice of hero on view. Negating the offset lands it 10% *above* instead, so the hero clears the viewport.

```diff
- top: window.scrollY + top - window.innerHeight * 0.1,
+ top: window.scrollY + top + window.innerHeight * 0.1,
```

- Affected routes: `/`
- Closes #4928

> [!NOTE]
> Overlaps with #4967, which rewrites the same handler. Merge one, not both.

## Testing

Chrome DevTools, homepage, checking the service cards section is fully in view after the scroll settles:

| Viewport | Result |
|---|---|
| 768 × 1024, 1440 × 900, 1920 × 1080 | ✅ |
| 390 × 844, 1280 × 800, 1366 × 768 | ⚠️ cards clipped 64–110 px |
| 375 × 667 | ❌ cards clipped 326 px |

Heading is always visible. Remaining clipping is because the formula aims at the button, not the section — and at 375 × 667 and 1366 × 768 the content is taller than the viewport, so no scroll offset fits it. Those need `py-24` or the card graphic shrunk.

