### PR TITLE
Add Hark Singh's Newcastle Coders September talk

### DIFF
--- a/content/events-calendar/2026/Newcastle-Coders-September-Mobile-101-Tales-of-Mobile-Development.json
+++ b/content/events-calendar/2026/Newcastle-Coders-September-Mobile-101-Tales-of-Mobile-Development.json
@@ -1,0 +1,24 @@
+{
+  "title": "Newcastle Coders September: Mobile 101: Tales of Mobile Development",
+  "slug": "newcastle-mobile-101",
+  "url": "https://www.meetup.com/newcastle-coders-group/events/315985820/",
+  "thumbnail": "/images/events/newcastle-coders-group.png",
+  "thumbnailDescription": "Newcastle Coders Group",
+  "presenterList": [
+    {
+      "presenter": "content/presenters/hark-singh.mdx"
+    }
+  ],
+  "startDateTime": "2026-09-02T08:00:00.000Z",
+  "endDateTime": "2026-09-02T10:00:00.000Z",
+  "startShowBannerDateTime": "2026-09-01T14:00:00.000Z",
+  "endShowBannerDateTime": "2026-09-02T12:00:00.000Z",
+  "calendarType": "User Groups",
+  "city": "Newcastle",
+  "category": "Mobile",
+  "abstract": "Everyone has a mobile phone, but how does an app actually get onto it? This is a beginner-friendly tour of the mobile world, whether you write code or not.\n\nWe start with a simple question: why do we even need mobile apps when the web is right there? From there, we follow an app on its journey to the customer and watch the friction you may face, from a web page you can ship in minutes, to a desktop app, to the app stores where going live is a real challenge.\n\nThen the interesting part. How you actually build for mobile, native versus cross-platform like Flutter and React Native, and a question my colleague Calum put to me: if AI can write the code now, do we still need cross-platform frameworks at all? We will work through that together.\n\nYou will leave knowing how mobile development really works, and a curiosity to explore mobile development.",
+  "description": "Everyone has a mobile phone, but how does an app actually get onto it? This is a beginner-friendly tour of the mobile world, whether you write code or not.\n\nWe start with a simple question: why do we even need mobile apps when the web is right there? From there, we follow an app on its journey to the customer and watch the friction you may face, from a web page you can ship in minutes, to a desktop app, to the app stores where going live is a real challenge.\n\nThen the interesting part. How you actually build for mobile, native versus cross-platform like Flutter and React Native, and a question my colleague Calum put to me: if AI can write the code now, do we still need cross-platform frameworks at all? We will work through that together.\n\nYou will leave knowing how mobile development really works, and a curiosity to explore mobile development.\n\n**About Hark:**\n\nHark is a Full-Stack Developer at SSW who builds clean, reliable software with a focus on user experience and delivery discipline. He joined SSW through FireBootCamp and works across Angular, .NET, Azure, and Flutter.",
+  "liveStreamDelayMinutes": 30,
+  "hostedAtSsw": true,
+  "enabled": true
+}


### PR DESCRIPTION
## Summary

- add the Newcastle Coders Group September event featuring Hark Singh
- reuse the verified Newcastle Coders Group thumbnail and Hark presenter profile
- configure the event for the SSW Newcastle livestream workflow

## Sources

- Authoritative event: https://www.meetup.com/newcastle-coders-group/events/315985820/
- Speaker profile: https://www.ssw.com.au/people/hark-singh/
- Comparable Newcastle event: `content/events-calendar/2026/Newcastle-Coders-July-From-Portal-Panic-to-Pipeline-Power-Introduction-to-Azure-IaC.json`
- Repeat talk source: `content/events-calendar/2026/August-User-Group---Mobile-101-Tales-of-Mobile-Development.json`
- Thumbnail source: `/images/events/newcastle-coders-group.png`

## Assumptions

- Newcastle Coders Group is externally run; Hark Singh is the confirmed SSW speaker.
- The supplied abstract replaces the Meetup placeholder for SSW's internal website record only.
- The event is livestreamed from SSW Newcastle.

## Validation

- JSON parses successfully.
- Local time converts to Wednesday 2 September 2026, 6:00–8:00 pm AEST (UTC+10).
- `Mobile` is an allowed category.
- Presenter file and thumbnail both exist on `main`.
- No pre-existing website record contains Meetup event ID `315985820`.

Draft only. Do not merge without review.
