### PR TITLE
💄 Footer social icon size + US English homepage copy (#4923 ACs 15, 9)

### DIFF
--- a/components/blocks/v3/videoFeature/videoFeature.schema.tsx
+++ b/components/blocks/v3/videoFeature/videoFeature.schema.tsx
@@ -49,7 +49,7 @@ export const V3VideoFeatureSchema: Template = {
             "Mainstream tech, real ROI, and clear action items. Every decision is measured by one question: does it actually work?",
         },
       ],
-      recognitionHeading: "Trusted & Recognised",
+      recognitionHeading: "Trusted & Recognized",
       recognitionBadges: [
         { label: "We love Microsoft - Cloud Partner", icon: "SiMicrosoft" },
         { label: "MAPA Learning Excellence", icon: "BiAward" },

--- a/components/socialIcons/socialIcons.tsx
+++ b/components/socialIcons/socialIcons.tsx
@@ -155,7 +155,7 @@ export const SocialIcon = ({ social, variant = "chip" }: SocialIconProps) => {
     return (
       <CustomLink
         href={url}
-        className="unstyled flex size-11 min-h-11 min-w-11 cursor-pointer items-center justify-center text-3xl text-white transition-colors hover:text-sswRed"
+        className="unstyled flex size-11 min-h-11 min-w-11 cursor-pointer items-center justify-center text-2xl text-white transition-colors hover:text-sswRed"
         title={label}
         aria-label={"Link to " + label}
       >

--- a/components/socialIcons/socialIcons.tsx
+++ b/components/socialIcons/socialIcons.tsx
@@ -155,11 +155,11 @@ export const SocialIcon = ({ social, variant = "chip" }: SocialIconProps) => {
     return (
       <CustomLink
         href={url}
-        className="unstyled flex size-11 min-h-9 min-w-9 cursor-pointer items-center justify-center text-xl text-white transition-colors hover:text-sswRed"
+        className="unstyled flex size-11 min-h-11 min-w-11 cursor-pointer items-center justify-center text-xl text-white transition-colors hover:text-sswRed"
         title={label}
         aria-label={"Link to " + label}
       >
-        <Icon className="text-xl" />
+        <Icon />
       </CustomLink>
     );
   }

--- a/components/socialIcons/socialIcons.tsx
+++ b/components/socialIcons/socialIcons.tsx
@@ -103,7 +103,8 @@ export const SocialIcons = ({
   return (
     <div
       className={classNames(
-        "flex flex-grow flex-wrap gap-2 sm:flex-grow-0",
+        "flex flex-grow flex-wrap sm:flex-grow-0",
+        variant === "plain" ? "gap-0" : "gap-2",
         className
       )}
     >
@@ -154,11 +155,11 @@ export const SocialIcon = ({ social, variant = "chip" }: SocialIconProps) => {
     return (
       <CustomLink
         href={url}
-        className="unstyled flex size-9 min-h-9 min-w-9 cursor-pointer items-center justify-center text-xl text-white transition-colors hover:text-sswRed"
+        className="unstyled flex size-11 min-h-9 min-w-9 cursor-pointer items-center justify-center text-xl text-white transition-colors hover:text-sswRed"
         title={label}
         aria-label={"Link to " + label}
       >
-        <Icon className="text-lg" />
+        <Icon className="text-xl" />
       </CustomLink>
     );
   }

--- a/components/socialIcons/socialIcons.tsx
+++ b/components/socialIcons/socialIcons.tsx
@@ -104,7 +104,7 @@ export const SocialIcons = ({
     <div
       className={classNames(
         "flex flex-grow flex-wrap sm:flex-grow-0",
-        variant === "plain" ? "gap-0" : "gap-2",
+        variant === "plain" ? "gap-px" : "gap-2",
         className
       )}
     >

--- a/components/socialIcons/socialIcons.tsx
+++ b/components/socialIcons/socialIcons.tsx
@@ -155,7 +155,7 @@ export const SocialIcon = ({ social, variant = "chip" }: SocialIconProps) => {
     return (
       <CustomLink
         href={url}
-        className="unstyled flex size-11 min-h-11 min-w-11 cursor-pointer items-center justify-center text-xl text-white transition-colors hover:text-sswRed"
+        className="unstyled flex size-11 min-h-11 min-w-11 cursor-pointer items-center justify-center text-3xl text-white transition-colors hover:text-sswRed"
         title={label}
         aria-label={"Link to " + label}
       >

--- a/content/pagesv2/home.json
+++ b/content/pagesv2/home.json
@@ -174,7 +174,7 @@
         },
         {
           "title": "How We Developed 'KNOWnoise' with Hutchison Weller",
-          "description": "Turning weeks of manual spreadsheet work into instant noise impact modelling.",
+          "description": "Turning weeks of manual spreadsheet work into instant noise impact modeling.",
           "image": {
             "imageSource": "/images/new-homepage-background-assets/hutchison-weller.png",
             "imageHeight": 1432,
@@ -372,7 +372,7 @@
           "highlightBody": "Every recommendation we make is grounded in our experience, the technology, measurable ROI and the next steps for your team. "
         }
       ],
-      "recognitionHeading": "Trusted & Recognised",
+      "recognitionHeading": "Trusted & Recognized",
       "recognitionBadges": [
         {
           "label": "We ♥ Microsoft - Solutions Partner",


### PR DESCRIPTION
Closes ACs 15 and 9 of #4923.

## AC 15: footer social icon size

`components/socialIcons/socialIcons.tsx`, `plain` variant only:

| | before | after |
|---|---|---|
| glyph | 20px | 27px |
| hit target | 41px | 50px |
| gap | 9px | 1px |

Measured pixels: `styles.css:13` sets `html { font-size: 18px }`, so 1rem is 18px here.

The box is the hit target, and at 50px it clears the 44px WCAG 2.5.5 minimum. `plain` drops to `gap-px` because that box carries 11.3px of padding per side. The row goes 486px to 504px, so nothing reflows: desktop keeps ten icons on one line, mobile still wraps 7+3.

Only the footer uses `plain`. The two live-stream widgets use `chip`, which does not change.

I posted screenshots in the comment below.

## AC 9: US English

- "Trusted & Recognised" → "Trusted & Recognized"
- "noise impact modelling" → "noise impact modeling"

`videoFeature.schema.tsx` seeded the first as a block default, so it changes too. I regenerated `tina/tina-lock.json` to match: 43 characters, all the same `s` → `z`.

Homepage copy only. Field names like `backgroundColour` stay, as do testimonial quotes, office addresses, and "The Shepherd Centre", which is a client's name and a live URL slug.

`pnpm test` 27/27, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
