### PR TITLE
Remove Angular training links from mega menu

### DIFF
--- a/content/megamenu/menu.json
+++ b/content/megamenu/menu.json
@@ -327,10 +327,6 @@
               "name": "Hack Days",
               "menuItems": [
                 {
-                  "name": "Angular Hack Day",
-                  "url": "https://angularhackday.com/"
-                },
-                {
                   "name": "MAUI Hack Day",
                   "url": "https://mauihackday.com/"
                 },
@@ -360,10 +356,6 @@
                   "url": "/events/ai-workshop-essentials"
                 },
                 {
-                  "name": "Angular Superpowers Tour",
-                  "url": "/events/angular-superpowers-tour"
-                },
-                {
                   "name": "Azure Superpowers Tour",
                   "url": "/events/azure-superpowers-tour"
                 },
@@ -383,10 +375,6 @@
                 {
                   "name": "AI Workshop",
                   "url": "https://www.ssw.com.au/events/ai-workshop"
-                },
-                {
-                  "name": "Angular Workshop",
-                  "url": "/events/angular-workshop"
                 },
                 {
                   "name": "Clean Architecture Workshop",


### PR DESCRIPTION
## Summary

- Remove Angular Superpowers Tour from 1-Day Training in the mega menu
- Remove Angular Workshop from 2-Day Training in the mega menu
- Remove Angular Hack Day from Hack Days in the mega menu
- Keep the underlying event pages unchanged

- Affected routes: Site-wide mega menu

## Verification

- Confirmed `content/megamenu/menu.json` parses successfully
- Confirmed all three Angular menu labels are absent
- `git diff --check`

## Screenshots

- Not included: data-only removal of the three menu entries highlighted in the supplied screenshot
