### PR TITLE
💄 Scope the people card name hover to the profile link

### DIFF
--- a/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
+++ b/components/blocks/v3/peopleCarousel/peopleCarousel.tsx
@@ -41,7 +41,10 @@ function ProfileLink({ person, className, children }) {
       rel="noopener noreferrer"
       aria-label={`View ${person?.name ?? "this person"}'s SSW People profile`}
       className={cn(
-        "!no-underline after:absolute after:inset-0 after:content-['']",
+        // group/profile scopes the name's red hover to this link: the pointer
+        // is over the link whenever it is over the stretched ::after overlay,
+        // but not when it is over a social icon sitting above that overlay.
+        "group/profile !no-underline after:absolute after:inset-0 after:content-['']",
         className
       )}
     >
@@ -52,7 +55,7 @@ function ProfileLink({ person, className, children }) {
 
 function PersonCard({ person, index, scope }) {
   return (
-    <div className="group relative flex h-full flex-col overflow-hidden rounded-card border-0.75 border-hairline bg-white transition-colors duration-300 hover:border-sswRed dark:border-sswBorder dark:bg-sswCard">
+    <div className="relative flex h-full flex-col overflow-hidden rounded-card border-0.75 border-hairline bg-white transition-colors duration-300 hover:border-sswRed dark:border-sswBorder dark:bg-sswCard">
       <ProfileLink person={person} className="block">
         {/* Red panel frames the photo with padding on the sides and top while the
             photo stays flush to the bottom, so the person reads as standing in it. */}
@@ -71,7 +74,7 @@ function PersonCard({ person, index, scope }) {
 
         <div className="px-4 pt-4 text-center xl:px-6 xl:pt-6">
           {person?.name && (
-            <h3 className="text-xl font-semibold text-foreground transition-colors group-hover:text-sswRed">
+            <h3 className="text-xl font-semibold text-foreground transition-colors group-hover/profile:text-sswRed">
               {person.name}
             </h3>
           )}


### PR DESCRIPTION
Hovering a social icon on a homepage people card lit up the person's name as well, so the card promised the SSW People profile while the click under the pointer went to LinkedIn/X/GitHub. This scopes the name's hover to the profile link.

- Affected routes: `/` (homepage — "We work together to form an amazing collective brain")
- Relates to #4875 — **not** `Fixed #`, see *A note on #4875* below.

## The failure

On `main`, resting the pointer on the LinkedIn icon of a people card turns **two** things red at once: the LinkedIn icon (correct) and the person's name (wrong — the name is the SSW People profile link, and that is not where this click goes). Same for the X and GitHub icons.

Measured with Playwright on `main`, hovering LinkedIn on Calum's card:

| element | computed colour |
| --- | --- |
| LinkedIn icon | `rgb(204, 65, 65)` — sswRed |
| name "Calum Simpson" | `rgb(204, 65, 65)` — **sswRed, and it should not be** |
| X icon / GitHub icon | `rgba(0, 0, 0, 0.9)` — foreground |

## The cause

`components/blocks/v3/peopleCarousel/peopleCarousel.tsx`. The card `<div>` carried Tailwind's `group`, and the name used `group-hover:text-sswRed`. The social icons live inside that card, so hovering any of them satisfied `group-hover` and reddened the name. The card is one `group` but it holds two different link destinations.

## The fix

Three lines, one file. Move the group onto the profile link itself — `group/profile` — and change the name to `group-hover/profile:text-sswRed`. The card `<div>` no longer needs `group`.

This does not shrink the click target. The profile link stretches across the whole card via its `after:absolute after:inset-0` overlay, and a pointer over that overlay is a pointer over the link, so hovering anywhere on the card (photo, name, role, corners, the gaps between icons) still reddens the name. The social icons sit above the overlay on `z-10`, so they — and only they — are excluded. The card's red border still comes from the card's own `hover:border-sswRed`, unchanged.

## Verification

Driven with Playwright against `next dev` at 1280×720, light mode, Chromium. Same script, same viewport, same card, before and after.

![before/after side by side](https://github.com/user-attachments/assets/85b7f364-b4f3-4215-96fa-0f20c484a4f1)

*The pointer is resting on the LinkedIn icon in both. Before: name red. After: name neutral, LinkedIn red like its siblings.*

![all four hover targets after the fix](https://github.com/user-attachments/assets/79928f1e-1571-434e-bbba-1455de856396)

*After the fix, each icon reddens alone and matches its siblings; the name reddens only for the profile link.*

Computed colours re-measured after the fix — hovering LinkedIn: icon `rgb(204,65,65)`, name `rgba(0,0,0,0.9)`, card border `rgb(204,65,65)`. Hovering the name, the photo, the role text, a card corner, or the gap between two icons: name `rgb(204,65,65)` and `document.elementFromPoint` resolves to `https://www.ssw.com.au/people/calum-simpson/` — the stretched click target is intact.

### Before — the bug, in motion

https://github.com/user-attachments/assets/30480457-aac2-4d93-96b6-ee318cd035d6

*`main`: the pointer visits LinkedIn, X, GitHub, then the name. The name turns red for every one of them.*

### After — the fix, in motion

https://github.com/user-attachments/assets/6506b9bb-1092-4a2c-8c52-73a4e65b5ff5

*This branch: the same tour. Only the hovered icon reddens; the name waits its turn.*

Also: `pnpm lint` clean, `pnpm test` 35/35 pass.

## A note on #4875

#4875 reports that the **SSW People icon** hovers differently from the LinkedIn and X icons beside it. That icon no longer exists — #4985 (AC 5) deleted the SSW-squares icon and moved the profile link onto the photo and name, which is what the issue asked for. So the bug as filed is not reproducible on `main`, and I did not invent it: what I could reproduce, in the same hover system on the same cards, is the leftover above.

I have deliberately not written `Fixed #4875` — closing it is Adam's and Tiago's call, since the thread also carries the still-open "All SSW People" wording debate.

## Checklist

- [ ] If adding a new page, I have followed the [📃 New Webpage](https://github.com/SSWConsulting/SSW.Website/issues/new?assignees=&labels=&projects=&template=new_webpage.yml&title=%F0%9F%93%84+%7B%7B+TITLE+%7D%7D+) issue template — n/a
- [ ] If updating the livestream banner, I have tested and followed the steps in [Wiki - Testing the live banner](https://github.com/SSWConsulting/SSW.Website/wiki/Testing-the-live-banner) — n/a
- [x] Include Done Video or screenshots — above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEcohj2sV3u4MEgd3f3BTK
