### PR TITLE
content: sharpen Claude training page — shared AI vision, two instructors, fresh curriculum

### DIFF
--- a/content/consultingv2/claude-training.json
+++ b/content/consultingv2/claude-training.json
@@ -95,6 +95,11 @@
             "icon": "BiMoneyWithdraw"
           },
           {
+            "heading": "Two Instructors, Not One",
+            "description": "One leads the teaching, one mentors the room, so nobody gets stuck",
+            "icon": "BiSolidGroup"
+          },
+          {
             "heading": "Hands-On by Design",
             "description": "Real prompts, workflows, skills and live prototypes",
             "icon": "BiSolidBookBookmark"
@@ -105,9 +110,14 @@
             "icon": "BiSolidWrench"
           },
           {
-            "heading": "One-Stop-Shop",
-            "description": "Get the right training for your business context",
+            "heading": "Tailored to Your Industry",
+            "description": "Built around your industry, your use cases and your real workflows",
             "icon": "BiSolidCustomize"
+          },
+          {
+            "heading": "Built Fresh Each Time",
+            "description": "Curriculum designed close to delivery, because AI moves fast",
+            "icon": "BiSolidBolt"
           }
         ]
       },
@@ -159,12 +169,12 @@
         {
           "brow": "01",
           "heading": "Quick call to map goals",
-          "description": "We map your objectives, attendee experience, approved tools, data-handling requirements and the workflows your team most wants to improve. We then tailor the Foundation session and prepare relevant scenarios.\n"
+          "description": "We map your objectives, attendee experience, approved tools, data-handling requirements and the workflows your team most wants to improve. We then tailor the Foundation session to your industry and use cases, and prepare relevant scenarios.\n\nWe design the curriculum close to the delivery date on purpose. AI is moving fast, so what we teach reflects what Claude can do the week you are in the room, not what it could do last quarter.\n"
         },
         {
           "brow": "02",
           "heading": "Foundation training and pilot",
-          "description": "Your pilot group completes a practical half-day at your office, then applies Claude to real work and runs internal sessions. This reveals which habits stick and where the real bottlenecks are.\n"
+          "description": "Your pilot group completes a practical half-day at your office with two SSW presenters: one leading the teaching, one mentoring attendees through the hands-on exercises so nobody gets left behind.\n\nThe group then applies Claude to real work and runs internal sessions. This reveals which habits stick and where the real bottlenecks are.\n"
         },
         {
           "brow": "03",
@@ -265,7 +275,7 @@
       "faqs": [
         {
           "question": "How much does it cost?",
-          "answer": "Foundation Training is $5,200 + GST.\n\nAdvanced Training is $5,200 + GST.\n\nThe total for both tiers is $10,400 + GST, but either could be done separately if needed.\n\nEach fee includes a half-day onsite session and dedicated preparation. Advanced Training is delivered by two SSW presenters. Any additional consulting, development or implementation work can be scoped separately.\n",
+          "answer": "Foundation Training is $5,200 + GST.\n\nAdvanced Training is $5,200 + GST.\n\nThe total for both tiers is $10,400 + GST, but either could be done separately if needed.\n\nEach fee includes a half-day onsite session, dedicated preparation and two SSW presenters: one leading the teaching and one mentoring attendees through the hands-on work. Any additional consulting, development or implementation work can be scoped separately.\n",
           "link": ""
         },
         {

--- a/content/consultingv2/claude-training.json
+++ b/content/consultingv2/claude-training.json
@@ -13,7 +13,7 @@
       },
       "brow": "claude training",
       "heading": "Give your staff the superpowers they **need**",
-      "description": "Move beyond one-off prompts. SSW’s hands-on group Claude training helps your people use Chat, Cowork and Code safely, apply them to real work, and turn valuable processes into repeatable skills, automations and working prototypes.\n",
+      "description": "Move beyond one-off prompts. SSW’s hands-on group Claude training helps your people use Chat, Cowork and Code safely, apply them to real work, and turn valuable processes into repeatable skills, automations and working prototypes. The outcome is one shared way of working with AI across your organisation, not 100 different ones.\n",
       "buttons": [
         {
           "buttonText": "Book a Free Initial Meeting",
@@ -142,8 +142,8 @@
         },
         {
           "brow": "03",
-          "heading": "Good results are hard to repeat",
-          "description": "Useful context, constraints and skills live inside one person’s chat history. The next person starts again, and quality varies across the team.\n"
+          "heading": "Every team invents its own way",
+          "description": "Useful context, constraints and skills live inside one person’s chat history. The next person starts from scratch, so quality varies wildly and the organisation accumulates dozens of competing approaches instead of one standard.\n"
         }
       ],
       "_template": "v3FeatureSteps"
@@ -181,6 +181,10 @@
         {
           "label": "Foundation - What Claude Is and Where It Fits",
           "content": "Understand what Claude is good at, where it is limited and where human judgement is still required.\n\nYour team learns the principles for using Claude safely, responsibly and effectively in day-to-day business work.\n"
+        },
+        {
+          "label": "Foundation - A Shared Way of Working with AI",
+          "content": "Agree what “good” looks like for your organisation - which work is worth handing to Claude, where the safe-use boundaries sit, and the shared language your teams use to talk about AI work.\n\nYour pilot group leaves with a common standard they can take back and spread through their own teams.\n"
         },
         {
           "label": "Foundation - Chat, Cowork and Code",
@@ -276,6 +280,11 @@
         {
           "question": "Who should attend?",
           "answer": "Foundation Training is for pilot groups and people who are new to Claude or are still developing consistent working habits.\n\nIt is suitable for business, finance, operations and relevant technical team members.\n\nAdvanced Training is for experienced users who have already applied Claude to real work and can bring specific bottlenecks, workflows or solution ideas into the room.\n\nThe appropriate group size is confirmed during planning so participants receive useful support during the hands-on exercises.\n",
+          "link": ""
+        },
+        {
+          "question": "Will this give us a consistent approach across the company?",
+          "answer": "That is the intent. Foundation Training gives everyone the same mental model for Chat, Cowork and Code, and the same safe-use boundaries.\n\nAdvanced Training turns the best of what your people discover into custom Claude skills, so a good workflow becomes company property rather than one person’s chat history.\n\nThe pilot group is chosen so they can carry that standard back into their own teams.\n",
           "link": ""
         },
         {

--- a/content/consultingv2/claude-training.json
+++ b/content/consultingv2/claude-training.json
@@ -194,7 +194,7 @@
         },
         {
           "label": "Foundation - A Shared Way of Working with AI",
-          "content": "Agree what “good” looks like for your organisation - which work is worth handing to Claude, where the safe-use boundaries sit, and the shared language your teams use to talk about AI work.\n\nYour pilot group leaves with a common standard they can take back and spread through their own teams.\n"
+          "content": "Agree what “good” looks like for your organisation: what work is worth handing to Claude, where the safe-use boundaries sit, and what shared language your teams use to talk about AI work.\n\nYour pilot group leaves with a common standard they can take back and spread through their own teams.\n"
         },
         {
           "label": "Foundation - Chat, Cowork and Code",


### PR DESCRIPTION
## Why

The [Claude training page](https://www.ssw.com.au/consulting/claude-training) undersold several things that matter to a buyer. Every benefit landed on the individual or the pilot group, and three real differentiators were either missing or buried.

## Changes

All in `content/consultingv2/claude-training.json`.

### 1. A shared way of working, not 100 different ones

The org-level outcome was only implied. Now stated:

- **Hero** — appended a sentence naming the outcome ("one shared way of working with AI across your organisation, not 100 different ones")
- **Barrier 03** — retitled *"Good results are hard to repeat"* → *"Every team invents its own way"*, lifting it from team-level variance to the org accumulating competing approaches
- **New Foundation accordion item** — *"A Shared Way of Working with AI"*: agreeing what "good" looks like, safe-use boundaries, shared language, pilot group carrying the standard back
- **New FAQ** — *"Will this give us a consistent approach across the company?"*

### 2. Two instructors, not one

Previously framed as an **Advanced-only** perk, and the cost FAQ used it to justify the Advanced fee. It actually applies to **both tiers**, so:

- **New At a Glance tile** — *"Two Instructors, Not One"* / one leads the teaching, one mentors the room
- **How It Works 02** — Foundation now names both presenters and the teach + mentor split
- **Cost FAQ** — corrected: two presenters are included in each tier's fee, not just Advanced

### 3. Fresh curriculum + industry tailoring

Recency wasn't mentioned anywhere, and tailoring only ever said "business context" — never *industry*:

- **New At a Glance tile** — *"Built Fresh Each Time"* / curriculum designed close to delivery, because AI moves fast
- **Retitled tile** — vague *"One-Stop-Shop"* → *"Tailored to Your Industry"*
- **How It Works 01** — names industry and use-case tailoring, and explains why the curriculum is deliberately designed late

At a Glance goes from 4 tiles to 6, so the two-column grid still fills evenly. All icons (`BiSolidGroup`, `BiSolidBolt`) verified against the Tina icon picker set.

## ⚠️ One thing to sanity-check

The new *"A Shared Way of Working with AI"* accordion item is a claim about what we deliver, not just a copy tweak — it says Foundation includes a "what does good look like for us" alignment exercise. If presenters don't run that today, either the session picks it up or that item needs softening. Everything else here describes what the program already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)