### PR TITLE
Add Calum's Newcastle Coders November talk

### DIFF
--- a/content/events-calendar/2026/Newcastle-Coders-November-AI-Its-a-Skill-Issue.json
+++ b/content/events-calendar/2026/Newcastle-Coders-November-AI-Its-a-Skill-Issue.json
@@ -1,0 +1,22 @@
+{
+  "title": "Newcastle Coders November: AI: It's a Skill Issue",
+  "slug": "newcastle-ai-its-a-skill-issue",
+  "url": "https://www.meetup.com/newcastle-coders-group/events/316437944/",
+  "thumbnail": "/images/events/newcastle-coders-group.png",
+  "thumbnailDescription": "Newcastle Coders Group",
+  "presenterList": [
+    {
+      "presenter": "content/presenters/calum-simpson.mdx"
+    }
+  ],
+  "startDateTime": "2026-11-04T07:00:00.000Z",
+  "endDateTime": "2026-11-04T09:00:00.000Z",
+  "calendarType": "User Groups",
+  "city": "Newcastle",
+  "category": "Artificial Intelligence",
+  "abstract": "Join SSW's VP of AI, Calum Simpson, for a talk about the current state of AI-assisted development and what you really need to know about to get the most out of the tools.\n\nCalum will explain what AI Skills are and how to use them, share some practical examples with you, and leave you with thoughts on the Human Skills required to succeed in the world of AI.",
+  "description": "Newcastle Coders Group welcomes Calum Simpson for **AI: It's a Skill Issue** at SSW Newcastle, 432 Hunter Street.\n\nJoin SSW's VP of AI, Calum Simpson, for a talk about the current state of AI-assisted development and what you really need to know about to get the most out of the tools.\n\nCalum will explain what AI Skills are and how to use them, share some practical examples with you, and leave you with thoughts on the Human Skills required to succeed in the world of AI.\n",
+  "hostedAtSsw": true,
+  "enabled": true,
+  "venue": "SSW Newcastle, 432 Hunter Street"
+}


### PR DESCRIPTION
## Change
Add Newcastle Coders Group's 4 November 2026 event to the SSW Events Calendar: **AI: It's a Skill Issue**, presented by Calum Simpson, SSW VP of AI.

- Wednesday 4 November 2026, 6–8 pm AEDT (Australia/Sydney), at SSW Newcastle, 432 Hunter Street.
- UTC: 2026-11-04 07:00–09:00.
- Intended route: https://www.ssw.com.au/events/2026/newcastle-ai-its-a-skill-issue
- Uses the existing Calum presenter profile and Newcastle Coders Group thumbnail.

## Sources and content decision
- Organizer: https://www.meetup.com/newcastle-coders-group/events/316437944/
- User-confirmed repeat talk: https://www.meetup.com/sydney-net-user-group/events/315114569/
- The Newcastle organizer currently lists “November: Calum SSW VP of AI” and says the topic is still being finalised. The requester explicitly confirmed that Calum will repeat “AI: It's a Skill Issue”; this entry uses that approved title and the existing June SSW talk abstract.
- Comparable event and artwork source: content/events-calendar/2026/Newcastle-Coders-September-Mobile-101-Tales-of-Mobile-Development.json, using /images/events/newcastle-coders-group.png.
- Existing talk/profile source: content/events-calendar/2026/June-User-Group---Talk-Title-TBA.json and content/presenters/calum-simpson.mdx.
- Event classification is external speaking at a community user group. Calendar type remains User Groups, matching previous Newcastle entries.
- No Newcastle livestream is confirmed, so livestream/banner fields are omitted.

## Validation
- Checked current Tina fields, allowed category/type/city, JSON parsing, presenter and thumbnail existence, route convention, timezone conversion, and duplicate destination/slug/date searches.
- Repository lint passed (npm run lint, invoking the same lint script); all 35 tests across 4 suites passed (npm test -- --runInBand). Prettier and staged whitespace checks passed. Windows checkout line endings in eslint.config.mjs were normalized locally for lint; no configuration change is included.
