### PR TITLE
reduce from 10s to 5s for chatbase bubblething

### DIFF
--- a/components/zendeskButton/chatBaseBot.tsx
+++ b/components/zendeskButton/chatBaseBot.tsx
@@ -6,7 +6,7 @@ const chatBaseBotId = process.env.NEXT_PUBLIC_CHATBASE_BOT_ID;
 
 // Chatbase reveals its greeting bubble 3s after the embed loads and offers no way
 // to dismiss it, so we hide it ourselves after 10s on screen.
-const DISMISS_GREETING_AFTER_LOAD_MS = 13_000;
+const DISMISS_GREETING_AFTER_LOAD_MS = 8_000;
 
 const dismissGreetingBubble = () => {
   setTimeout(() => {


### PR DESCRIPTION
Reduce from 10s (from mount) to 3s as per Uly's req

<img width="177" height="36" alt="Screenshot 2026-08-24 at 10 35 20 am" src="https://github.com/user-attachments/assets/05338d64-1f64-4eb2-92f9-b99c8ea8368c" />

**Figure: Uly requests 10s -> 5s**

