### PR TITLE
Company Index - Use SSW red for card title and hover border

### DIFF
--- a/components/company/companyPageCard.tsx
+++ b/components/company/companyPageCard.tsx
@@ -47,7 +47,7 @@ const CompanyPageCardContent = ({ title, body, schema, index }) => {
     <article className="col-span-1 size-full rounded border-1 border-gray-300 bg-white px-8 py-4 shadow hover:border-ssw-red dark:border-gray-700 dark:bg-gray-800">
       <div className="prose prose-h2:text-3xl/9">
         <h2
-          className="my-1"
+          className="my-1 text-ssw-red"
           data-tina-field={tinaField(
             schema[index],
             companyIndexSchemaConstants.companyPages.title

--- a/components/company/companyPageCard.tsx
+++ b/components/company/companyPageCard.tsx
@@ -44,7 +44,7 @@ const CompanyPageCard = ({ data, schema, index }) => {
 
 const CompanyPageCardContent = ({ title, body, schema, index }) => {
   return (
-    <article className="col-span-1 size-full rounded border-1 border-gray-300 bg-white px-8 py-4 shadow hover:border-ssw-black dark:border-gray-700 dark:bg-gray-800">
+    <article className="col-span-1 size-full rounded border-1 border-gray-300 bg-white px-8 py-4 shadow hover:border-ssw-red dark:border-gray-700 dark:bg-gray-800">
       <div className="prose prose-h2:text-3xl/9">
         <h2
           className="my-1"


### PR DESCRIPTION
Changed the Company Index card title and hover border to SSW red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
