### PR TITLE
✨ Fix: Homepage UX Improvements (#4923) (ACs 2, 3, 5, 6, 7, 8, 10, 16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ npm-debug.log*
 # TypeScript
 next-env.d.ts
 *.tsbuildinfo
+
+# git worktrees
+/.worktrees/

--- a/components/blocks/v3/globe/globe.tsx
+++ b/components/blocks/v3/globe/globe.tsx
@@ -20,7 +20,7 @@ function OfficeAccordionItem({ office, isOpen, onToggle }) {
   return (
     <div
       className={cn(
-        "relative border-b border-hairline bg-gray-100 dark:border-white/10 dark:bg-sswBorder",
+        "relative border-b border-hairline bg-gray-100 transition-colors hover:bg-gray-200 dark:border-white/10 dark:bg-sswBorder dark:hover:bg-sswBlack",
         isOpen && "bg-gray-200 dark:bg-sswBlack"
       )}
     >

--- a/components/blocks/v3/imageCards/imageCards.tsx
+++ b/components/blocks/v3/imageCards/imageCards.tsx
@@ -38,11 +38,11 @@ function ImageCard({ card, cardBackgroundClass, showBorder }) {
       />
       <div
         className={cn(
-          "relative flex aspect-[4/3] items-center justify-center bg-sswRed p-4 sm:p-8"
+          "relative flex aspect-video items-center justify-center bg-sswRed p-4 sm:p-6"
         )}
       >
         {card?.graphic?.imageSource && (
-          <div className={cn("relative size-40 max-w-[70%]")}>
+          <div className={cn("relative size-28 max-w-[60%]")}>
             <Image
               src={card.graphic.imageSource}
               alt={card.graphic.altText ?? card?.title ?? ""}

--- a/components/blocks/v3/peopleCarousel/peopleCarousel.schema.tsx
+++ b/components/blocks/v3/peopleCarousel/peopleCarousel.schema.tsx
@@ -122,6 +122,11 @@ export const V3PeopleCarouselSchema: Template = {
         },
         {
           type: "string",
+          label: "GitHub URL",
+          name: "github",
+        },
+        {
+          type: "string",
           label: "SSW People URL",
           name: "sswPeople",
         },

--- a/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
+++ b/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
@@ -40,7 +40,7 @@ function ProfileLink({ person, className, children }) {
       target="_blank"
       rel="noopener noreferrer"
       aria-label={`View ${person?.name ?? "this person"}'s SSW People profile`}
-      className={cn("!no-underline after:absolute after:inset-0", className)}
+      className={cn("!no-underline after:absolute after:inset-0 after:content-['']", className)}
     >
       {children}
     </Link>

--- a/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
+++ b/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
@@ -13,34 +13,22 @@ import { cn } from "@/lib/utils";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { FaLinkedinIn } from "react-icons/fa";
+import { FaGithub, FaLinkedinIn } from "react-icons/fa";
 import { FaXTwitter } from "react-icons/fa6";
 import { tinaField } from "tinacms/dist/react";
 import { CarouselDots } from "../shared/carouselDots";
 import { CarouselMoreCard } from "../shared/carouselMoreCard";
 import { PersonCardTexture } from "./personCardTexture";
 
-// The SSW mark is a 2×2 grid of squares. Rendered in currentColor so it inherits
-// the white→sswRed hover from its link, like the react-icons beside it.
-function SswPeopleIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 100 100" fill="currentColor" className={className}>
-      <rect x="0" y="0" width="46" height="46" />
-      <rect x="54" y="0" width="46" height="46" />
-      <rect x="0" y="54" width="46" height="46" />
-      <rect x="54" y="54" width="46" height="46" />
-    </svg>
-  );
-}
-
 const socials = [
   { key: "linkedin", label: "LinkedIn", Icon: FaLinkedinIn },
   { key: "twitter", label: "X", Icon: FaXTwitter },
-  { key: "sswPeople", label: "SSW People", Icon: SswPeopleIcon },
+  { key: "github", label: "GitHub", Icon: FaGithub },
 ];
 
-// The photo and name link to the profile; the social icons link out on their
-// own. A plain <div> stands in when there's no profile to link to.
+// Links the photo and name to the profile, with an ::after overlay stretching
+// the click target across the whole card; the social icons sit above it on
+// their own z-layer. A plain <div> stands in when there's no profile to link to.
 function ProfileLink({ person, className, children }) {
   if (!person?.sswPeople) {
     return <div className={className}>{children}</div>;
@@ -52,7 +40,7 @@ function ProfileLink({ person, className, children }) {
       target="_blank"
       rel="noopener noreferrer"
       aria-label={`View ${person?.name ?? "this person"}'s SSW People profile`}
-      className={cn("!no-underline", className)}
+      className={cn("!no-underline after:absolute after:inset-0", className)}
     >
       {children}
     </Link>
@@ -61,7 +49,7 @@ function ProfileLink({ person, className, children }) {
 
 function PersonCard({ person, index, scope }) {
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-card border-0.75 border-hairline bg-white transition-colors duration-300 hover:border-sswRed dark:border-sswBorder dark:bg-sswCard">
+    <div className="group relative flex h-full flex-col overflow-hidden rounded-card border-0.75 border-hairline bg-white transition-colors duration-300 hover:border-sswRed dark:border-sswBorder dark:bg-sswCard">
       <ProfileLink person={person} className="block">
         {/* Red panel frames the photo with padding on the sides and top while the
             photo stays flush to the bottom, so the person reads as standing in it. */}
@@ -80,7 +68,7 @@ function PersonCard({ person, index, scope }) {
 
         <div className="px-4 pt-4 text-center xl:px-6 xl:pt-6">
           {person?.name && (
-            <h3 className="text-xl font-semibold text-foreground">
+            <h3 className="text-xl font-semibold text-foreground transition-colors group-hover:text-sswRed">
               {person.name}
             </h3>
           )}
@@ -104,7 +92,8 @@ function PersonCard({ person, index, scope }) {
               aria-label={`${person?.name ?? ""} on ${label}`}
               // Keep the icon at 16px but give the link a ≥36×36px hit area
               // so it meets the minimum accessible touch-target size.
-              className="flex size-9 items-center justify-center text-foreground transition-colors hover:text-sswRed"
+              // z-10 lifts it above the stretched profile-link overlay.
+              className="relative z-10 flex size-9 items-center justify-center text-foreground transition-colors hover:text-sswRed"
             >
               <Icon className="size-4" />
             </Link>

--- a/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
+++ b/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
@@ -40,7 +40,10 @@ function ProfileLink({ person, className, children }) {
       target="_blank"
       rel="noopener noreferrer"
       aria-label={`View ${person?.name ?? "this person"}'s SSW People profile`}
-      className={cn("!no-underline after:absolute after:inset-0 after:content-['']", className)}
+      className={cn(
+        "!no-underline after:absolute after:inset-0 after:content-['']",
+        className
+      )}
     >
       {children}
     </Link>

--- a/components/blocks/v3/videoFeature/videoFeature.tsx
+++ b/components/blocks/v3/videoFeature/videoFeature.tsx
@@ -174,7 +174,7 @@ export function V3VideoFeature({ data }) {
               {data?.recognitionHeading && (
                 <span
                   data-tina-field={tinaField(data, "recognitionHeading")}
-                  className="font-mono text-xs uppercase tracking-widest text-muted-foreground"
+                  className="font-mono text-xs uppercase tracking-wider text-muted-foreground"
                 >
                   {data.recognitionHeading}
                 </span>

--- a/content/pagesv2/home.json
+++ b/content/pagesv2/home.json
@@ -92,7 +92,7 @@
       "background": {
         "backgroundColour": 7
       },
-      "heading": "The SSW difference",
+      "heading": "The SSW Advantage",
       "statistics": [
         {
           "figure": 7000,
@@ -110,7 +110,7 @@
           "figure": 30,
           "figureSuffix": "+",
           "heading": "Years experience",
-          "description": "Trusted since 1995"
+          "description": "Across 15 countries"
         }
       ],
       "_template": "v3Statistics"
@@ -318,6 +318,7 @@
           },
           "linkedin": "https://www.linkedin.com/in/calumjs/",
           "twitter": "https://x.com/_____Calum",
+          "github": "https://github.com/calumjs",
           "sswPeople": "https://www.ssw.com.au/people/calum-simpson/"
         },
         {
@@ -331,12 +332,13 @@
           },
           "linkedin": "https://www.linkedin.com/in/matt-wicks/",
           "twitter": "https://x.com/matteightyate",
+          "github": "https://github.com/wicksipedia",
           "sswPeople": "https://www.ssw.com.au/people/matt-wicks/"
         }
       ],
       "seeMoreButton": [
         {
-          "buttonText": "More SSW People",
+          "buttonText": "See All SSW People",
           "buttonLink": "/people",
           "icon": "BiChevronRight"
         }


### PR DESCRIPTION
Fixes #4923 — implements the open acceptance criteria ACs 2–8, 10, and 16. AC 9 (AU vs US English — pending Adam's call re SSW Global) and AC 15 (footer icon sizing) are intentionally left open.

## Changes

| AC | Change |
|----|--------|
| 2 | Red feature cards reduced from 4:3 to 16:9 panels with smaller icons — shorter, wider cards |
| 3 | Statistics heading renamed: "The SSW difference" → "The SSW Advantage" |
| 4 | "Years experience" supporting text: "Trusted since 1995" → "Across 15 countries" |
| 5 | Removed the misleading SSW-squares social icon from people cards |
| 6 | New optional GitHub URL field on people (Tina schema) + GitHub icons for Calum and Matt |
| 7 | Whole people card is now clickable (stretched profile link) so the red-border hover matches the click target; name turns red on hover; social icons keep independent click targets |
| 8 | "Trusted & Recognised" eyebrow aligned to the site-wide eyebrow tracking |
| 10 | Office accordion rows now have visible hover states (light + dark) |
| 16 | Button label: "More SSW People" → "See All SSW People" |

Also carries the `.worktrees/` gitignore housekeeping commit.

## Testing

- 27/27 jest tests pass
- Verified in the browser at 1440px in light and dark mode: card sizing, GitHub icons, whole-card click target (dead corners resolve to the profile link, social icons win their own clicks), accordion hover, all copy changes

Note for reviewers: local `pnpm test` currently only passes with a stale jest cache — `next/babel` under `babel-jest` emits `@babel/runtime` imports that pnpm's strict node_modules can't resolve. Pre-existing, unrelated to this PR (pristine checkout fails identically); CI is unaffected. Happy to raise a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
