### PR TITLE
💄 Auto-dismiss the Chatbase greeting bubble after 10 seconds

### DIFF
--- a/components/zendeskButton/chatBaseBot.tsx
+++ b/components/zendeskButton/chatBaseBot.tsx
@@ -1,8 +1,69 @@
+"use client";
+
 import Script from "next/script";
+import { useEffect } from "react";
 
 const chatBaseBotId = process.env.NEXT_PUBLIC_CHATBASE_BOT_ID;
 
+const GREETING_BUBBLE_ID = "chatbase-message-bubbles";
+const GREETING_BUBBLE_LIFETIME_MS = 10_000;
+
+// Chatbase only lets us configure how long before the greeting bubble appears, never
+// when it leaves. It renders the bubble up front with an inline `display: none` and
+// flips that to show it, so we watch the style attribute rather than the node itself.
+const useAutoDismissGreetingBubble = () => {
+  useEffect(() => {
+    if (!chatBaseBotId) return;
+
+    let hideTimeout: ReturnType<typeof setTimeout> | undefined;
+    const observers: MutationObserver[] = [];
+
+    const scheduleHide = (bubble: HTMLElement) => {
+      if (hideTimeout !== undefined || bubble.style.display === "none") return;
+
+      hideTimeout = setTimeout(() => {
+        bubble.style.display = "none";
+        hideTimeout = undefined;
+      }, GREETING_BUBBLE_LIFETIME_MS);
+    };
+
+    const watchBubble = (bubble: HTMLElement) => {
+      const styleObserver = new MutationObserver(() => scheduleHide(bubble));
+      styleObserver.observe(bubble, { attributeFilter: ["style"] });
+      observers.push(styleObserver);
+      scheduleHide(bubble);
+    };
+
+    const bubble = document.getElementById(GREETING_BUBBLE_ID);
+
+    if (bubble) {
+      watchBubble(bubble);
+    } else {
+      const injectionObserver = new MutationObserver(() => {
+        const injected = document.getElementById(GREETING_BUBBLE_ID);
+        if (!injected) return;
+
+        injectionObserver.disconnect();
+        watchBubble(injected);
+      });
+
+      injectionObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+      observers.push(injectionObserver);
+    }
+
+    return () => {
+      observers.forEach((observer) => observer.disconnect());
+      clearTimeout(hideTimeout);
+    };
+  }, []);
+};
+
 const ChatBaseBot = () => {
+  useAutoDismissGreetingBubble();
+
   return (
     chatBaseBotId && (
       <Script

--- a/components/zendeskButton/chatBaseBot.tsx
+++ b/components/zendeskButton/chatBaseBot.tsx
@@ -1,69 +1,21 @@
 "use client";
 
 import Script from "next/script";
-import { useEffect } from "react";
 
 const chatBaseBotId = process.env.NEXT_PUBLIC_CHATBASE_BOT_ID;
 
-const GREETING_BUBBLE_ID = "chatbase-message-bubbles";
-const GREETING_BUBBLE_LIFETIME_MS = 10_000;
+// Chatbase reveals its greeting bubble 3s after the embed loads and offers no way
+// to dismiss it, so we hide it ourselves after 10s on screen.
+const DISMISS_GREETING_AFTER_LOAD_MS = 13_000;
 
-// Chatbase only lets us configure how long before the greeting bubble appears, never
-// when it leaves. It renders the bubble up front with an inline `display: none` and
-// flips that to show it, so we watch the style attribute rather than the node itself.
-const useAutoDismissGreetingBubble = () => {
-  useEffect(() => {
-    if (!chatBaseBotId) return;
-
-    let hideTimeout: ReturnType<typeof setTimeout> | undefined;
-    const observers: MutationObserver[] = [];
-
-    const scheduleHide = (bubble: HTMLElement) => {
-      if (hideTimeout !== undefined || bubble.style.display === "none") return;
-
-      hideTimeout = setTimeout(() => {
-        bubble.style.display = "none";
-        hideTimeout = undefined;
-      }, GREETING_BUBBLE_LIFETIME_MS);
-    };
-
-    const watchBubble = (bubble: HTMLElement) => {
-      const styleObserver = new MutationObserver(() => scheduleHide(bubble));
-      styleObserver.observe(bubble, { attributeFilter: ["style"] });
-      observers.push(styleObserver);
-      scheduleHide(bubble);
-    };
-
-    const bubble = document.getElementById(GREETING_BUBBLE_ID);
-
-    if (bubble) {
-      watchBubble(bubble);
-    } else {
-      const injectionObserver = new MutationObserver(() => {
-        const injected = document.getElementById(GREETING_BUBBLE_ID);
-        if (!injected) return;
-
-        injectionObserver.disconnect();
-        watchBubble(injected);
-      });
-
-      injectionObserver.observe(document.body, {
-        childList: true,
-        subtree: true,
-      });
-      observers.push(injectionObserver);
-    }
-
-    return () => {
-      observers.forEach((observer) => observer.disconnect());
-      clearTimeout(hideTimeout);
-    };
-  }, []);
+const dismissGreetingBubble = () => {
+  setTimeout(() => {
+    const bubble = document.getElementById("chatbase-message-bubbles");
+    if (bubble) bubble.style.display = "none";
+  }, DISMISS_GREETING_AFTER_LOAD_MS);
 };
 
 const ChatBaseBot = () => {
-  useAutoDismissGreetingBubble();
-
   return (
     chatBaseBotId && (
       <Script
@@ -72,6 +24,7 @@ const ChatBaseBot = () => {
         async
         defer
         strategy="lazyOnload"
+        onLoad={dismissGreetingBubble}
       />
     )
   );


### PR DESCRIPTION
## TL;DR

The Chatbase greeting ("Hi! I am a ChatGPT assistant created by SSW. Ask me something!") pops up 3s after the embed loads and then sits on screen until the visitor closes it. This hides it after ~10s.

- Affected routes: all pages (rendered from the root layout)

## Why

Chatbase has no auto-dismiss. Its dashboard only exposes *when to show* (`floatingInitialMessagesDelay`, plus a separate mobile duration), and the widget JS API is limited to `open()`, `close()`, and `resetChat()` — `close()` targets the chat window, not the greeting bubble. So the timeout has to live on our side.

## Reviewer notes

- **Timer hangs off `onLoad`, not mount.** The embed is `lazyOnload`, so hydration is a poor clock — `onLoad` fires close to when Chatbase starts its own 3s delay. The 13s constant is that delay plus the 10s we want it on screen.
- **Hides the way Chatbase does.** Sets inline `display: none`, the same end state as the widget's own close button.
- **Tradeoff:** the 13s assumes the dashboard's 3s reveal delay. If that setting changes, or a slow load pushes the reveal past 13s, the bubble shows for less than 10s — worst case it isn't caught at all. The robust alternative is observing the bubble's style attribute for the reveal; deliberately skipped to keep this to one `setTimeout`.

## Tests

None — the behaviour depends on a third-party script that isn't loaded in Jest. `tsc` and Prettier are clean; the 10s needs an eyeball on a preview slot.

## Links

- [Chatbase — Floating Initial Messages](https://www.chatbase.co/docs/developer-guides/floating-initial-messages)
- [Chatbase — Widget Control](https://www.chatbase.co/docs/developer-guides/control-widget)

---

Changes made with Claude Opus 5 in Claude Code.