### PR TITLE
content: swap Angular Hack Day Melbourne presenter to Luke Cook

### DIFF
--- a/content/events-calendar/2026/Angular-Hack-Day---Melbourne.json
+++ b/content/events-calendar/2026/Angular-Hack-Day---Melbourne.json
@@ -9,7 +9,7 @@
       "presenter": "content/presenters/gert-marx.mdx"
     },
     {
-      "presenter": "content/presenters/adam-cogan.mdx"
+      "presenter": "content/presenters/luke-cook.mdx"
     }
   ],
   "headerLayout": "avatars",


### PR DESCRIPTION
Changes the presenter on the 2026 Melbourne Angular Hack Day event from Adam Cogan to Luke Cook.

- `content/events-calendar/2026/Angular-Hack-Day---Melbourne.json` — `adam-cogan.mdx` → `luke-cook.mdx`
- Gert Marx remains as the other presenter
- No new presenter file needed — `content/presenters/luke-cook.mdx` already exists with bio, photo, skills and profile URL

Page: https://www.ssw.com.au/events/2026/angularhackdaymelb26

🤖 Generated with [Claude Code](https://claude.com/claude-code)