### PR TITLE
Add Adam Cogan's NDC Oslo 2026 talk

### DIFF
--- a/content/events-calendar/2026/NDC-Oslo-2026---From-Copilot-to-the-Garden-of-Eden.json
+++ b/content/events-calendar/2026/NDC-Oslo-2026---From-Copilot-to-the-Garden-of-Eden.json
@@ -1,0 +1,24 @@
+{
+  "title": "NDC Oslo 2026 - From Copilot to the Garden of Eden",
+  "slug": "ndc-oslo-2026-adam-cogan",
+  "url": "https://ndcoslo.com/tickets",
+  "ctaLabel": "Get tickets",
+  "thumbnail": "/images/events/NDC%20Conferences.png",
+  "thumbnailDescription": "NDC Oslo 2026",
+  "presenterList": [
+    {
+      "presenter": "content/presenters/adam-cogan.mdx"
+    }
+  ],
+  "startDateTime": "2026-09-16T11:40:00.000Z",
+  "endDateTime": "2026-09-16T12:40:00.000Z",
+  "calendarType": "Conferences",
+  "venue": "Room 6, Oslo Spektrum",
+  "city": "Other",
+  "cityOther": "Oslo",
+  "category": "Artificial Intelligence",
+  "abstract": "Move beyond the underwhelming 2023 \"Copilot hype\" to the tools actually delivering value for developers. Adam Cogan cuts through the noise, exploring how AI is fundamentally reshaping the enterprise stack, from Copilot and Cowork to agentic workflows and CLI-based coding.\n\nAgents such as OpenClaw, and Hermes are changing the way developers automate their day-to-day work.\n\nLearn how roles are shifting, which AI assistants are winning, and what an AI-integrated \"Garden of Eden\" looks like. Leave with a practical roadmap to build, analyze, and automate with confidence.",
+  "description": "Adam Cogan is speaking at NDC Oslo 2026.\n\n**From Copilot to the Garden of Eden**\n\nMove beyond the underwhelming 2023 \"Copilot hype\" to the tools actually delivering value for developers. Adam Cogan cuts through the noise, exploring how AI is fundamentally reshaping the enterprise stack, from Copilot and Cowork to agentic workflows and CLI-based coding.\n\nAgents such as OpenClaw, and Hermes are changing the way developers automate their day-to-day work.\n\nLearn how roles are shifting, which AI assistants are winning, and what an AI-integrated \"Garden of Eden\" looks like. Leave with a practical roadmap to build, analyze, and automate with confidence.\n\n**When:** Wednesday 16 September 2026, 13:40 - 14:40 (UTC+02)\n\n**Where:** Room 6, Oslo Spektrum, Sonja Henies plass 2, 0185 Oslo\n\n[View Adam's session](https://ndcoslo.com/agenda/tba-adam-cogan)\n",
+  "liveStreamDelayMinutes": 30,
+  "enabled": true
+}


### PR DESCRIPTION
## What changed

- Added Adam Cogan's NDC Oslo 2026 session, "From Copilot to the Garden of Eden", to the events calendar.
- Added the confirmed session time, Room 6 venue details, Artificial Intelligence category, Adam's presenter profile, and the existing NDC Conferences thumbnail.
- Added a stable SSW event slug and linked the registration CTA to the NDC Oslo ticket page.

## Sources

- Event and agenda: https://ndcoslo.com/agenda
- Session page: https://ndcoslo.com/agenda/tba-adam-cogan
- Speaker profile: https://ndcoslo.com/speakers/adam-cogan
- Venue: https://ndcoslo.com/venue
- Registration: https://ndcoslo.com/tickets

## Comparable SSW content

- `content/events-calendar/2026/NDC-Sydney-2026---AI--NET.json`
- `content/events-calendar/2026/Newcastle-Coders-Group-May-From-Copilot-to-the-Garden-of-Eden.json`

The thumbnail is reused from the existing NDC Sydney listing: `/images/events/NDC%20Conferences.png`.

## Notes

- The organizer agenda currently labels the session as `TBA - Adam Cogan`. The title and abstract in this PR are the newer SSW-approved copy supplied by Marketing.
- Oslo is represented using the schema's `Other` city option with `cityOther: "Oslo"`.
- 16 September 2026, 13:40-14:40 UTC+02 converts to `11:40-12:40Z`.

## Validation

- Parsed the event file as JSON.
- Checked required fields and allowed schema values.
- Verified the presenter and thumbnail paths exist.
- Verified the UTC conversion for Europe/Oslo.
- Ran `git diff --check`.
