### PR TITLE
📝 Clarify Node/pnpm setup and mark Docker optional in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,18 @@ This repository is a v3 of the SSW.Website. This website uses NextJS with TinaCM
 
 ## Requirements
 
-- Git, [Node.js Active LTS](https://nodejs.org/en/about/releases/)
+- Git, and the Node.js version pinned in [`.nvmrc`](.nvmrc) (currently v24.13.1). `nvm use` picks it up automatically.
 - pnpm `corepack enable pnpm`
 - A [TinaCMS](https://app.tina.io) account for live editing.
 
 ## Get Started
+
+Select the pinned Node version and enable pnpm. Both are one-off, and Corepack ships with Node:
+
+```bash
+nvm use
+corepack enable pnpm
+```
 
 Install the project's dependencies:
 
@@ -39,7 +46,7 @@ Install the project's dependencies:
 pnpm install
 ```
 
-Run the project locally:
+Run the project locally. This starts Next.js and the local TinaCMS server together, which is why there are two ports below:
 
 ```bash
 pnpm dev
@@ -51,7 +58,9 @@ Build the project:
 pnpm build
 ```
 
-## Build the Docker image locally:
+## Build the Docker image locally (optional)
+
+Docker is not required for day-to-day development. `pnpm dev` above is usually the quicker path, and is easier to debug. Build the image when you need to reproduce the deployed container, for example to chase a build or runtime problem that only shows up there.
 
 To build the Docker image, execute the following command to extract the necessary Docker build command:
 


### PR DESCRIPTION
README-only change to the getting-started steps.

- Affected routes: none (docs only)

- No linked issue - `no-issue` label applied, per its description ("used to bypass the PR-Lint check. Should be used for non-coding changes")

**Changes:**

- **Node version was vague.** Requirements said "Node.js Active LTS", which doesn't match the repo - `.nvmrc` pins v24.13.1. Now points at `.nvmrc` with the concrete version and mentions `nvm use`.
- **pnpm appeared from nowhere.** `pnpm install` was the first command with no explanation of where `pnpm` comes from. Added `nvm use` + `corepack enable pnpm` as one-off setup. Corepack reads `pnpm@10.25.0` from the `packageManager` field, so nobody has to choose a version.
- **Docker read as required.** It sits between the local steps and the Dev Container section with no indication it's optional. Heading is now "(optional)", with one sentence on when it *is* the right tool (reproducing the deployed container) so it doesn't read as discouraging it.
- Noted that `pnpm dev` starts Next.js and the local Tina server together, since the localhost list further down shows ports 3000 and 4001 without saying why there are two.

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template

- [ ] If updating the livestream banner, I have tested and followed the steps in [Wiki - Testing the live banner](https://github.com/SSWConsulting/SSW.Website/wiki/Testing-the-live-banner)

- [x] Include Done Video or screenshots - n/a, the diff is the change (README only)
