### PR TITLE
Move September user group to Melbourne

### DIFF
--- a/content/events-calendar/2026/September-User-Group---Getting-Found-in-the-Age-of-AI.json
+++ b/content/events-calendar/2026/September-User-Group---Getting-Found-in-the-Age-of-AI.json
@@ -1,9 +1,9 @@
 {
   "title": "September User Group - Getting Found in the Age of AI",
   "slug": "getting-found-in-the-age-of-ai",
-  "url": "https://www.meetup.com/sydney-net-user-group/",
-  "thumbnail": "/images/events/sydney-ug-thumb.jpg",
-  "thumbnailDescription": "Sydney .NET User Group",
+  "url": "https://www.meetup.com/melbourne-net-user-group/events/315899849",
+  "thumbnail": "/images/events/melbourne-ug-thumb.jpg",
+  "thumbnailDescription": "Melbourne .NET User Group",
   "presenterList": [
     {
       "presenter": "content/presenters/jack-bear.mdx"
@@ -14,7 +14,7 @@
   "startShowBannerDateTime": "2026-09-15T14:00:00.000Z",
   "endShowBannerDateTime": "2026-09-16T12:00:00.000Z",
   "calendarType": "User Groups",
-  "city": "Sydney",
+  "city": "Melbourne",
   "category": "Artificial Intelligence",
   "abstract": "How AI is rewriting the way businesses get discovered online. From traditional SEO to AI-powered search, and what it means for your brand's visibility.",
   "description": "How AI is rewriting the way businesses get discovered online. From traditional SEO to AI-powered search, and what it means for your brand's visibility.\n\n[Connect with Jack on LinkedIn](https://www.linkedin.com/in/jack-bear-726578226/)\n",


### PR DESCRIPTION
Move September's Getting Found in the Age of AI user group from Sydney to Melbourne and point registration to the supplied Melbourne Meetup event.

Updates city, thumbnail, thumbnail description, and registration URL. Preserves talk copy, presenter, and September 16 date/time (6-9 pm AEST; Australia/Melbourne verified UTC+10).

Validation: JSON parses, git diff --check passes, presenter and Melbourne thumbnail/page exist in the repository. Local lint/test could not complete because dependencies are unavailable and registry access was blocked; CI validation is required. Meetup identity matched SSW, but get_event returned an invalid response, so the user-supplied city/link are the source for this narrow correction.
